### PR TITLE
Switch scraper text generation to DeepSeek with generic LLM interface

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,12 +27,14 @@ EXPO_PUBLIC_API_URL=http://localhost:3000
 GOOGLE_API_KEY=your_google_api_key_here
 GOOGLE_SEARCH_ENGINE_ID=your_search_engine_id_here
 
-# Google Gemini API key — used by @ai-sdk/google for AI text generation
-# https://aistudio.google.com/app/apikey
-GOOGLE_GENERATIVE_AI_API_KEY=your_gemini_api_key_here
+# DeepSeek API key — used for AI text generation (summaries, articles, keywords)
+# https://platform.deepseek.com/
+DEEPSEEK_API_KEY=your_deepseek_api_key_here
 
-# OpenAI API key for DALL-E image generation
-OPENAI_API_KEY=your_openai_api_key_here
+# Google Vertex AI — used for Imagen 3 image generation
+# https://console.cloud.google.com/vertex-ai
+GOOGLE_VERTEX_PROJECT=your_gcp_project_id
+GOOGLE_VERTEX_LOCATION=us-central1
 
 # Congress.gov REST API key — used by the congress.ts scraper
 # Free sign-up at: https://api.congress.gov/sign-up/

--- a/apps/scraper/package.json
+++ b/apps/scraper/package.json
@@ -5,6 +5,7 @@
   "description": "Government data scraper for Billion app",
   "dependencies": {
     "@acme/db": "workspace:*",
+    "@ai-sdk/deepseek": "^1.0.0",
     "@ai-sdk/google": "^3.0.53",
     "@ai-sdk/google-vertex": "^4.0.105",
     "ai": "^6.0.141",

--- a/apps/scraper/src/utils/ai/image-keywords.ts
+++ b/apps/scraper/src/utils/ai/image-keywords.ts
@@ -1,14 +1,14 @@
 /**
  * AI-powered image keyword generation
- * Uses Google Vertex AI to extract visual concepts for image search
+ * Uses LLM to extract visual concepts for image search
  */
 
 import { generateText, APICallError, RetryError } from 'ai';
 
 import { AIRateLimitError, rateLimitHit, setRateLimitHit } from './text-generation.js';
 import { createLogger } from '../log.js';
-import { trackGeminiUsage } from '../costs.js';
-import { vertexProvider } from './provider.js';
+import { trackLLMUsage } from '../costs.js';
+import { llm } from './provider.js';
 
 const logger = createLogger("ai");
 
@@ -44,7 +44,7 @@ export async function generateImageSearchKeywords(
   }
   try {
     const { text, usage } = await generateText({
-      model: vertexProvider('gemini-2.5-flash'),
+      model: llm,
       prompt: `Given this ${type} title and content, generate 2-4 search keywords for finding visually striking, high-end editorial stock photos. Focus on dramatic, cinematic, and photographic concepts that feel professional and modern.
 
 GOOD examples (specific, dynamic, visual):
@@ -67,7 +67,7 @@ Content: ${content.substring(0, 500)}
 
 Return ONLY 2-4 specific visual keywords separated by spaces. No quotes, no explanation:`,
     });
-    trackGeminiUsage(usage.inputTokens, usage.outputTokens);
+    trackLLMUsage(usage.inputTokens, usage.outputTokens);
 
     return text.trim().replace(/['"]/g, '');
   } catch (error) {

--- a/apps/scraper/src/utils/ai/marketing-generation.ts
+++ b/apps/scraper/src/utils/ai/marketing-generation.ts
@@ -1,14 +1,14 @@
 /**
- * AI marketing content generation using Google Vertex AI
+ * AI marketing content generation
  * Generates compelling social media titles, descriptions, and image prompts
  */
 
 import { generateObject, APICallError, RetryError } from "ai";
 import { z } from "zod";
 import { createLogger } from "../log.js";
-import { trackGeminiUsage } from "../costs.js";
+import { trackLLMUsage } from "../costs.js";
 import { AIRateLimitError, rateLimitHit, setRateLimitHit } from "./text-generation.js";
-import { vertexProvider } from "./provider.js";
+import { llm } from "./provider.js";
 
 function isRateLimitError(error: unknown): boolean {
   if (error instanceof APICallError) return error.statusCode === 429;
@@ -47,7 +47,7 @@ export async function generateMarketingCopy(
     logger.start(`Generating marketing copy for: ${articleTitle}`);
 
     const { object, usage } = await generateObject({
-      model: vertexProvider("gemini-2.5-flash"),
+      model: llm,
       schema: MarketingCopySchema,
       prompt: `You are a professional marketing copywriter creating engaging social media content.
 
@@ -61,7 +61,7 @@ Requirements:
 Article Title: ${articleTitle}
 Content Preview: ${articleContent.substring(0, 1000)}`,
     });
-    trackGeminiUsage(usage.inputTokens, usage.outputTokens);
+    trackLLMUsage(usage.inputTokens, usage.outputTokens);
 
     return object;
   } catch (error) {

--- a/apps/scraper/src/utils/ai/provider.ts
+++ b/apps/scraper/src/utils/ai/provider.ts
@@ -1,5 +1,19 @@
+import { createDeepSeek } from "@ai-sdk/deepseek";
 import { createVertex } from "@ai-sdk/google-vertex";
 
+const deepseekApiKey = process.env.DEEPSEEK_API_KEY;
+
+if (!deepseekApiKey) {
+  throw new Error("DEEPSEEK_API_KEY environment variable is required");
+}
+
+const deepseekProvider = createDeepSeek({
+  apiKey: deepseekApiKey,
+});
+
+export const llm = deepseekProvider("deepseek-v4-flash");
+
+// Keep Vertex for Imagen image generation
 const project = process.env.GOOGLE_VERTEX_PROJECT;
 const location = process.env.GOOGLE_VERTEX_LOCATION;
 const apiKey = process.env.GOOGLE_VERTEX_API_KEY;
@@ -9,4 +23,3 @@ export const vertexProvider = createVertex({
   ...(location ? { location } : {}),
   ...(apiKey ? { apiKey } : {}),
 });
-

--- a/apps/scraper/src/utils/ai/text-generation.ts
+++ b/apps/scraper/src/utils/ai/text-generation.ts
@@ -1,18 +1,18 @@
 /**
- * AI text generation utilities using Google Vertex AI
+ * AI text generation utilities
  * Generates summaries and full articles from government content
  */
 
 import { generateText, APICallError, RetryError } from 'ai';
 import { createLogger } from '../log.js';
-import { trackGeminiUsage } from '../costs.js';
-import { vertexProvider } from './provider.js';
+import { trackLLMUsage } from '../costs.js';
+import { llm } from './provider.js';
 
 const logger = createLogger("ai");
 
 export class AIRateLimitError extends Error {
   constructor() {
-    super('Gemini rate limit hit — deferring AI generation to next run');
+    super('LLM rate limit hit — deferring AI generation to next run');
     this.name = 'AIRateLimitError';
   }
 }
@@ -53,7 +53,7 @@ export async function generateAISummary(
   }
   try {
     const { text, usage } = await generateText({
-      model: vertexProvider('gemini-2.5-flash'),
+      model: llm,
       prompt: `You are an expert at simplifying complex government and legal jargon for a general audience.
 Generate a very short, punchy summary (max 100 characters) for this content.
 
@@ -66,7 +66,7 @@ Content: ${content.substring(0, 2000)}
 
 Summary (max 100 characters):`,
     });
-    trackGeminiUsage(usage.inputTokens, usage.outputTokens);
+    trackLLMUsage(usage.inputTokens, usage.outputTokens);
 
     return text.trim().substring(0, 100);
   } catch (error) {
@@ -100,7 +100,7 @@ export async function generateAIArticle(
     logger.start(`Generating AI article for: ${title}`);
 
     const { text, usage } = await generateText({
-      model: vertexProvider('gemini-2.5-flash'),
+      model: llm,
       prompt: `You are an expert at making government and legal content accessible and engaging for everyday people. Transform the following ${type} into a well-structured, markdown-formatted article.
 
 **Structure your article with these 4 sections:**
@@ -144,7 +144,7 @@ ${fullText}
 
 Write the article now using the 4-section structure above:`,
     });
-    trackGeminiUsage(usage.inputTokens, usage.outputTokens);
+    trackLLMUsage(usage.inputTokens, usage.outputTokens);
 
     return text.trim();
   } catch (error) {

--- a/apps/scraper/src/utils/costs.ts
+++ b/apps/scraper/src/utils/costs.ts
@@ -3,15 +3,15 @@
  *
  * Prices are approximate and may drift as providers update pricing.
  * Override via env vars if needed:
- *   GEMINI_FLASH_INPUT_PRICE, GEMINI_FLASH_OUTPUT_PRICE,
- *   DALLE3_IMAGE_PRICE, GOOGLE_SEARCH_PRICE
+ *   LLM_INPUT_PRICE, LLM_OUTPUT_PRICE,
+ *   IMAGEN_IMAGE_PRICE, GOOGLE_SEARCH_PRICE
  */
 
 // Prices per unit (USD)
 const PRICES = {
-  // Gemini 2.5 Flash — $/1M tokens
-  geminiFlashInput: Number(process.env.GEMINI_FLASH_INPUT_PRICE) || 0.15,
-  geminiFlashOutput: Number(process.env.GEMINI_FLASH_OUTPUT_PRICE) || 0.60,
+  // LLM — $/1M tokens (default: DeepSeek V4 Flash pricing)
+  llmInput: Number(process.env.LLM_INPUT_PRICE) || 0.10,
+  llmOutput: Number(process.env.LLM_OUTPUT_PRICE) || 0.30,
   // Imagen 3 — $/image (1:1 aspect ratio)
   imagenImage: Number(process.env.IMAGEN_IMAGE_PRICE) || 0.03,
   // Google Custom Search — $/query (after free tier)
@@ -19,34 +19,34 @@ const PRICES = {
 };
 
 interface CostState {
-  geminiInputTokens: number;
-  geminiOutputTokens: number;
+  llmInputTokens: number;
+  llmOutputTokens: number;
   imagenImages: number;
   googleSearches: number;
 }
 
 let state: CostState = {
-  geminiInputTokens: 0,
-  geminiOutputTokens: 0,
+  llmInputTokens: 0,
+  llmOutputTokens: 0,
   imagenImages: 0,
   googleSearches: 0,
 };
 
 export function resetCosts(): void {
   state = {
-    geminiInputTokens: 0,
-    geminiOutputTokens: 0,
+    llmInputTokens: 0,
+    llmOutputTokens: 0,
     imagenImages: 0,
     googleSearches: 0,
   };
 }
 
-export function trackGeminiUsage(
+export function trackLLMUsage(
   inputTokens: number | undefined,
   outputTokens: number | undefined,
 ): void {
-  state.geminiInputTokens += inputTokens ?? 0;
-  state.geminiOutputTokens += outputTokens ?? 0;
+  state.llmInputTokens += inputTokens ?? 0;
+  state.llmOutputTokens += outputTokens ?? 0;
 }
 
 export function trackImagenImage(): void {
@@ -58,28 +58,28 @@ export function trackGoogleSearch(): void {
 }
 
 export interface CostSummary {
-  geminiInputTokens: number;
-  geminiOutputTokens: number;
+  llmInputTokens: number;
+  llmOutputTokens: number;
   imagenImages: number;
   googleSearches: number;
-  geminiCost: number;
+  llmCost: number;
   imagenCost: number;
   googleSearchCost: number;
   totalCost: number;
 }
 
 export function getCostSummary(): CostSummary {
-  const geminiCost =
-    (state.geminiInputTokens / 1_000_000) * PRICES.geminiFlashInput +
-    (state.geminiOutputTokens / 1_000_000) * PRICES.geminiFlashOutput;
+  const llmCost =
+    (state.llmInputTokens / 1_000_000) * PRICES.llmInput +
+    (state.llmOutputTokens / 1_000_000) * PRICES.llmOutput;
   const imagenCost = state.imagenImages * PRICES.imagenImage;
   const googleSearchCost = state.googleSearches * PRICES.googleSearch;
 
   return {
     ...state,
-    geminiCost,
+    llmCost,
     imagenCost,
     googleSearchCost,
-    totalCost: geminiCost + imagenCost + googleSearchCost,
+    totalCost: llmCost + imagenCost + googleSearchCost,
   };
 }

--- a/apps/scraper/src/utils/db/metrics.ts
+++ b/apps/scraper/src/utils/db/metrics.ts
@@ -134,9 +134,9 @@ export function printMetricsSummary(scraperName: string): void {
 
   if (costs.totalCost > 0) {
     printHeader("Estimated Costs");
-    if (costs.geminiInputTokens > 0 || costs.geminiOutputTokens > 0) {
-      const totalTokens = costs.geminiInputTokens + costs.geminiOutputTokens;
-      printKeyValue("Gemini tokens", `${totalTokens.toLocaleString()} (${formatUsd(costs.geminiCost)})`);
+    if (costs.llmInputTokens > 0 || costs.llmOutputTokens > 0) {
+      const totalTokens = costs.llmInputTokens + costs.llmOutputTokens;
+      printKeyValue("LLM tokens", `${totalTokens.toLocaleString()} (${formatUsd(costs.llmCost)})`);
     }
     if (costs.imagenImages > 0) {
       printKeyValue("Imagen 3 images", `${costs.imagenImages} (${formatUsd(costs.imagenCost)})`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -385,6 +385,9 @@ importers:
       '@acme/db':
         specifier: workspace:*
         version: link:../../packages/db
+      '@ai-sdk/deepseek':
+        specifier: ^1.0.0
+        version: 1.0.41(zod@4.3.6)
       '@ai-sdk/google':
         specifier: ^3.0.53
         version: 3.0.53(zod@4.3.6)
@@ -800,6 +803,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/deepseek@1.0.41':
+    resolution: {integrity: sha512-7L2Do5wk0xRe0Ox8CVRF9B5b5SPemZP16ZbyBUAlNtO16EMFLSX8LXGeQREZ2SOQ4pC95BwSXThcTkt1JbFNlA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.83':
     resolution: {integrity: sha512-LvlWujbSdEkTBXBLFtF7GS6riXdHhH0O+DpDrCaNQvXeHmSF2jKsOg7JWXiCgygAHM5cWFAO3JYmZp83DjiuBQ==}
     engines: {node: '>=18'}
@@ -830,6 +839,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@3.0.25':
+    resolution: {integrity: sha512-CvsRu+32Y8a167s+lrIBtsybvgTHp8j9y+6BeTvLeoW3Q+okw/b4CnNUFOLIXsRaKHQKAH+IHNJPYWywfpw0LA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@4.0.21':
     resolution: {integrity: sha512-MtFUYI1/8mgDvRmaBDjbLJPFFrMG777AvSgyIFQtZHIMzm88R/12vYBBpnk7pfiWLFE1DSZzY4WDYzGbKAcmiw==}
     engines: {node: '>=18'}
@@ -841,6 +856,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@2.0.3':
+    resolution: {integrity: sha512-h88OPkavHTiN9tMn2l5awAznGB0lXzjcLhgR1/rvjB2zlLprsNxbM2tt6OJsHUxduLC3klq0/eqaSf6fX5XVww==}
+    engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
     resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
@@ -8262,6 +8281,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/deepseek@1.0.41(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@ai-sdk/provider-utils': 3.0.25(zod@4.3.6)
+      zod: 4.3.6
+
   '@ai-sdk/gateway@3.0.83(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -8299,6 +8324,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.23(zod@4.3.6)
       zod: 4.3.6
 
+  '@ai-sdk/provider-utils@3.0.25(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.3
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
   '@ai-sdk/provider-utils@4.0.21(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -8312,6 +8344,10 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.3.6
+
+  '@ai-sdk/provider@2.0.3':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@3.0.8':
     dependencies:


### PR DESCRIPTION
## Summary
- Replace Vertex AI Gemini with DeepSeek V4 Flash for text generation
- Use generic `llm` export and `LLM` naming for easy provider swaps
- Imagen 3 retained for images until Flux migration (#86)

## Changes
- `provider.ts`: Export single `llm` model (currently DeepSeek V4 Flash)
- `costs.ts`: Generic `trackLLMUsage()` and `llmCost` (not provider-specific)
- `metrics.ts`: Display 'LLM tokens' instead of provider name
- All AI files now import `llm` instead of provider-specific model

## Why generic naming?
Vercel AI SDK lets us swap providers easily. Generic naming means future switches (OpenAI, Anthropic, etc.) only require changing `provider.ts` — no renaming across codebase.

## Env vars
- `DEEPSEEK_API_KEY` (required)
- `GOOGLE_VERTEX_*` (still needed for Imagen)
- `LLM_INPUT_PRICE`, `LLM_OUTPUT_PRICE` (optional, for cost tracking)

## Test plan
- [ ] Set `DEEPSEEK_API_KEY` env var
- [ ] Run scraper and verify text generation works
- [ ] Verify image generation still works with Imagen

🤖 Generated with [Claude Code](https://claude.com/claude-code)