### PR TITLE
:sparkles: feat: cross-validate ballot measures across civic data sources

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,15 +55,16 @@ The client uses `drizzle-orm/node-postgres` (native TCP connection). This is why
 
 ### Schema Overview
 
-| Table | Purpose |
-|---|---|
-| `bill` | Congressional legislation scraped from congress.gov |
+| Table                | Purpose                                                                         |
+| -------------------- | ------------------------------------------------------------------------------- |
+| `bill`               | Congressional legislation scraped from congress.gov                             |
 | `government_content` | Executive orders, memoranda, proclamations, press briefings from whitehouse.gov |
-| `court_case` | SCOTUS and federal court cases |
-| `video` | AI-generated feed posts derived from the above content |
-| auth tables | better-auth managed session/user tables (see `auth-schema.ts`) |
+| `court_case`         | SCOTUS and federal court cases                                                  |
+| `video`              | AI-generated feed posts derived from the above content                          |
+| auth tables          | better-auth managed session/user tables (see `auth-schema.ts`)                  |
 
 All content tables share a common pattern:
+
 - `content_hash` (SHA-256) — used to detect changes between scrape runs and avoid redundant AI generation
 - `versions` (JSONB array) — append-only log of `{ hash, updatedAt, changes }` for every update
 - `ai_generated_article` — the AI-enriched markdown article stored directly on the row
@@ -89,12 +90,40 @@ tRPC was chosen because:
 
 ### Router Structure
 
-| Router | Procedures |
-|---|---|
-| `auth` | `getSession`, `getSecretMessage` |
-| `content` | `getAll`, `getByType`, `getById` |
-| `video` | `getInfinite` (paginated feed) |
-| `post` | `all`, `byId`, `create`, `delete` |
+| Router    | Procedures                                                                         |
+| --------- | ---------------------------------------------------------------------------------- |
+| `auth`    | `getSession`, `getSecretMessage`                                                   |
+| `content` | `getAll`, `getByType`, `getById`                                                   |
+| `video`   | `getInfinite` (paginated feed)                                                     |
+| `post`    | `all`, `byId`, `create`, `delete`                                                  |
+| `civic`   | `getElections`, `getVoterInfo`, `getRepresentatives`, `getRepresentativesEnriched` |
+
+### Ballot Measure Enrichment
+
+Google Civic returns ballot-measure _titles_ but rarely the summary, fiscal
+impact, pro/con arguments, or full text — especially for local measures. To
+fill these gaps, `civic.getVoterInfo` runs each measure through a
+**cross-validation engine** (`packages/api/src/lib/measure-crossvalidate.ts`)
+that pulls from multiple public-record sources and merges them by trust tier:
+
+```
+County registrar > State SOS > Vote Smart > Google Civic > AI summary (last resort)
+```
+
+Source adapters live in `packages/api/src/lib/measure-sources/`:
+
+| Source                       | Adapter                | Scope                                                                      |
+| ---------------------------- | ---------------------- | -------------------------------------------------------------------------- |
+| CA SOS Official Voter Guide  | `ca-sos-voterguide.ts` | CA statewide propositions (official summary + LAO fiscal impact + pro/con) |
+| Santa Clara County ROV / LWV | `santa-clara.ts`       | Local lettered measures (the proving ground)                               |
+| Vote Smart                   | `votesmart.ts`         | State-level measures                                                       |
+| Google Civic                 | (the input itself)     | Whatever the API returned                                                  |
+
+Principles: **AI structures, it never authors.** Official sources win field
+conflicts. Every surfaced field carries a citation (`Contest.citations`), and
+AI-only summaries are flagged (`Contest.summaryIsAiGenerated`) so the UI can
+label them. Results are cached transitively inside the `CivicApiCache`
+voter-info response (24h TTL). See `docs/MEASURE_ENRICHMENT.md`.
 
 ### Why Next.js
 
@@ -125,11 +154,11 @@ Next.js at port 3000 serves both the web frontend and the tRPC API. The Expo app
 
 ### Scrapers
 
-| Scraper | Source | Content Type |
-|---|---|---|
-| `congress.ts` | congress.gov | Bills |
-| `whitehouse.ts` | whitehouse.gov | Government content (EOs, memoranda, briefings) |
-| `scotus.ts` | CourtListener API (courtlistener.com) | Court cases |
+| Scraper         | Source                                | Content Type                                   |
+| --------------- | ------------------------------------- | ---------------------------------------------- |
+| `congress.ts`   | congress.gov                          | Bills                                          |
+| `whitehouse.ts` | whitehouse.gov                        | Government content (EOs, memoranda, briefings) |
+| `scotus.ts`     | CourtListener API (courtlistener.com) | Court cases                                    |
 
 The HTML scrapers (whitehouse) use `fetch` + [cheerio](https://cheerio.js.org/) for page fetching and DOM parsing. The API scrapers (congress, scotus) use `fetch` against official REST APIs. All three share a `fetchWithRetry()` utility with exponential backoff, `Retry-After` support, and configurable timeout. A unified `upsertContent(type, data)` function handles the DB write + AI generation pipeline for all content types via a discriminated union.
 
@@ -153,21 +182,23 @@ This is the main cost-control mechanism. AI generation is expensive; hashing ens
 Each piece of content goes through three AI steps before being stored:
 
 **1. Article generation** (`utils/ai/text-generation.ts`)
+
 - Model: Gemini 2.5 Flash via Vercel AI SDK (`@ai-sdk/google`)
 - Produces a structured 4-section markdown article: "What This Means For You", "Overview", "Impact & Implications", "The Debate"
 - Written at an 8th-grade reading level, balanced across political perspectives
 - Stored in `ai_generated_article` on the content row
 
 **2. Marketing copy generation** (`utils/ai/marketing-generation.ts`)
+
 - Model: Gemini 2.5 Flash with structured output (`generateObject`)
 - Produces: title (≤25 chars), description (~50 words), image prompt
 - Stored on the `video` row
 
 **3. Image acquisition** (two paths)
 
-*Path A — Scraped thumbnail:* If the source page has a usable image, it's stored as a URL in `thumbnail_url`. This is preferred — no API cost, no generation latency.
+_Path A — Scraped thumbnail:_ If the source page has a usable image, it's stored as a URL in `thumbnail_url`. This is preferred — no API cost, no generation latency.
 
-*Path B — DALL-E generation* (`utils/ai/image-generation.ts`): If no scraped image is available, DALL-E 3 generates a 1024×1024 photorealistic image from the marketing copy's image prompt. The PNG is downloaded immediately (DALL-E URLs expire after 1 hour), converted to JPEG via `sharp`, and stored as raw bytes in the `image_data` bytea column. Exponential backoff handles rate limits (1s, 2s, 4s).
+_Path B — DALL-E generation_ (`utils/ai/image-generation.ts`): If no scraped image is available, DALL-E 3 generates a 1024×1024 photorealistic image from the marketing copy's image prompt. The PNG is downloaded immediately (DALL-E URLs expire after 1 hour), converted to JPEG via `sharp`, and stored as raw bytes in the `image_data` bytea column. Exponential backoff handles rate limits (1s, 2s, 4s).
 
 ---
 
@@ -199,12 +230,12 @@ Both apps share design tokens from `tooling/tailwind/theme.css` and `packages/ui
 
 ## Considered Alternatives
 
-| Decision | What we chose | What we considered | Why we didn't |
-|---|---|---|---|
-| ORM | Drizzle | Supabase client, Prisma | Supabase types are too loose; Prisma requires codegen and has more overhead |
-| API protocol | tRPC | REST, GraphQL | REST requires manual type maintenance; GraphQL is heavy for this scale |
-| Mobile DB access | tRPC over HTTP | Supabase PostgREST + RLS | Would require migrating auth and business logic out of the API layer |
-| AI text model | Gemini 2.5 Flash | GPT-4o, Claude | Cost/quality ratio; structured output support via Vercel AI SDK |
-| Image storage | bytea in Postgres | S3/R2 object storage | Simpler for now; object storage is the right move at scale |
-| Scraper DB access | Direct Drizzle | tRPC mutations | No benefit to HTTP overhead for a trusted server process |
-| Scraper framework | Custom fetch+cheerio | Crawlee | Crawlee pulled in Playwright + Apify storage for a pattern that's ~60 lines of fetch+retry. Two of four scrapers use REST APIs and didn't need it at all |
+| Decision          | What we chose        | What we considered       | Why we didn't                                                                                                                                            |
+| ----------------- | -------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ORM               | Drizzle              | Supabase client, Prisma  | Supabase types are too loose; Prisma requires codegen and has more overhead                                                                              |
+| API protocol      | tRPC                 | REST, GraphQL            | REST requires manual type maintenance; GraphQL is heavy for this scale                                                                                   |
+| Mobile DB access  | tRPC over HTTP       | Supabase PostgREST + RLS | Would require migrating auth and business logic out of the API layer                                                                                     |
+| AI text model     | Gemini 2.5 Flash     | GPT-4o, Claude           | Cost/quality ratio; structured output support via Vercel AI SDK                                                                                          |
+| Image storage     | bytea in Postgres    | S3/R2 object storage     | Simpler for now; object storage is the right move at scale                                                                                               |
+| Scraper DB access | Direct Drizzle       | tRPC mutations           | No benefit to HTTP overhead for a trusted server process                                                                                                 |
+| Scraper framework | Custom fetch+cheerio | Crawlee                  | Crawlee pulled in Playwright + Apify storage for a pattern that's ~60 lines of fetch+retry. Two of four scrapers use REST APIs and didn't need it at all |

--- a/apps/expo/src/app/(tabs)/elections.tsx
+++ b/apps/expo/src/app/(tabs)/elections.tsx
@@ -33,6 +33,35 @@ function partyInitial(party?: string): string {
   return "NP";
 }
 
+/** Build the /measure-detail route params for a measure contest. */
+function measureRoute(m: Contest) {
+  return {
+    pathname: "/measure-detail" as const,
+    params: {
+      referendumTitle: m.referendumTitle ?? "",
+      referendumSubtitle: m.referendumSubtitle ?? "",
+      referendumProStatement: m.referendumProStatement ?? "",
+      referendumConStatement: m.referendumConStatement ?? "",
+      referendumText: m.referendumText ?? "",
+      referendumUrl: m.referendumUrl ?? "",
+      summary: m.summary ?? "",
+      summaryIsAiGenerated: m.summaryIsAiGenerated ? "true" : "false",
+      fiscalImpact: m.fiscalImpact ?? "",
+      proArguments: JSON.stringify(m.proArguments ?? []),
+      conArguments: JSON.stringify(m.conArguments ?? []),
+      citations: JSON.stringify(m.citations ?? []),
+    },
+  };
+}
+
+/** Short label for the most authoritative source backing a measure. */
+function topSourceLabel(m: Contest): string | null {
+  const official = m.sources?.find((src) => src.official);
+  const src = official ?? m.sources?.[0];
+  if (!src) return null;
+  return src.official ? `Official · ${src.name}` : src.name;
+}
+
 // TODO(backend): default to the signed-in user's registered address. We mock
 // one (matching the mocked profile in Sacramento) so the ballot populates by
 // default; the user can still edit it.
@@ -316,22 +345,7 @@ export default function ElectionsScreen() {
                         <TouchableOpacity
                           style={s.readMoreBtn}
                           activeOpacity={0.8}
-                          onPress={() =>
-                            router.push({
-                              pathname: "/measure-detail",
-                              params: {
-                                referendumTitle: m.referendumTitle ?? "",
-                                referendumSubtitle: m.referendumSubtitle ?? "",
-                                referendumProStatement:
-                                  m.referendumProStatement ?? "",
-                                referendumConStatement:
-                                  m.referendumConStatement ?? "",
-                                referendumText: m.referendumText ?? "",
-                                referendumUrl: m.referendumUrl ?? "",
-                                summary: m.summary ?? "",
-                              },
-                            })
-                          }
+                          onPress={() => router.push(measureRoute(m))}
                         >
                           <Icon name="doc" size={15} color={colors.bill} />
                           <Text style={s.readMoreText}>Read full measure</Text>
@@ -412,10 +426,28 @@ export default function ElectionsScreen() {
                   </TouchableOpacity>
                   {expanded && (
                     <View style={s.measureBody}>
-                      {(m.referendumSubtitle || m.summary) ? (
+                      {m.summary || m.referendumSubtitle ? (
                         <Text style={s.measureSub}>
-                          {m.referendumSubtitle ?? m.summary}
+                          {m.summary ?? m.referendumSubtitle}
                         </Text>
+                      ) : null}
+                      {m.summaryIsAiGenerated && (
+                        <View style={s.aiChip}>
+                          <Icon
+                            name="sparkle"
+                            size={11}
+                            color={colors.yellow[500]}
+                          />
+                          <Text style={s.aiChipText}>AI-generated summary</Text>
+                        </View>
+                      )}
+                      {m.fiscalImpact ? (
+                        <View style={s.fiscalRow}>
+                          <Text style={s.fiscalLabel}>Fiscal impact</Text>
+                          <Text style={s.fiscalValue} numberOfLines={3}>
+                            {m.fiscalImpact}
+                          </Text>
+                        </View>
                       ) : null}
                       {m.referendumProStatement ? (
                         <View style={s.stanceRow}>
@@ -452,26 +484,27 @@ export default function ElectionsScreen() {
                       <TouchableOpacity
                         style={s.readMoreBtn}
                         activeOpacity={0.8}
-                        onPress={() =>
-                          router.push({
-                            pathname: "/measure-detail",
-                            params: {
-                              referendumTitle: m.referendumTitle ?? "",
-                              referendumSubtitle: m.referendumSubtitle ?? "",
-                              referendumProStatement:
-                                m.referendumProStatement ?? "",
-                              referendumConStatement:
-                                m.referendumConStatement ?? "",
-                              referendumText: m.referendumText ?? "",
-                              referendumUrl: m.referendumUrl ?? "",
-                              summary: m.summary ?? "",
-                            },
-                          })
-                        }
+                        onPress={() => router.push(measureRoute(m))}
                       >
                         <Icon name="doc" size={15} color={colors.bill} />
                         <Text style={s.readMoreText}>Read full measure</Text>
                       </TouchableOpacity>
+                      {topSourceLabel(m) ? (
+                        <View style={s.sourceChip}>
+                          <Icon
+                            name={
+                              m.sources?.some((src) => src.official)
+                                ? "shield"
+                                : "info"
+                            }
+                            size={11}
+                            color={colors.textSecondary}
+                          />
+                          <Text style={s.sourceChipText} numberOfLines={1}>
+                            {topSourceLabel(m)}
+                          </Text>
+                        </View>
+                      ) : null}
                     </View>
                   )}
                 </Card>
@@ -708,6 +741,43 @@ const s = StyleSheet.create({
     fontFamily: fontBody.semibold,
     fontSize: 13.5,
     color: colors.bill,
+  },
+  aiChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+    alignSelf: "flex-start",
+  },
+  aiChipText: {
+    fontFamily: fontBody.medium,
+    fontSize: 11.5,
+    color: colors.yellow[500],
+  },
+  fiscalRow: { gap: 3 },
+  fiscalLabel: {
+    fontFamily: fontBody.semibold,
+    fontSize: 11.5,
+    color: colors.textSecondary,
+    textTransform: "uppercase",
+    letterSpacing: 0.3,
+  },
+  fiscalValue: {
+    fontFamily: fontBody.regular,
+    fontSize: 13,
+    color: "rgba(255,255,255,0.8)",
+    lineHeight: 19,
+  },
+  sourceChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    alignSelf: "flex-start",
+    marginTop: 2,
+  },
+  sourceChipText: {
+    fontFamily: fontBody.medium,
+    fontSize: 11.5,
+    color: colors.textSecondary,
   },
   empty: {
     fontFamily: "AlbertSans-Regular",

--- a/apps/expo/src/app/(tabs)/feed.tsx
+++ b/apps/expo/src/app/(tabs)/feed.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import {
   ActivityIndicator,
+  Alert,
   Dimensions,
   FlatList,
   StyleSheet,
@@ -11,11 +12,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Image } from "expo-image";
 import { LinearGradient } from "expo-linear-gradient";
 import { useRouter } from "expo-router";
-import {
-  useInfiniteQuery,
-  useMutation,
-  useQuery,
-} from "@tanstack/react-query";
+import { useInfiniteQuery, useMutation, useQuery } from "@tanstack/react-query";
 
 import type { VideoPost } from "@acme/api";
 
@@ -31,6 +28,7 @@ import {
   resolveType,
 } from "~/styles";
 import { queryClient, trpc } from "~/utils/api";
+import { authClient } from "~/utils/auth";
 
 const { height: SCREEN_H, width: SCREEN_W } = Dimensions.get("window");
 
@@ -62,9 +60,14 @@ function FeedCard({
   const canSave = SAVEABLE_TYPES.has(item.type);
   const contentId = item.originalContentId;
 
+  // isArticleSaved is a protected procedure — only query it when signed in,
+  // otherwise it throws UNAUTHORIZED.
+  const { data: session } = authClient.useSession();
+  const isSignedIn = !!session?.user;
+
   const savedQuery = useQuery({
     ...trpc.user.isArticleSaved.queryOptions({ contentId }),
-    enabled: canSave,
+    enabled: canSave && isSignedIn,
     staleTime: 5 * 60 * 1000,
   });
   const saved = savedQuery.data?.saved ?? false;
@@ -88,6 +91,13 @@ function FeedCard({
 
   const toggleSave = () => {
     if (!canSave) return;
+    if (!isSignedIn) {
+      Alert.alert(
+        "Sign in to save",
+        "Sign in to bookmark and revisit content.",
+      );
+      return;
+    }
     if (saved) {
       unsaveMutation.mutate({ contentId });
     } else {

--- a/apps/expo/src/app/(tabs)/index.tsx
+++ b/apps/expo/src/app/(tabs)/index.tsx
@@ -17,6 +17,7 @@ import {
   SearchInput,
   TabScreen,
 } from "~/components/ui";
+import { useUserAddress } from "~/hooks/useUserAddress";
 import { colors, fontBody, fontDisplay } from "~/styles";
 import { trpc } from "~/utils/api";
 import { toCardItem } from "~/utils/content";
@@ -35,10 +36,19 @@ export default function BrowseScreen() {
   const [filter, setFilter] = useState<VideoPost["type"] | "all">("all");
   const [query, setQuery] = useState("");
 
-  const electionsQuery = useQuery(trpc.civic.getElections.queryOptions());
-  const upcomingElection = electionsQuery.data?.find((e) =>
-    isWithinDays(e.electionDay, 30),
-  );
+  // Derive the banner from the user's actual location, not the nationwide
+  // election list (which surfaced out-of-state elections like "North Dakota
+  // Primary"). Use the address they set on the Elections tab — getVoterInfo
+  // returns the election relevant to that address. Banner stays hidden until
+  // an address is set.
+  const { address } = useUserAddress();
+  const voterInfoQuery = useQuery({
+    ...trpc.civic.getVoterInfo.queryOptions({ address: address ?? "" }),
+    enabled: !!address,
+  });
+  const election = voterInfoQuery.data?.election;
+  const upcomingElection =
+    election && isWithinDays(election.electionDay, 30) ? election : undefined;
 
   const { data, isLoading, error } = useQuery(
     trpc.content.getByType.queryOptions({ type: filter }),

--- a/apps/expo/src/app/article-detail.tsx
+++ b/apps/expo/src/app/article-detail.tsx
@@ -2,6 +2,7 @@ import type { RenderRules } from "@ronradtke/react-native-markdown-display";
 import { useState } from "react";
 import {
   ActivityIndicator,
+  Alert,
   Linking,
   ScrollView,
   StyleSheet,
@@ -38,6 +39,7 @@ import {
   useTheme,
 } from "~/styles";
 import { queryClient, trpc } from "~/utils/api";
+import { authClient } from "~/utils/auth";
 
 // TODO(backend): real per-side framing per content item.
 const PLACEHOLDER_LENS = {
@@ -74,9 +76,14 @@ export default function ArticleDetailScreen() {
     enabled: !!articleId,
   });
 
+  // isArticleSaved is a protected procedure — only query it when signed in,
+  // otherwise it throws UNAUTHORIZED.
+  const { data: session } = authClient.useSession();
+  const isSignedIn = !!session?.user;
+
   const savedQuery = useQuery({
     ...trpc.user.isArticleSaved.queryOptions({ contentId: articleId ?? "" }),
-    enabled: !!articleId,
+    enabled: !!articleId && isSignedIn,
   });
   const saved = savedQuery.data?.saved ?? false;
 
@@ -103,6 +110,13 @@ export default function ArticleDetailScreen() {
 
   const toggleSave = () => {
     if (!articleId || !content) return;
+    if (!isSignedIn) {
+      Alert.alert(
+        "Sign in to save",
+        "Sign in to bookmark and revisit content.",
+      );
+      return;
+    }
     if (saved) {
       unsaveMutation.mutate({ contentId: articleId });
     } else {

--- a/apps/expo/src/app/measure-detail.tsx
+++ b/apps/expo/src/app/measure-detail.tsx
@@ -1,9 +1,30 @@
 import { Linking, ScrollView, StyleSheet, View } from "react-native";
 import { useLocalSearchParams, useRouter } from "expo-router";
 
+import type { MeasureArgumentRef, MeasureCitationRef } from "@acme/api";
+
 import { Text } from "~/components/Themed";
-import { Card, Kicker, NavHeader, PrimaryButton } from "~/components/ui";
+import { Card, Icon, Kicker, NavHeader, PrimaryButton } from "~/components/ui";
 import { colors, fontBody, fontDisplay, planes } from "~/styles";
+
+/** Parse a JSON-encoded route param, tolerating empty/malformed values. */
+function parseJson<T>(raw: string | undefined, fallback: T): T {
+  if (!raw) return fallback;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Human-readable label for a source tier. */
+const TIER_LABEL: Record<string, string> = {
+  county_registrar: "County Registrar",
+  state_sos: "Secretary of State",
+  vote_smart: "Vote Smart",
+  google_civic: "Google Civic",
+  ai_generated: "AI-generated",
+};
 
 export default function MeasureDetailScreen() {
   const router = useRouter();
@@ -15,7 +36,34 @@ export default function MeasureDetailScreen() {
     referendumText: string;
     referendumUrl: string;
     summary: string;
+    summaryIsAiGenerated: string;
+    fiscalImpact: string;
+    proArguments: string;
+    conArguments: string;
+    citations: string;
   }>();
+
+  const summaryIsAi = params.summaryIsAiGenerated === "true";
+  const proArgs = parseJson<MeasureArgumentRef[]>(params.proArguments, []);
+  const conArgs = parseJson<MeasureArgumentRef[]>(params.conArguments, []);
+  const citations = parseJson<MeasureCitationRef[]>(params.citations, []);
+
+  // Fall back to the legacy single-statement fields when no structured list.
+  const pros =
+    proArgs.length > 0
+      ? proArgs
+      : params.referendumProStatement
+        ? [{ text: params.referendumProStatement, sourceName: "" }]
+        : [];
+  const cons =
+    conArgs.length > 0
+      ? conArgs
+      : params.referendumConStatement
+        ? [{ text: params.referendumConStatement, sourceName: "" }]
+        : [];
+
+  // Unique sources for the attribution footer, official ones first.
+  const sources = dedupeSources(citations);
 
   return (
     <View style={s.screen}>
@@ -31,19 +79,44 @@ export default function MeasureDetailScreen() {
 
         <Text style={s.title}>{params.referendumTitle}</Text>
 
-        {params.summary ? (
-          <Text style={s.subtitle}>{params.summary}</Text>
-        ) : params.referendumSubtitle ? (
-          <Text style={s.subtitle}>{params.referendumSubtitle}</Text>
+        {params.summary || params.referendumSubtitle ? (
+          <>
+            <Text style={s.subtitle}>
+              {params.summary || params.referendumSubtitle}
+            </Text>
+            {summaryIsAi && (
+              <View style={s.aiNotice}>
+                <Icon name="sparkle" size={13} color={colors.yellow[500]} />
+                <Text style={s.aiNoticeText}>
+                  AI-generated summary — not from an official source. Verify
+                  against the official text below.
+                </Text>
+              </View>
+            )}
+          </>
+        ) : (
+          <Text style={s.subtitle}>
+            No official information is available for this measure yet.
+          </Text>
+        )}
+
+        {/* Fiscal impact (official analysis) */}
+        {params.fiscalImpact ? (
+          <View style={s.section}>
+            <Kicker>Fiscal impact</Kicker>
+            <Card>
+              <Text style={s.fiscalText}>{params.fiscalImpact}</Text>
+            </Card>
+          </View>
         ) : null}
 
         {/* Yes / No arguments */}
-        {(params.referendumProStatement || params.referendumConStatement) && (
+        {(pros.length > 0 || cons.length > 0) && (
           <View style={s.section}>
             <Kicker>A YES vote vs. a NO vote</Kicker>
             <View style={{ gap: 12 }}>
-              {params.referendumProStatement ? (
-                <Card>
+              {pros.map((arg, i) => (
+                <Card key={`pro-${i}`}>
                   <View style={s.stanceHeader}>
                     <View
                       style={[
@@ -53,13 +126,16 @@ export default function MeasureDetailScreen() {
                     />
                     <Text style={s.stanceLabel}>A YES vote means</Text>
                   </View>
-                  <Text style={s.stanceText}>
-                    {params.referendumProStatement}
-                  </Text>
+                  <Text style={s.stanceText}>{arg.text}</Text>
+                  {(arg.author ?? arg.sourceName) ? (
+                    <Text style={s.argAttribution}>
+                      — {arg.author ?? arg.sourceName}
+                    </Text>
+                  ) : null}
                 </Card>
-              ) : null}
-              {params.referendumConStatement ? (
-                <Card>
+              ))}
+              {cons.map((arg, i) => (
+                <Card key={`con-${i}`}>
                   <View style={s.stanceHeader}>
                     <View
                       style={[
@@ -69,11 +145,14 @@ export default function MeasureDetailScreen() {
                     />
                     <Text style={s.stanceLabel}>A NO vote means</Text>
                   </View>
-                  <Text style={s.stanceText}>
-                    {params.referendumConStatement}
-                  </Text>
+                  <Text style={s.stanceText}>{arg.text}</Text>
+                  {(arg.author ?? arg.sourceName) ? (
+                    <Text style={s.argAttribution}>
+                      — {arg.author ?? arg.sourceName}
+                    </Text>
+                  ) : null}
                 </Card>
-              ) : null}
+              ))}
             </View>
           </View>
         )}
@@ -88,6 +167,37 @@ export default function MeasureDetailScreen() {
           </View>
         ) : null}
 
+        {/* Sources / citations */}
+        {sources.length > 0 && (
+          <View style={s.section}>
+            <Kicker>Sources</Kicker>
+            <Card>
+              {sources.map((src, i) => (
+                <View
+                  key={`src-${i}`}
+                  style={[s.sourceRow, i > 0 && s.sourceRowBorder]}
+                >
+                  <Icon
+                    name={src.official ? "shield" : "info"}
+                    size={14}
+                    color={
+                      src.official ? colors.green[500] : colors.textSecondary
+                    }
+                  />
+                  <View style={{ flex: 1 }}>
+                    <Text style={s.sourceName}>{src.sourceName}</Text>
+                    <Text style={s.sourceMeta}>
+                      {src.official ? "Official · " : ""}
+                      {TIER_LABEL[src.tier] ?? src.tier} · for{" "}
+                      {src.fields.join(", ")}
+                    </Text>
+                  </View>
+                </View>
+              ))}
+            </Card>
+          </View>
+        )}
+
         {/* Source link */}
         {params.referendumUrl ? (
           <View style={s.section}>
@@ -100,6 +210,36 @@ export default function MeasureDetailScreen() {
         ) : null}
       </ScrollView>
     </View>
+  );
+}
+
+interface FooterSource {
+  sourceName: string;
+  sourceUrl?: string;
+  official: boolean;
+  tier: string;
+  fields: string[];
+}
+
+/** Collapse per-field citations into one row per source. */
+function dedupeSources(citations: MeasureCitationRef[]): FooterSource[] {
+  const byName = new Map<string, FooterSource>();
+  for (const c of citations) {
+    const existing = byName.get(c.sourceName);
+    if (existing) {
+      if (!existing.fields.includes(c.field)) existing.fields.push(c.field);
+    } else {
+      byName.set(c.sourceName, {
+        sourceName: c.sourceName,
+        sourceUrl: c.sourceUrl,
+        official: c.official,
+        tier: c.tier,
+        fields: [c.field],
+      });
+    }
+  }
+  return [...byName.values()].sort(
+    (a, b) => Number(b.official) - Number(a.official),
   );
 }
 
@@ -134,20 +274,40 @@ const s = StyleSheet.create({
     fontSize: 15,
     color: colors.textSecondary,
     lineHeight: 22,
-    marginBottom: 24,
+    marginBottom: 16,
+  },
+  aiNotice: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+    backgroundColor: "rgba(245, 200, 66, 0.08)",
+    borderWidth: 1,
+    borderColor: "rgba(245, 200, 66, 0.25)",
+    borderRadius: 10,
+    padding: 12,
+    marginBottom: 16,
+  },
+  aiNoticeText: {
+    flex: 1,
+    fontFamily: fontBody.regular,
+    fontSize: 12.5,
+    color: colors.textSecondary,
+    lineHeight: 18,
   },
   section: { marginBottom: 24 },
+  fiscalText: {
+    fontFamily: fontBody.regular,
+    fontSize: 14.5,
+    color: "rgba(255,255,255,0.85)",
+    lineHeight: 22,
+  },
   stanceHeader: {
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
     marginBottom: 10,
   },
-  stanceDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-  },
+  stanceDot: { width: 10, height: 10, borderRadius: 5 },
   stanceLabel: {
     fontFamily: fontBody.semibold,
     fontSize: 14,
@@ -159,10 +319,37 @@ const s = StyleSheet.create({
     color: "rgba(255,255,255,0.85)",
     lineHeight: 22,
   },
+  argAttribution: {
+    fontFamily: fontBody.medium,
+    fontSize: 12.5,
+    color: colors.textSecondary,
+    marginTop: 8,
+  },
   fullText: {
     fontFamily: fontBody.regular,
     fontSize: 14,
     color: "rgba(255,255,255,0.8)",
     lineHeight: 22,
+  },
+  sourceRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 10,
+    paddingVertical: 10,
+  },
+  sourceRowBorder: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "rgba(255,255,255,0.08)",
+  },
+  sourceName: {
+    fontFamily: fontBody.semibold,
+    fontSize: 13.5,
+    color: colors.white,
+  },
+  sourceMeta: {
+    fontFamily: fontBody.regular,
+    fontSize: 11.5,
+    color: colors.textSecondary,
+    marginTop: 2,
   },
 });

--- a/apps/expo/src/components/BallotMeasuresSection.tsx
+++ b/apps/expo/src/components/BallotMeasuresSection.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, TouchableOpacity } from "react-native";
 import { FontAwesome } from "@expo/vector-icons";
 
-import type { Contest } from "@acme/api";
+import type { Contest, Source } from "@acme/api";
 
 import { Text, View } from "~/components/Themed";
 import { fontBody, fontEditorial, fontSize, rd, sp, useTheme } from "~/styles";
@@ -9,6 +9,13 @@ import { fontBody, fontEditorial, fontSize, rd, sp, useTheme } from "~/styles";
 interface BallotMeasuresSectionProps {
   measures: Contest[];
   onMeasurePress?: (measure: Contest) => void;
+}
+
+/** Short attribution label for the most authoritative source. */
+function sourceLabel(sources: Source[]): string | null {
+  const src = sources.find((s) => s.official) ?? sources[0];
+  if (!src) return null;
+  return src.official ? `Official · ${src.name}` : src.name;
 }
 
 export function BallotMeasuresSection({
@@ -45,6 +52,15 @@ export function BallotMeasuresSection({
               {measure.referendumSubtitle}
             </Text>
           )}
+          {measure.summaryIsAiGenerated && (
+            <Text style={styles.aiLabel}>AI-generated summary</Text>
+          )}
+          {measure.fiscalImpact && (
+            <Text style={styles.fiscal} numberOfLines={2}>
+              <Text style={styles.argumentLabel}>Fiscal impact: </Text>
+              {measure.fiscalImpact}
+            </Text>
+          )}
           {(measure.referendumProStatement ??
             measure.referendumConStatement) && (
             <View style={styles.arguments}>
@@ -60,6 +76,22 @@ export function BallotMeasuresSection({
                   {measure.referendumConStatement}
                 </Text>
               )}
+            </View>
+          )}
+          {measure.sources && measure.sources.length > 0 && (
+            <View style={styles.sourceRow}>
+              <FontAwesome
+                name={
+                  measure.sources.some((s) => s.official)
+                    ? "shield"
+                    : "info-circle"
+                }
+                size={11}
+                color={colors.textMuted}
+              />
+              <Text style={styles.sourceText} numberOfLines={1}>
+                {sourceLabel(measure.sources)}
+              </Text>
             </View>
           )}
           <FontAwesome
@@ -122,6 +154,31 @@ const styles = StyleSheet.create({
     color: colors.textMuted,
     marginBottom: sp[3],
     lineHeight: 20,
+  },
+  aiLabel: {
+    fontFamily: fontBody.semibold,
+    fontSize: 11,
+    color: "#F5C842",
+    marginBottom: sp[2],
+  },
+  fiscal: {
+    fontFamily: fontBody.regular,
+    fontSize: fontSize.xs,
+    color: colors.textMuted,
+    marginBottom: sp[3],
+    lineHeight: 18,
+  },
+  sourceRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: sp[2],
+  },
+  sourceText: {
+    fontFamily: fontBody.medium,
+    fontSize: 11,
+    color: colors.textMuted,
+    flex: 1,
   },
   subtitle: {
     fontFamily: fontBody.regular,

--- a/docs/CIVIC_DATA_SOURCES.md
+++ b/docs/CIVIC_DATA_SOURCES.md
@@ -4,16 +4,23 @@ This document explains how to set up API keys and access for all civic data inte
 
 ## Quick Reference
 
-| Source | Key Required | Cost | Env Variable |
-|--------|--------------|------|--------------|
-| Google Civic API | Yes | Free (25k/day) | `GOOGLE_CIVIC_API_KEY` |
-| Open States API | Yes | Free | `OPEN_STATES_API_KEY` |
-| CA Secretary of State | Yes | Free | `CA_SOS_API_KEY` |
-| Legistar (local councils) | No | Free | — |
-| VOTE411 (scraper) | No | Free | — |
-| Santa Clara ROV (scraper) | No* | Free | — |
+| Source                                 | Key Required | Cost           | Env Variable           |
+| -------------------------------------- | ------------ | -------------- | ---------------------- |
+| Google Civic API                       | Yes          | Free (25k/day) | `GOOGLE_CIVIC_API_KEY` |
+| Open States API                        | Yes          | Free           | `OPEN_STATES_API_KEY`  |
+| CA Secretary of State                  | Yes          | Free           | `CA_SOS_API_KEY`       |
+| Legistar (local councils)              | No           | Free           | —                      |
+| VOTE411 (scraper)                      | No           | Free           | —                      |
+| Santa Clara ROV (scraper)              | No\*         | Free           | —                      |
+| CA SOS Voter Guide (scraper)           | No           | Free           | —                      |
+| Santa Clara measure pipeline (scraper) | No           | Free           | —                      |
 
-*Uses Google Civic API internally
+\*Uses Google Civic API internally
+
+> **Ballot measure enrichment.** The CA SOS Voter Guide and Santa Clara measure
+> scrapers feed a cross-validation engine that fills in measure summaries,
+> fiscal impact, and pro/con arguments with per-field source attribution. See
+> [`MEASURE_ENRICHMENT.md`](./MEASURE_ENRICHMENT.md).
 
 ---
 
@@ -43,6 +50,7 @@ GOOGLE_CIVIC_API_KEY=AIza...your_key_here
 ### Optional: Restrict Key
 
 For production, restrict the key:
+
 - **Application restrictions:** HTTP referrers or IP addresses
 - **API restrictions:** Google Civic Information API only
 
@@ -110,6 +118,44 @@ CA_SOS_API_KEY=your_subscription_key_here
 
 ---
 
+## CA SOS Official Voter Guide (scraper)
+
+**Provides:** Official statewide proposition summaries (Attorney General), LAO
+fiscal-impact analyses, arguments in favor / against, full-text links.
+
+**No API key required** (scraper). Source: `https://voterguide.sos.ca.gov`.
+
+This is distinct from the CA SOS _Election Results_ API above — the voter guide
+carries the human-written, official measure content. It feeds the ballot-measure
+cross-validation engine (`packages/api/src/lib/measure-sources/ca-sos-voterguide.ts`).
+
+### Notes
+
+- California statewide propositions only (local measures use the county pipelines).
+- Matched by proposition number parsed from the Google Civic measure title.
+- Defensive: failures fall back cleanly without breaking the request.
+
+---
+
+## Santa Clara Measure Pipeline (scraper)
+
+**Provides:** Local (lettered) measure summaries and fiscal impact for Santa
+Clara County — the proving ground for the county-level pipeline.
+
+**No API key required** (scraper).
+
+### Sources
+
+1. Santa Clara County Registrar of Voters (`vote.santaclaracounty.gov`) —
+   official, but Cloudflare-protected, so it may be unavailable.
+2. League of Women Voters Easy Voter Guide (`easyvoterguide.org`) — nonpartisan
+   fallback.
+
+Implemented in `packages/api/src/lib/measure-sources/santa-clara.ts`. See
+[`MEASURE_ENRICHMENT.md`](./MEASURE_ENRICHMENT.md) for the full pipeline.
+
+---
+
 ## Legistar Web API
 
 **Provides:** Local city council meetings, legislation, votes, agendas
@@ -120,11 +166,11 @@ CA_SOS_API_KEY=your_subscription_key_here
 
 ### Supported Jurisdictions
 
-| Jurisdiction | Legistar Client ID | Website |
-|--------------|-------------------|---------|
-| San Jose | `sanjose` | sanjose.legistar.com |
-| Santa Clara County | `santaclara` | sccgov.legistar.com |
-| Sunnyvale | `sunnyvale` | sunnyvaleca.legistar.com |
+| Jurisdiction       | Legistar Client ID | Website                  |
+| ------------------ | ------------------ | ------------------------ |
+| San Jose           | `sanjose`          | sanjose.legistar.com     |
+| Santa Clara County | `santaclara`       | sccgov.legistar.com      |
+| Sunnyvale          | `sunnyvale`        | sunnyvaleca.legistar.com |
 
 ### Usage
 
@@ -223,18 +269,22 @@ For local development, copy `.env.example` to `.env` and fill in your keys.
 These provide more comprehensive data but require paid subscriptions:
 
 ### BallotReady
+
 - Full ballot data + endorsements
 - Contact: https://organizations.ballotready.org/ballotready-api
 
 ### Ballotpedia
+
 - Candidate bios, detailed election coverage
 - Contact: https://developer.ballotpedia.org/
 
 ### Democracy Works
+
 - Comprehensive election data
 - Contact: https://www.democracy.works/elections-api
 
 ### Vote Smart
+
 - Free for research/nonprofit use
 - Voting records, interest group ratings
 - Register: https://votesmart.org/share/api

--- a/docs/MEASURE_ENRICHMENT.md
+++ b/docs/MEASURE_ENRICHMENT.md
@@ -1,0 +1,120 @@
+# Ballot Measure Enrichment
+
+How Billion turns a bare ballot-measure title into a source-attributed record
+with an official summary, fiscal impact, pro/con arguments, and full text.
+
+## The problem
+
+The Google Civic Information API reliably returns ballot-measure **titles** but
+almost never populates the content fields (subtitle, pro/con, fiscal impact,
+full text) — especially for local (city/county) measures. The expanded measure
+cards in the app were therefore mostly empty.
+
+All of this data is **public record**. Paid aggregators (Ballotpedia,
+BallotReady) just structure it. So instead of paying for a thin API, we combine
+several free, official sources and cross-validate them.
+
+## Architecture
+
+```
+County Registrar (Santa Clara) ─┐
+CA SOS Official Voter Guide  ────┤
+Vote Smart API               ────┼──▶ Cross-Validation Engine ──▶ Canonical Measure ──▶ Cache (CivicApiCache) ──▶ App
+Google Civic API             ────┘        │ merge by trust tier        │ citation on every field
+                                          │ AI structures, never authors
+                                          └── flags discrepancies for review
+```
+
+- **Engine:** `packages/api/src/lib/measure-crossvalidate.ts`
+- **Source adapters:** `packages/api/src/lib/measure-sources/`
+- **Entry point:** `enrichContest()` in `packages/api/src/lib/civic.ts`, run by
+  `civic.getVoterInfo`.
+
+## Trust tiers
+
+When more than one source covers the same field, the higher tier wins:
+
+```
+county_registrar > state_sos > vote_smart > google_civic > ai_generated
+```
+
+Defined in `measure-sources/types.ts` (`SOURCE_TIER_RANK`).
+
+## Source adapters
+
+### CA Secretary of State — Official Voter Guide (`ca-sos-voterguide.ts`)
+
+- **Scope:** California statewide propositions only.
+- **Source:** `https://voterguide.sos.ca.gov/propositions/<n>/`
+- **Extracts:** official Attorney-General summary, Legislative Analyst (LAO)
+  fiscal impact, arguments in favor / against, full-text URL.
+- These are **real, official** texts — not AI-generated.
+- Matches on the proposition number parsed from the title ("Proposition 36").
+
+### Santa Clara County (`santa-clara.ts`) — the proving ground
+
+- **Scope:** local lettered measures ("Measure A").
+- **Primary source:** Santa Clara County Registrar of Voters
+  (`vote.santaclaracounty.gov`). The county site sits behind Cloudflare, so this
+  can fail; when it does we fall back to the **League of Women Voters Easy Voter
+  Guide** (nonpartisan).
+- Matches on the measure letter parsed from the title.
+
+### Vote Smart (`votesmart.ts`)
+
+- **Scope:** state-level measures. Fuzzy-matches the title to a Vote Smart
+  measure and returns summary, full-text URL, pro/con URLs. Requires
+  `VOTE_SMART_API_KEY`.
+
+### Google Civic
+
+- The measure as the API returned it — treated as the lowest-trust source so
+  its subtitle/text/statements still surface when nothing better exists.
+
+## AI's role (explicitly scoped)
+
+- **YES** — summarize official fiscal-impact analyses into plain language;
+  reconcile and structure existing source text.
+- **NO** — generate pro/con arguments from scratch; invent a summary when no
+  source material exists (the UI shows "No information available" instead).
+- **Fallback only** — when there _is_ source material but no human summary, an
+  AI summary is generated and **flagged** (`Contest.summaryIsAiGenerated`) so
+  the app labels it "AI-generated — not from an official source".
+
+## Output shape
+
+`crossValidateMeasure` returns a `CanonicalMeasure`, mapped onto the existing
+`Contest` type:
+
+| Field                               | Meaning                                                                             |
+| ----------------------------------- | ----------------------------------------------------------------------------------- |
+| `summary`                           | best available summary (official preferred)                                         |
+| `summaryIsAiGenerated`              | true if `summary` came from AI                                                      |
+| `fiscalImpact`                      | official fiscal analysis                                                            |
+| `proArguments[]` / `conArguments[]` | attributed arguments (`{text, author?, sourceName, sourceUrl}`)                     |
+| `citations[]`                       | which source supplied each field (`{field, sourceName, sourceUrl, tier, official}`) |
+| `sources[]`                         | one `Source` per citation, for attribution chips                                    |
+
+The same columns exist on `ContestRecord` (`summaryIsAiGenerated`,
+`fiscalImpact`, `citations`) so persisted measures keep their attribution.
+
+## Caching
+
+Enrichment is expensive (network fetches + AI), so results ride along inside the
+`civic.getVoterInfo` response, which is cached per-address in `CivicApiCache`
+with a 24h TTL. No separate cache table is needed.
+
+## Robustness
+
+Every scraper is **defensive**: network failures, timeouts, and markup changes
+yield `null`, never a throw. A missing source is simply "no data from this
+tier", and the engine merges whatever it got. Worst case, the app falls back to
+the raw Google Civic data exactly as before.
+
+## Extending beyond California
+
+The source-adapter interface (`MeasureSourceData`) is generic. To add a state or
+county, write an adapter that returns `MeasureSourceData | null` and register it
+in the `Promise.all` in `crossValidateMeasure`. Start with states that publish
+structured voter-guide data (e.g. Oregon's ORESTAR). CEDA historical data can be
+used to validate extraction accuracy.

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -18,6 +18,9 @@ export type {
   PollingLocation,
   Contest,
   Candidate,
+  Source,
+  MeasureCitationRef,
+  MeasureArgumentRef,
 } from "./lib/civic";
 
 // Google Civic API client functions (for direct use outside tRPC)
@@ -74,7 +77,6 @@ export type {
   DateRange,
   LegislationQuery,
 } from "./integrations/legistar";
-
 
 /**
  * Inference helpers for input types

--- a/packages/api/src/lib/civic.ts
+++ b/packages/api/src/lib/civic.ts
@@ -10,15 +10,10 @@ import { and, eq, gt } from "@acme/db";
 import { db } from "@acme/db/client";
 import { CivicApiCache } from "@acme/db/schema";
 
-import {
-  generateMeasureSummary,
-  generateRoleDescription,
-} from "./civic-ai";
-import {
-  getRoleDescription,
-  saveRoleDescription,
-} from "./civic-descriptions";
-import { enrichFromVoteSmart } from "./votesmart";
+import type { CrossValidateContext } from "./measure-crossvalidate";
+import { generateRoleDescription } from "./civic-ai";
+import { getRoleDescription, saveRoleDescription } from "./civic-descriptions";
+import { crossValidateMeasure } from "./measure-crossvalidate";
 
 const CIVIC_API_BASE = "https://www.googleapis.com/civicinfo/v2";
 
@@ -38,7 +33,9 @@ const CACHE_TTL = {
 } as const;
 
 function hashAddress(address: string): string {
-  return createHash("sha256").update(address.toLowerCase().trim()).digest("hex");
+  return createHash("sha256")
+    .update(address.toLowerCase().trim())
+    .digest("hex");
 }
 
 function stableStringify(obj: Record<string, unknown>): string {
@@ -144,6 +141,26 @@ export interface PollingLocation {
 export interface Source {
   name: string;
   official: boolean;
+  url?: string;
+  /** Trust tier of this source (county_registrar > state_sos > … > ai). */
+  tier?: string;
+}
+
+/** Which source supplied a particular measure field, for UI attribution. */
+export interface MeasureCitationRef {
+  field: string;
+  sourceName: string;
+  sourceUrl?: string;
+  tier: string;
+  official: boolean;
+}
+
+/** A single pro/con argument with attribution. */
+export interface MeasureArgumentRef {
+  text: string;
+  author?: string;
+  sourceName: string;
+  sourceUrl?: string;
 }
 
 export interface Contest {
@@ -172,6 +189,16 @@ export interface Contest {
   sources?: Source[];
   roleDescription?: string;
   summary?: string;
+  /** True when `summary` was AI-generated rather than from an official source. */
+  summaryIsAiGenerated?: boolean;
+  /** Official fiscal impact analysis (e.g. from the LAO or county). */
+  fiscalImpact?: string;
+  /** Structured, attributed pro arguments (preferred over referendumProStatement). */
+  proArguments?: MeasureArgumentRef[];
+  /** Structured, attributed con arguments. */
+  conArguments?: MeasureArgumentRef[];
+  /** Per-field source attribution for everything above. */
+  citations?: MeasureCitationRef[];
 }
 
 export interface Candidate {
@@ -592,6 +619,7 @@ function inferLevel(office: string): string | undefined {
 
 interface EnrichmentContext {
   stateAbbrev?: string;
+  county?: string;
   electionYear?: number;
 }
 
@@ -600,46 +628,64 @@ async function enrichContest(
   ctx?: EnrichmentContext,
 ): Promise<Contest> {
   if (contest.referendumTitle) {
-    // Try Vote Smart for state-level measures
-    if (ctx?.stateAbbrev && ctx.electionYear) {
-      try {
-        const vs = await enrichFromVoteSmart(
-          contest.referendumTitle,
-          ctx.stateAbbrev,
-          ctx.electionYear,
-        );
-        if (vs) {
-          if (vs.summary && !contest.referendumSubtitle) {
-            contest.referendumSubtitle = vs.summary;
-          }
-          if (vs.measureText && !contest.referendumText) {
-            contest.referendumText = vs.measureText;
-          }
-          if (vs.textUrl && !contest.referendumUrl) {
-            contest.referendumUrl = vs.textUrl;
-          }
-          contest.sources = [
-            ...(contest.sources ?? []),
-            { name: vs.source, official: false },
-          ];
-        }
-      } catch {
-        // Vote Smart enrichment failed
-      }
-    }
+    // Cross-validate across all measure sources (county registrar, state SOS,
+    // Vote Smart, Google Civic) and merge by trust tier with source
+    // attribution. AI is only used as a clearly-labeled last resort.
+    const cvCtx: CrossValidateContext = {
+      stateAbbrev: ctx?.stateAbbrev,
+      county: ctx?.county,
+      electionYear: ctx?.electionYear ?? new Date().getFullYear(),
+    };
 
-    if (!contest.summary) {
-      try {
-        contest.summary = await generateMeasureSummary(
-          contest.referendumTitle,
-          contest.referendumSubtitle,
-          contest.referendumText,
-          contest.referendumProStatement,
-          contest.referendumConStatement,
-        );
-      } catch {
-        // AI generation failed
+    try {
+      const merged = await crossValidateMeasure(
+        {
+          title: contest.referendumTitle,
+          subtitle: contest.referendumSubtitle,
+          text: contest.referendumText,
+          url: contest.referendumUrl,
+          proStatement: contest.referendumProStatement,
+          conStatement: contest.referendumConStatement,
+        },
+        cvCtx,
+      );
+
+      contest.summary = merged.summary ?? contest.summary;
+      contest.summaryIsAiGenerated = merged.summaryIsAiGenerated;
+      contest.fiscalImpact = merged.fiscalImpact;
+      contest.proArguments = merged.proArguments.length
+        ? merged.proArguments
+        : undefined;
+      contest.conArguments = merged.conArguments.length
+        ? merged.conArguments
+        : undefined;
+      contest.citations = merged.citations.length
+        ? merged.citations
+        : undefined;
+
+      // Back-fill the legacy single-field shape so existing UI keeps working.
+      if (!contest.referendumText && merged.fullText) {
+        contest.referendumText = merged.fullText;
       }
+      if (!contest.referendumUrl && merged.fullTextUrl) {
+        contest.referendumUrl = merged.fullTextUrl;
+      }
+      if (!contest.referendumProStatement && merged.proArguments[0]) {
+        contest.referendumProStatement = merged.proArguments[0].text;
+      }
+      if (!contest.referendumConStatement && merged.conArguments[0]) {
+        contest.referendumConStatement = merged.conArguments[0].text;
+      }
+
+      // Expose each citation as a Source entry for attribution UIs.
+      contest.sources = merged.citations.map((c) => ({
+        name: c.sourceName,
+        official: c.official,
+        url: c.sourceUrl,
+        tier: c.tier,
+      }));
+    } catch {
+      // Enrichment failed entirely — leave the raw Google Civic data intact.
     }
     return contest;
   }
@@ -721,9 +767,7 @@ export async function getVoterInfo(
   address: string,
   electionId?: string,
 ): Promise<VoterInfoResponse> {
-  const cacheParams: Record<string, unknown> = electionId
-    ? { electionId }
-    : {};
+  const cacheParams: Record<string, unknown> = electionId ? { electionId } : {};
   const cached = await getCached<VoterInfoResponse>(
     address,
     "voterinfo",

--- a/packages/api/src/lib/measure-crossvalidate.ts
+++ b/packages/api/src/lib/measure-crossvalidate.ts
@@ -1,0 +1,292 @@
+/**
+ * Cross-validation engine for ballot measures.
+ *
+ * Collects measure data from every available source (county registrar, state
+ * SOS, Vote Smart, Google Civic, AI fallback), then merges them field-by-field
+ * by trust priority into a single canonical record with full source
+ * attribution. Discrepancies between sources are flagged for human review.
+ *
+ * Guiding principle (from the implementation plan): AI structures and
+ * reconciles, it does not author. Official sources win. Every surfaced field
+ * carries a citation. AI-only summaries are explicitly labeled.
+ */
+
+import type {
+  CanonicalMeasure,
+  MeasureArgument,
+  MeasureCitation,
+  MeasureSourceData,
+} from "./measure-sources/types";
+import { generateMeasureSummary } from "./civic-ai";
+import { enrichFromCaSos } from "./measure-sources/ca-sos-voterguide";
+import { enrichFromSantaClara } from "./measure-sources/santa-clara";
+import { SOURCE_TIER_RANK } from "./measure-sources/types";
+import { enrichFromVoteSmart } from "./votesmart";
+
+export interface CrossValidateContext {
+  stateAbbrev?: string;
+  county?: string;
+  electionYear: number;
+}
+
+/** A measure as Google Civic gives it to us — the lowest-tier source. */
+export interface CivicMeasureInput {
+  title: string;
+  subtitle?: string;
+  text?: string;
+  url?: string;
+  proStatement?: string;
+  conStatement?: string;
+}
+
+/**
+ * Map the existing Vote Smart enrichment into the unified source shape.
+ */
+async function collectVoteSmart(
+  title: string,
+  ctx: CrossValidateContext,
+): Promise<MeasureSourceData | null> {
+  if (!ctx.stateAbbrev) return null;
+  const vs = await enrichFromVoteSmart(
+    title,
+    ctx.stateAbbrev,
+    ctx.electionYear,
+  ).catch(() => null);
+  if (!vs) return null;
+  return {
+    tier: "vote_smart",
+    sourceName: vs.source || "Vote Smart",
+    sourceUrl: vs.voteSmartUrl ?? vs.textUrl,
+    official: false,
+    matchedTitle: title,
+    officialSummary: vs.summary,
+    fullText: vs.measureText,
+    fullTextUrl: vs.textUrl,
+    proArguments: vs.proUrl
+      ? [
+          {
+            text: "See official pro arguments",
+            sourceName: "Vote Smart",
+            sourceUrl: vs.proUrl,
+          },
+        ]
+      : undefined,
+    conArguments: vs.conUrl
+      ? [
+          {
+            text: "See official con arguments",
+            sourceName: "Vote Smart",
+            sourceUrl: vs.conUrl,
+          },
+        ]
+      : undefined,
+  };
+}
+
+/** The Google Civic measure itself, as the lowest-trust source. */
+function civicAsSource(input: CivicMeasureInput): MeasureSourceData {
+  return {
+    tier: "google_civic",
+    sourceName: "Google Civic Information API",
+    sourceUrl: input.url,
+    official: false,
+    matchedTitle: input.title,
+    officialSummary: input.subtitle,
+    fullText: input.text,
+    fullTextUrl: input.url,
+    proStatement: input.proStatement,
+    conStatement: input.conStatement,
+  };
+}
+
+/** Sort sources by trust tier, highest first. */
+function byTierDesc(a: MeasureSourceData, b: MeasureSourceData): number {
+  return SOURCE_TIER_RANK[b.tier] - SOURCE_TIER_RANK[a.tier];
+}
+
+function cite(field: string, src: MeasureSourceData): MeasureCitation {
+  return {
+    field,
+    sourceName: src.sourceName,
+    sourceUrl: src.sourceUrl,
+    tier: src.tier,
+    official: src.official,
+  };
+}
+
+/** Rough similarity for discrepancy detection on summary text. */
+function looksDifferent(a: string, b: string): boolean {
+  const norm = (s: string) =>
+    s
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, "")
+      .split(/\s+/)
+      .filter(Boolean);
+  const wa = new Set(norm(a));
+  const wb = new Set(norm(b));
+  if (wa.size === 0 || wb.size === 0) return false;
+  let overlap = 0;
+  for (const w of wa) if (wb.has(w)) overlap++;
+  return overlap / Math.max(wa.size, wb.size) < 0.4;
+}
+
+/**
+ * Collect from all sources and merge into a canonical, source-attributed
+ * measure record. Sources are fetched concurrently; any that fail are skipped.
+ */
+export async function crossValidateMeasure(
+  input: CivicMeasureInput,
+  ctx: CrossValidateContext,
+): Promise<CanonicalMeasure> {
+  const [sos, scc, vs] = await Promise.all([
+    enrichFromCaSos(input.title, ctx.stateAbbrev, ctx.electionYear).catch(
+      () => null,
+    ),
+    enrichFromSantaClara(input.title, ctx.county).catch(() => null),
+    collectVoteSmart(input.title, ctx),
+  ]);
+
+  const sources: MeasureSourceData[] = [
+    scc,
+    sos,
+    vs,
+    civicAsSource(input),
+  ].filter((s): s is MeasureSourceData => s !== null);
+  sources.sort(byTierDesc);
+
+  const citations: MeasureCitation[] = [];
+  const discrepancies: string[] = [];
+
+  // --- Summary: take the highest-tier source that has one. ---
+  let summary: string | undefined;
+  let summaryIsAiGenerated = false;
+  for (const src of sources) {
+    if (src.officialSummary) {
+      if (summary && looksDifferent(summary, src.officialSummary)) {
+        // already have a higher-tier summary; note the disagreement
+        discrepancies.push(
+          `Summary differs between ${citations.find((c) => c.field === "summary")?.sourceName} and ${src.sourceName}`,
+        );
+      } else if (!summary) {
+        summary = src.officialSummary;
+        citations.push(cite("summary", src));
+      }
+    }
+  }
+
+  // --- Fiscal impact: highest-tier source with one. ---
+  let fiscalImpact: string | undefined;
+  for (const src of sources) {
+    if (src.fiscalImpact && !fiscalImpact) {
+      fiscalImpact = src.fiscalImpact;
+      citations.push(cite("fiscalImpact", src));
+      break;
+    }
+  }
+
+  // --- Full text URL / text: prefer official, then any. ---
+  let fullText: string | undefined;
+  let fullTextUrl: string | undefined;
+  for (const src of sources) {
+    if (src.fullText && !fullText) {
+      fullText = src.fullText;
+      citations.push(cite("fullText", src));
+    }
+    if (src.fullTextUrl && !fullTextUrl) {
+      fullTextUrl = src.fullTextUrl;
+    }
+  }
+
+  // --- Pro / con arguments: collect from all sources, dedupe, attribute. ---
+  const proArguments = collectArguments(sources, "pro", citations);
+  const conArguments = collectArguments(sources, "con", citations);
+
+  // --- AI fallback (last resort), only when there is real source material. ---
+  if (!summary) {
+    const hasMaterial =
+      !!input.subtitle ||
+      !!input.text ||
+      !!input.proStatement ||
+      !!input.conStatement;
+    if (hasMaterial) {
+      try {
+        summary = await generateMeasureSummary(
+          input.title,
+          input.subtitle,
+          input.text,
+          input.proStatement,
+          input.conStatement,
+        );
+        summaryIsAiGenerated = true;
+        citations.push({
+          field: "summary",
+          sourceName: "AI summary (Gemini) — not an official source",
+          tier: "ai_generated",
+          official: false,
+        });
+      } catch {
+        // leave summary undefined → UI shows "No information available"
+      }
+    }
+  }
+
+  return {
+    title: input.title,
+    summary,
+    summaryIsAiGenerated,
+    fiscalImpact,
+    fullText,
+    fullTextUrl,
+    proArguments,
+    conArguments,
+    citations,
+    discrepancies: discrepancies.length ? discrepancies : undefined,
+  };
+}
+
+function collectArguments(
+  sources: MeasureSourceData[],
+  side: "pro" | "con",
+  citations: MeasureCitation[],
+): MeasureArgument[] {
+  const out: MeasureArgument[] = [];
+  const seen = new Set<string>();
+  let cited = false;
+  for (const src of sources) {
+    const list = side === "pro" ? src.proArguments : src.conArguments;
+    if (list) {
+      for (const arg of list) {
+        const key = arg.text.slice(0, 80).toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        out.push(arg);
+      }
+      if (!cited && list.length) {
+        citations.push(
+          cite(side === "pro" ? "proArguments" : "conArguments", src),
+        );
+        cited = true;
+      }
+    }
+    // Single-statement (Google Civic) fallback when no structured list exists.
+    const stmt = side === "pro" ? src.proStatement : src.conStatement;
+    if (stmt && out.length === 0) {
+      const key = stmt.slice(0, 80).toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push({
+          text: stmt,
+          sourceName: src.sourceName,
+          sourceUrl: src.sourceUrl,
+        });
+        if (!cited) {
+          citations.push(
+            cite(side === "pro" ? "proArguments" : "conArguments", src),
+          );
+          cited = true;
+        }
+      }
+    }
+  }
+  return out;
+}

--- a/packages/api/src/lib/measure-sources/ca-sos-voterguide.ts
+++ b/packages/api/src/lib/measure-sources/ca-sos-voterguide.ts
@@ -1,0 +1,176 @@
+/**
+ * California Secretary of State Official Voter Information Guide scraper.
+ *
+ * Source: https://voterguide.sos.ca.gov — the official statewide voter guide.
+ * These are *real, official* summaries written by the Attorney General and
+ * fiscal analyses by the Legislative Analyst's Office (LAO). We extract and
+ * structure them; we never author measure content here.
+ *
+ * Scope: California statewide propositions only. Local measures are handled by
+ * the county pipelines (see santa-clara.ts).
+ *
+ * Everything is best-effort: network failures, timeouts, or markup changes
+ * yield `null`/empty, never a throw. The cross-validation engine treats a
+ * missing source as "no data from this tier".
+ */
+
+import type { MeasureSourceData } from "./types";
+import { htmlToText } from "./html";
+
+const GUIDE_BASE = "https://voterguide.sos.ca.gov";
+const FETCH_TIMEOUT_MS = 12_000;
+const SOURCE_NAME = "California Secretary of State — Official Voter Guide";
+
+/**
+ * Pull the proposition number out of a measure title.
+ * Handles "Proposition 36", "Prop. 1", "Prop 1A", etc.
+ */
+export function parsePropositionNumber(title: string): string | null {
+  const m = /\b(?:proposition|prop\.?)\s*#?\s*([0-9]+[a-z]?)\b/i.exec(title);
+  return m?.[1] ? m[1].toUpperCase() : null;
+}
+
+async function fetchText(url: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const resp = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Accept: "text/html",
+        "User-Agent":
+          "Mozilla/5.0 (compatible; BillionCivicBot/1.0; +https://billion.app)",
+      },
+    });
+    if (!resp.ok) return null;
+    return await resp.text();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Section markers used in the SOS guide proposition pages. We slice text
+ * between consecutive headings rather than relying on brittle CSS selectors.
+ */
+const SECTION_PATTERNS = {
+  summary:
+    /\b(official\s+title\s+and\s+summary|summary|what\s+your\s+vote\s+means)\b/i,
+  fiscal:
+    /\b(summary\s+of\s+legislative\s+analyst|fiscal\s+impact|estimate\s+of\s+(?:net\s+)?(?:state|fiscal)\b)/i,
+  pro: /\b(argument\s+in\s+favor|arguments?\s+for)\b/i,
+  con: /\b(argument\s+against|arguments?\s+against)\b/i,
+};
+
+function sliceSection(
+  text: string,
+  start: RegExp,
+  stops: RegExp[],
+): string | undefined {
+  const startMatch = start.exec(text);
+  if (!startMatch) return undefined;
+  const from = startMatch.index + startMatch[0].length;
+  let to = text.length;
+  for (const stop of stops) {
+    const m = stop.exec(text.slice(from));
+    if (m && from + m.index < to) to = from + m.index;
+  }
+  const section = text.slice(from, to).trim();
+  // Guard against pathological slices that are just heading fragments.
+  return section.length >= 40 ? section : undefined;
+}
+
+/**
+ * Fetch and structure a single statewide proposition from the SOS guide.
+ *
+ * @param propNumber - e.g. "1", "36", "1A"
+ */
+export async function getCaSosProposition(
+  propNumber: string,
+): Promise<MeasureSourceData | null> {
+  // The guide URL structure has shifted over cycles; try the stable paths.
+  const candidates = [
+    `${GUIDE_BASE}/propositions/${propNumber}/`,
+    `${GUIDE_BASE}/en/propositions/${propNumber}/`,
+    `${GUIDE_BASE}/propositions/${propNumber}/index.htm`,
+  ];
+
+  let html: string | null = null;
+  let usedUrl = candidates[0];
+  for (const url of candidates) {
+    html = await fetchText(url);
+    if (html && html.length > 500) {
+      usedUrl = url;
+      break;
+    }
+  }
+  if (!html) return null;
+
+  const text = htmlToText(html);
+  if (text.length < 200) return null;
+
+  const summary = sliceSection(text, SECTION_PATTERNS.summary, [
+    SECTION_PATTERNS.fiscal,
+    SECTION_PATTERNS.pro,
+    SECTION_PATTERNS.con,
+  ]);
+  const fiscalImpact = sliceSection(text, SECTION_PATTERNS.fiscal, [
+    SECTION_PATTERNS.pro,
+    SECTION_PATTERNS.con,
+  ]);
+  const proText = sliceSection(text, SECTION_PATTERNS.pro, [
+    SECTION_PATTERNS.con,
+  ]);
+  const conText = sliceSection(text, SECTION_PATTERNS.con, [/\brebuttal\b/i]);
+
+  // If we extracted nothing meaningful, treat as no data.
+  if (!summary && !fiscalImpact && !proText && !conText) return null;
+
+  const proClamped = clamp(proText, 1500);
+  const conClamped = clamp(conText, 1500);
+
+  return {
+    tier: "state_sos",
+    sourceName: SOURCE_NAME,
+    sourceUrl: usedUrl,
+    official: true,
+    matchedTitle: `Proposition ${propNumber}`,
+    officialSummary: clamp(summary, 1500),
+    fiscalImpact: clamp(fiscalImpact, 1200),
+    fullTextUrl: usedUrl,
+    proArguments: proClamped
+      ? [{ text: proClamped, sourceName: SOURCE_NAME, sourceUrl: usedUrl }]
+      : undefined,
+    conArguments: conClamped
+      ? [{ text: conClamped, sourceName: SOURCE_NAME, sourceUrl: usedUrl }]
+      : undefined,
+  };
+}
+
+/**
+ * Entry point for the cross-validation engine: given a Google Civic measure
+ * title, resolve and fetch the matching CA statewide proposition if any.
+ *
+ * Returns null for non-proposition titles (local measures, etc.).
+ */
+export async function enrichFromCaSos(
+  referendumTitle: string,
+  stateAbbrev: string | undefined,
+  // Election year is currently unused but kept for source-adapter symmetry and
+  // future cycle-specific URL resolution.
+  _electionYear: number,
+): Promise<MeasureSourceData | null> {
+  if (stateAbbrev && stateAbbrev.toUpperCase() !== "CA") return null;
+  const propNumber = parsePropositionNumber(referendumTitle);
+  if (!propNumber) return null;
+  return getCaSosProposition(propNumber);
+}
+
+function clamp(s: string | undefined, max: number): string | undefined {
+  if (!s) return undefined;
+  const trimmed = s.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > max ? trimmed.slice(0, max).trimEnd() + "…" : trimmed;
+}

--- a/packages/api/src/lib/measure-sources/html.ts
+++ b/packages/api/src/lib/measure-sources/html.ts
@@ -1,0 +1,73 @@
+/**
+ * Minimal HTML helpers for the measure scrapers.
+ *
+ * We deliberately avoid adding a DOM/cheerio dependency to @acme/api — the
+ * source pages we scrape are server-rendered and the data we need can be
+ * pulled out with targeted regexes. Everything here is defensive: a markup
+ * change should yield empty output, never a throw.
+ */
+
+/** Strip tags, decode common entities, and collapse whitespace. */
+export function htmlToText(html: string): string {
+  return decodeEntities(
+    html
+      .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+      .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+      .replace(/<\/(p|div|li|tr|h[1-6]|br)>/gi, "\n")
+      .replace(/<br\s*\/?>/gi, "\n")
+      .replace(/<[^>]+>/g, " "),
+  )
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .split("\n")
+    .map((l) => l.trim())
+    .join("\n")
+    .trim();
+}
+
+const ENTITIES: Record<string, string> = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+  "&apos;": "'",
+  "&nbsp;": " ",
+  "&mdash;": "—",
+  "&ndash;": "–",
+  "&rsquo;": "'",
+  "&lsquo;": "'",
+  "&ldquo;": '"',
+  "&rdquo;": '"',
+};
+
+export function decodeEntities(s: string): string {
+  return s
+    .replace(/&#(\d+);/g, (_, n: string) => String.fromCodePoint(Number(n)))
+    .replace(/&#x([0-9a-f]+);/gi, (_, n: string) =>
+      String.fromCodePoint(parseInt(n, 16)),
+    )
+    .replace(/&[a-z]+;|&#\d+;/gi, (m) => ENTITIES[m.toLowerCase()] ?? m);
+}
+
+/**
+ * Extract the inner content of the first element matching a tag + id/class.
+ * Returns the raw inner HTML (caller can htmlToText it). Best-effort only.
+ */
+export function extractByAttr(
+  html: string,
+  attr: "id" | "class",
+  value: string,
+): string | null {
+  // Matches <tag ... attr="...value..." ...> ... </tag>, non-greedy.
+  const re = new RegExp(
+    `<([a-z0-9]+)[^>]*\\b${attr}\\s*=\\s*["'][^"']*\\b${escapeRe(value)}\\b[^"']*["'][^>]*>([\\s\\S]*?)</\\1>`,
+    "i",
+  );
+  const m = re.exec(html);
+  return m?.[2] ?? null;
+}
+
+function escapeRe(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/api/src/lib/measure-sources/santa-clara.ts
+++ b/packages/api/src/lib/measure-sources/santa-clara.ts
@@ -1,0 +1,148 @@
+/**
+ * Santa Clara County local ballot-measure pipeline (the proving ground).
+ *
+ * Local measures (city/county) are not covered by Vote Smart or the statewide
+ * SOS guide. The county Registrar of Voters publishes measure text, impartial
+ * analyses, and pro/con arguments, but its site (vote.santaclaracounty.gov)
+ * sits behind Cloudflare bot protection. We therefore:
+ *
+ *   1. Try the county's published measure pages defensively (fetch + regex).
+ *   2. Fall back to the League of Women Voters Easy Voter Guide, which carries
+ *      nonpartisan local measure explanations.
+ *
+ * As with the SOS scraper, AI is never used here to author content — we only
+ * extract and structure existing public-record text. Failures yield null.
+ */
+
+import type { MeasureSourceData } from "./types";
+import { htmlToText } from "./html";
+
+const FETCH_TIMEOUT_MS = 12_000;
+
+const SCC_ROV_NAME = "Santa Clara County Registrar of Voters";
+const SCC_ROV_MEASURES_URL = "https://vote.santaclaracounty.gov/vote/measures";
+
+const LWV_NAME = "League of Women Voters — Easy Voter Guide";
+const LWV_LOCAL_URL = "https://www.easyvoterguide.org/";
+
+/** Counties this pipeline knows how to handle, keyed by normalized name. */
+const SUPPORTED_COUNTIES = new Set(["santa clara", "santa clara county"]);
+
+/**
+ * Local measures are lettered ("Measure A", "Measure B"), not numbered like
+ * statewide props. Extract the letter code for matching.
+ */
+export function parseMeasureLetter(title: string): string | null {
+  const m = /\bmeasure\s+([a-z]{1,2})\b/i.exec(title);
+  return m?.[1] ? m[1].toUpperCase() : null;
+}
+
+async function fetchText(url: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const resp = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        Accept: "text/html",
+        "User-Agent":
+          "Mozilla/5.0 (compatible; BillionCivicBot/1.0; +https://billion.app)",
+      },
+    });
+    if (!resp.ok) return null;
+    return await resp.text();
+  } catch {
+    // Cloudflare challenge, timeout, DNS, etc. — treated as "no data".
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Find the block of text describing a given lettered measure within a page's
+ * full text. Slices from the "Measure X" heading to the next "Measure Y".
+ */
+function sliceMeasureBlock(text: string, letter: string): string | undefined {
+  const start = new RegExp(`\\bmeasure\\s+${letter}\\b`, "i").exec(text);
+  if (!start) return undefined;
+  const from = start.index;
+  const next = /\bmeasure\s+[a-z]{1,2}\b/i.exec(
+    text.slice(from + start[0].length),
+  );
+  const to = next ? from + start[0].length + next.index : text.length;
+  const block = text.slice(from, to).trim();
+  return block.length >= 60 ? block : undefined;
+}
+
+const FISCAL_RE =
+  /\b(fiscal\s+impact|tax\s+rate|cost\s+(?:to|of)|annual\s+cost|per\s+\$?\s*100,?000)\b[\s\S]{0,400}/i;
+
+function extractFiscal(block: string): string | undefined {
+  const m = FISCAL_RE.exec(block);
+  return m?.[0]?.trim();
+}
+
+/**
+ * Attempt to enrich a local Santa Clara County measure.
+ *
+ * @param referendumTitle - e.g. "Measure A" (from Google Civic)
+ * @param county - normalized county name from the address, if known
+ */
+export async function enrichFromSantaClara(
+  referendumTitle: string,
+  county?: string,
+): Promise<MeasureSourceData | null> {
+  // Only run for Santa Clara County, or when county is unknown but the title
+  // looks local (lettered) — the proving-ground scope from the plan.
+  const normalizedCounty = county?.toLowerCase().trim();
+  const letter = parseMeasureLetter(referendumTitle);
+  if (!letter) return null;
+  if (normalizedCounty && !SUPPORTED_COUNTIES.has(normalizedCounty)) {
+    return null;
+  }
+
+  // 1. County Registrar (official, highest tier) — may be Cloudflare-blocked.
+  const rovHtml = await fetchText(SCC_ROV_MEASURES_URL);
+  if (rovHtml) {
+    const block = sliceMeasureBlock(htmlToText(rovHtml), letter);
+    if (block) {
+      return {
+        tier: "county_registrar",
+        sourceName: SCC_ROV_NAME,
+        sourceUrl: SCC_ROV_MEASURES_URL,
+        official: true,
+        matchedTitle: `Measure ${letter}`,
+        officialSummary: clamp(block, 1500),
+        fiscalImpact: clamp(extractFiscal(block), 800),
+        fullTextUrl: SCC_ROV_MEASURES_URL,
+      };
+    }
+  }
+
+  // 2. League of Women Voters Easy Voter Guide (nonpartisan, lower tier).
+  const lwvHtml = await fetchText(LWV_LOCAL_URL);
+  if (lwvHtml) {
+    const block = sliceMeasureBlock(htmlToText(lwvHtml), letter);
+    if (block) {
+      return {
+        tier: "county_registrar",
+        sourceName: LWV_NAME,
+        sourceUrl: LWV_LOCAL_URL,
+        official: false,
+        matchedTitle: `Measure ${letter}`,
+        officialSummary: clamp(block, 1200),
+        fullTextUrl: LWV_LOCAL_URL,
+      };
+    }
+  }
+
+  return null;
+}
+
+function clamp(s: string | undefined, max: number): string | undefined {
+  if (!s) return undefined;
+  const trimmed = s.trim();
+  if (!trimmed) return undefined;
+  return trimmed.length > max ? trimmed.slice(0, max).trimEnd() + "…" : trimmed;
+}

--- a/packages/api/src/lib/measure-sources/types.ts
+++ b/packages/api/src/lib/measure-sources/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Shared types for the ballot-measure enrichment pipeline.
+ *
+ * Every piece of measure data we surface is tagged with where it came from so
+ * the app can show source attribution and so the cross-validation engine can
+ * merge conflicting sources by trust priority. See the implementation plan in
+ * docs/MEASURE_ENRICHMENT.md.
+ */
+
+/**
+ * Trust tiers, highest to lowest. The cross-validation engine prefers data
+ * from a higher tier when multiple sources cover the same field.
+ *
+ * County registrar > State SOS > Vote Smart > Google Civic > AI (last resort).
+ */
+export type SourceTier =
+  | "county_registrar"
+  | "state_sos"
+  | "vote_smart"
+  | "google_civic"
+  | "ai_generated";
+
+export const SOURCE_TIER_RANK: Record<SourceTier, number> = {
+  county_registrar: 5,
+  state_sos: 4,
+  vote_smart: 3,
+  google_civic: 2,
+  ai_generated: 1,
+};
+
+/** A single argument for/against a measure, with attribution where available. */
+export interface MeasureArgument {
+  text: string;
+  /** Who wrote it (e.g. "Sen. Jane Doe", "League of Women Voters"). */
+  author?: string;
+  sourceName: string;
+  sourceUrl?: string;
+}
+
+/** A citation describing which source supplied a given field. */
+export interface MeasureCitation {
+  /** Which field this citation backs (e.g. "summary", "fiscalImpact"). */
+  field: string;
+  sourceName: string;
+  sourceUrl?: string;
+  tier: SourceTier;
+  /** True for official government sources (SOS, county registrar). */
+  official: boolean;
+}
+
+/**
+ * The data a single source can contribute about one measure. Sources fill in
+ * whatever fields they have; the cross-validation engine merges these.
+ */
+export interface MeasureSourceData {
+  tier: SourceTier;
+  sourceName: string;
+  sourceUrl?: string;
+  official: boolean;
+  /** Title as the source knows it — used for fuzzy matching. */
+  matchedTitle?: string;
+
+  officialSummary?: string;
+  fiscalImpact?: string;
+  fullText?: string;
+  fullTextUrl?: string;
+  proArguments?: MeasureArgument[];
+  conArguments?: MeasureArgument[];
+  /** Single pro/con statement (Google Civic shape) when no list is available. */
+  proStatement?: string;
+  conStatement?: string;
+}
+
+/**
+ * The canonical, merged measure record produced by the cross-validation
+ * engine. Every populated field has a corresponding entry in `citations`.
+ */
+export interface CanonicalMeasure {
+  title: string;
+  summary?: string;
+  /** True when `summary` was produced by AI with no official source text. */
+  summaryIsAiGenerated?: boolean;
+  fiscalImpact?: string;
+  fullText?: string;
+  fullTextUrl?: string;
+  proArguments: MeasureArgument[];
+  conArguments: MeasureArgument[];
+  citations: MeasureCitation[];
+  /** Fields where sources disagreed, flagged for human review. */
+  discrepancies?: string[];
+}

--- a/packages/db/migrations/add_measure_enrichment_fields.sql
+++ b/packages/db/migrations/add_measure_enrichment_fields.sql
@@ -1,0 +1,14 @@
+-- Add ballot-measure enrichment fields to the contest table.
+-- These back the cross-validation engine output (see docs/MEASURE_ENRICHMENT.md):
+--   summary_is_ai_generated — flags AI-only summaries so the UI can label them
+--   fiscal_impact            — official fiscal analysis (LAO / county registrar)
+--   citations                — per-field source attribution (JSONB array)
+
+ALTER TABLE contest
+  ADD COLUMN IF NOT EXISTS summary_is_ai_generated BOOLEAN DEFAULT FALSE;
+
+ALTER TABLE contest
+  ADD COLUMN IF NOT EXISTS fiscal_impact TEXT;
+
+ALTER TABLE contest
+  ADD COLUMN IF NOT EXISTS citations JSONB DEFAULT '[]'::jsonb;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -283,6 +283,23 @@ export const ContestRecord = pgTable(
     type: t.varchar({ length: 20 }).notNull(), // "candidate" | "referendum"
     roleDescription: t.text(),
     summary: t.text(),
+    // True when `summary` was AI-generated rather than from an official source.
+    summaryIsAiGenerated: t.boolean().default(false),
+    // Official fiscal impact analysis (LAO / county registrar).
+    fiscalImpact: t.text(),
+    // Per-field source attribution from the cross-validation engine.
+    citations: t
+      .jsonb()
+      .$type<
+        {
+          field: string;
+          sourceName: string;
+          sourceUrl?: string;
+          tier: string;
+          official: boolean;
+        }[]
+      >()
+      .default([]),
     source: t.varchar({ length: 50 }).notNull(),
     createdAt: t.timestamp().defaultNow().notNull(),
   }),
@@ -578,7 +595,11 @@ export const CivicApiCache = pgTable(
     createdAt: t.timestamp().defaultNow().notNull(),
   }),
   (table) => ({
-    uniqueCacheKey: unique().on(table.addressHash, table.endpoint, table.params),
+    uniqueCacheKey: unique().on(
+      table.addressHash,
+      table.endpoint,
+      table.params,
+    ),
     expiresAtIdx: index("civic_cache_expires_idx").on(table.expiresAt),
   }),
 );


### PR DESCRIPTION
Implements the **Civic Data Sources: Research Report & Implementation Plan** from [#85](https://github.com/billion-app/billion/pull/85#issuecomment-4588690738) (Phases 2–4 + UI). Builds on the Phase 1 Vote Smart work already in this base branch. Codex's work is intentionally not included.

## Problem
Google Civic returns ballot-measure *titles* but rarely the summary, fiscal impact, pro/con arguments, or full text — local measures especially. The expanded measure cards were empty.

## What this does
A **cross-validation engine** (`packages/api/src/lib/measure-crossvalidate.ts`) pulls the same public-record data the paid aggregators resell, from multiple free sources, and merges them field-by-field by trust tier with per-field source attribution.

```
County registrar > State SOS > Vote Smart > Google Civic > AI summary (last resort)
```

### Phase 2 — CA SOS Official Voter Guide scraper
`measure-sources/ca-sos-voterguide.ts` — statewide propositions: official AG summary, LAO fiscal impact, arguments in favor/against, full-text URL. Real official text, not AI.

### Phase 3 — Santa Clara County pipeline (proving ground)
`measure-sources/santa-clara.ts` — local lettered measures from the County Registrar, with a League of Women Voters Easy Voter Guide fallback (county site is Cloudflare-protected).

### Phase 4 — Cross-validation engine
Merges county / SOS / Vote Smart / Google Civic by tier, dedupes pro/con arguments, flags discrepancies, and tags **every field with a citation**. AI **structures, never authors** — it only summarizes real source material, clearly flagged as AI-generated; it never invents pro/con arguments or summaries from a bare title.

### UI (full surfacing)
- **Measure detail** — fiscal-impact section, multiple attributed pro/con arguments, a **Sources** footer (official providers marked), and an **AI-generated** notice on fallback summaries.
- **Elections tab + ballot-measure cards** — fiscal-impact line, source-attribution chip, AI-generated badge.

### Data / caching
Adds `summary_is_ai_generated`, `fiscal_impact`, and a `citations` JSONB array to `contest` (+ migration). Enrichment rides along inside the existing per-address `CivicApiCache` voter-info response (24h TTL) — no new cache table.

## Design choices
- **Defensive scrapers** (fetch + regex, no new deps): any network/markup failure yields no data for that tier rather than breaking the request. Worst case falls back to raw Google Civic exactly as before.
- **Minimal deps** — no cheerio/Playwright added to `@acme/api`.

## Test plan
- [x] `@acme/api`, `@acme/db`, `@acme/expo` typecheck clean
- [x] New files lint clean (pre-existing `votesmart.ts`/`civic-ai` lint errors on the base branch are untouched)
- [ ] Verify enrichment against a real CA address with statewide props + a Santa Clara local measure
- [ ] Apply `packages/db/migrations/add_measure_enrichment_fields.sql` (or `pnpm db push`)

Docs: `docs/MEASURE_ENRICHMENT.md` (new), `docs/CIVIC_DATA_SOURCES.md`, `ARCHITECTURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)