### PR TITLE
feat(candidates): local candidate statements + raw Civic passthrough

### DIFF
--- a/apps/expo/src/app/contest-detail.tsx
+++ b/apps/expo/src/app/contest-detail.tsx
@@ -221,13 +221,12 @@ export default function ContestDetailScreen() {
               const sources = cand.citations
                 ? dedupeSources(cand.citations)
                 : [];
+              const hasStatement =
+                !!cand.statement?.trim() || !!cand.statementSummary?.trim();
+              const hasContact =
+                contactRows.length > 0 || (cand.channels?.length ?? 0) > 0;
               const hasBody =
-                contactRows.length > 0 ||
-                !!cand.biography ||
-                !!cand.statement ||
-                !!cand.statementSummary ||
-                (cand.channels?.length ?? 0) > 0 ||
-                sources.length > 0;
+                hasContact || !!cand.biography || hasStatement || sources.length > 0;
 
               return (
                 <Card key={i}>
@@ -279,6 +278,18 @@ export default function ContestDetailScreen() {
                         <Text style={s.candBio}>{cand.biography}</Text>
                       ) : null}
                       <CandidateStatement cand={cand} />
+                      {!hasStatement ? (
+                        <View style={s.emptyNote}>
+                          <Icon
+                            name="doc"
+                            size={13}
+                            color={colors.textSecondary}
+                          />
+                          <Text style={s.noContact}>
+                            No statement submitted to the official voter guide.
+                          </Text>
+                        </View>
+                      ) : null}
                       {!hasBody ? (
                         <Text style={s.noContact}>
                           No contact information available.
@@ -507,6 +518,11 @@ const s = StyleSheet.create({
     fontSize: 13.5,
     color: colors.white,
     marginTop: 1,
+  },
+  emptyNote: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
   },
   noContact: {
     fontFamily: fontBody.regular,

--- a/apps/expo/src/app/contest-detail.tsx
+++ b/apps/expo/src/app/contest-detail.tsx
@@ -12,7 +12,7 @@ import {
 import { useLocalSearchParams, useRouter } from "expo-router";
 
 import { Text } from "~/components/Themed";
-import { Card, Icon, Kicker, NavHeader } from "~/components/ui";
+import { Card, Icon, Kicker, NavHeader, Segmented } from "~/components/ui";
 import { colors, fontBody, fontDisplay, hair, planes } from "~/styles";
 
 interface CandidateCitation {
@@ -32,6 +32,9 @@ interface CandidateParam {
   photoUrl?: string;
   channels?: { type: string; id: string }[];
   biography?: string;
+  statement?: string;
+  statementSummary?: string;
+  statementSummaryIsAiGenerated?: boolean;
   incumbent?: boolean;
   citations?: CandidateCitation[];
 }
@@ -84,6 +87,51 @@ function partyInitial(party?: string): string {
   if (p.startsWith("d")) return "D";
   if (p.startsWith("r")) return "R";
   return "NP";
+}
+
+/**
+ * A candidate's statement of qualifications. When an AI summary exists alongside
+ * the verbatim statement, show a two-tab control (AI summary first, then the
+ * verbatim text) mirroring the measure detail screen. With only one of the two,
+ * render it directly without tabs.
+ */
+function CandidateStatement({ cand }: { cand: CandidateParam }) {
+  const hasSummary = !!cand.statementSummary?.trim();
+  const hasVerbatim = !!cand.statement?.trim();
+  const [mode, setMode] = useState<"summary" | "verbatim">(
+    hasSummary ? "summary" : "verbatim",
+  );
+  if (!hasSummary && !hasVerbatim) return null;
+
+  const showTabs = hasSummary && hasVerbatim;
+  const showingSummary = hasSummary && (mode === "summary" || !hasVerbatim);
+
+  return (
+    <View style={s.statementWrap}>
+      {showTabs && (
+        <Segmented
+          value={mode}
+          onChange={setMode}
+          options={[
+            { id: "summary", label: "Plain summary", icon: "sparkle" },
+            { id: "verbatim", label: "Statement", icon: "doc" },
+          ]}
+        />
+      )}
+      {showingSummary && cand.statementSummaryIsAiGenerated && (
+        <View style={s.aiNotice}>
+          <Icon name="sparkle" size={13} color={colors.yellow[500]} />
+          <Text style={s.aiNoticeText}>
+            AI summary of the candidate&apos;s own statement — not an official
+            source. Read the full statement for their exact words.
+          </Text>
+        </View>
+      )}
+      <Text style={s.candBio}>
+        {showingSummary ? cand.statementSummary : cand.statement}
+      </Text>
+    </View>
+  );
 }
 
 export default function ContestDetailScreen() {
@@ -176,6 +224,8 @@ export default function ContestDetailScreen() {
               const hasBody =
                 contactRows.length > 0 ||
                 !!cand.biography ||
+                !!cand.statement ||
+                !!cand.statementSummary ||
                 (cand.channels?.length ?? 0) > 0 ||
                 sources.length > 0;
 
@@ -228,6 +278,7 @@ export default function ContestDetailScreen() {
                       {cand.biography ? (
                         <Text style={s.candBio}>{cand.biography}</Text>
                       ) : null}
+                      <CandidateStatement cand={cand} />
                       {!hasBody ? (
                         <Text style={s.noContact}>
                           No contact information available.
@@ -419,6 +470,26 @@ const s = StyleSheet.create({
     borderTopColor: hair[1],
     paddingTop: 12,
     gap: 8,
+  },
+  statementWrap: {
+    gap: 10,
+  },
+  aiNotice: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+    backgroundColor: "rgba(245, 200, 66, 0.08)",
+    borderWidth: 1,
+    borderColor: "rgba(245, 200, 66, 0.25)",
+    borderRadius: 10,
+    padding: 12,
+  },
+  aiNoticeText: {
+    flex: 1,
+    fontFamily: fontBody.regular,
+    fontSize: 12.5,
+    color: colors.textSecondary,
+    lineHeight: 18,
   },
   contactRow: {
     flexDirection: "row",

--- a/apps/expo/src/app/contest-detail.tsx
+++ b/apps/expo/src/app/contest-detail.tsx
@@ -226,7 +226,10 @@ export default function ContestDetailScreen() {
               const hasContact =
                 contactRows.length > 0 || (cand.channels?.length ?? 0) > 0;
               const hasBody =
-                hasContact || !!cand.biography || hasStatement || sources.length > 0;
+                hasContact ||
+                !!cand.biography ||
+                hasStatement ||
+                sources.length > 0;
 
               return (
                 <Card key={i}>

--- a/apps/expo/src/app/contest-detail.tsx
+++ b/apps/expo/src/app/contest-detail.tsx
@@ -164,7 +164,7 @@ export default function ContestDetailScreen() {
 
   return (
     <View style={s.screen}>
-      <NavHeader title="Contest" onBack={() => router.back()} />
+      <NavHeader title={params.office} onBack={() => router.back()} />
       <ScrollView
         style={s.scroll}
         contentContainerStyle={s.scrollContent}

--- a/apps/scraper/package.json
+++ b/apps/scraper/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "description": "Government data scraper for Billion app",
   "dependencies": {
+    "@acme/api": "workspace:*",
     "@acme/db": "workspace:*",
     "@ai-sdk/deepseek": "^1.0.0",
     "@ai-sdk/google": "^3.0.53",
@@ -16,6 +17,7 @@
     "playwright": "^1.58.2",
     "sharp": "^0.34.5",
     "turndown": "^7.2.2",
+    "unpdf": "^1.6.2",
     "yargs": "^18.0.0",
     "zod": "catalog:"
   },

--- a/apps/scraper/src/main.ts
+++ b/apps/scraper/src/main.ts
@@ -6,6 +6,7 @@ import { scotus } from "./scrapers/scotus.js";
 import { federalregister } from "./scrapers/federalregister.js";
 import { vote411 } from "./scrapers/vote411.js";
 import { sccCvig } from "./scrapers/scc-cvig.js";
+import { caSosStatements } from "./scrapers/ca-sos-statements.js";
 import type { Scraper } from "./utils/types.js";
 import { createLogger } from "./utils/log.js";
 import { setConcurrency } from "./utils/concurrency.js";
@@ -13,7 +14,7 @@ import { resetMetrics, printMetricsSummary } from "./utils/db/metrics.js";
 
 const logger = createLogger("main");
 
-const scrapers: Scraper[] = [federalregister, congress, scotus, vote411, sccCvig];
+const scrapers: Scraper[] = [federalregister, congress, scotus, vote411, sccCvig, caSosStatements];
 const scraperNames = scrapers.map((s) => s.name);
 
 const argv = await yargs(hideBin(process.argv))

--- a/apps/scraper/src/main.ts
+++ b/apps/scraper/src/main.ts
@@ -5,6 +5,7 @@ import { congress } from "./scrapers/congress.js";
 import { scotus } from "./scrapers/scotus.js";
 import { federalregister } from "./scrapers/federalregister.js";
 import { vote411 } from "./scrapers/vote411.js";
+import { sccCvig } from "./scrapers/scc-cvig.js";
 import type { Scraper } from "./utils/types.js";
 import { createLogger } from "./utils/log.js";
 import { setConcurrency } from "./utils/concurrency.js";
@@ -12,7 +13,7 @@ import { resetMetrics, printMetricsSummary } from "./utils/db/metrics.js";
 
 const logger = createLogger("main");
 
-const scrapers: Scraper[] = [federalregister, congress, scotus, vote411];
+const scrapers: Scraper[] = [federalregister, congress, scotus, vote411, sccCvig];
 const scraperNames = scrapers.map((s) => s.name);
 
 const argv = await yargs(hideBin(process.argv))

--- a/apps/scraper/src/scrapers/ca-sos-statements.ts
+++ b/apps/scraper/src/scrapers/ca-sos-statements.ts
@@ -1,0 +1,111 @@
+/**
+ * California Secretary of State Official Voter Information Guide statement scraper.
+ *
+ * Fetches the nine statewide-office candidate-statement pages and writes ONE
+ * CivicApiCache row per election year. The thin API adapter
+ * (packages/api .../ca-sos-voterguide.ts) reads that row at request time and
+ * matches a candidate by name — keeping the page fetch + HTML parse out of the
+ * serverless API path. The adapter still falls back to a live fetch on a cache
+ * miss, so this scraper is a performance/robustness win, not a hard dependency.
+ *
+ * Source: https://voterguide.sos.ca.gov/candidates/{office}-candidate-statements.htm
+ * These URLs are STABLE and election-agnostic (no electionId in the path), so the
+ * cron just refetches the same pages — whatever election is live wins. That makes
+ * SOS discovery trivial compared to the per-county PDF guides (see scc-cvig.ts).
+ * The site WAF-filters bare clients, so we send a browser User-Agent.
+ *
+ * Cadence: statements publish ~5–6 weeks before each statewide election. Run this
+ * on a cron through that window; re-runs upsert the single per-year row.
+ */
+
+import { db } from "@acme/db/client";
+import { CivicApiCache } from "@acme/db/schema";
+import {
+  CA_SOS_ADDRESS_HASH,
+  CA_SOS_ENDPOINT,
+  caSosCacheParams,
+} from "@acme/api/lib/candidate-sources/ca-sos-cache";
+import type {
+  CaSosPayload,
+  CaSosStatement,
+} from "@acme/api/lib/candidate-sources/ca-sos-cache";
+import {
+  OFFICE_SLUGS,
+  fetchText,
+  officeUrl,
+  parseOfficePage,
+} from "@acme/api/lib/candidate-sources/ca-sos-voterguide";
+
+import type { Scraper } from "../utils/types.js";
+import { createLogger } from "../utils/log.js";
+
+const logger = createLogger("ca-sos-statements");
+
+/** Cache rows live past a single election cycle; re-runs upsert. */
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/** The election year to scrape. SOS pages are election-agnostic, so this only keys the cache row. */
+function targetYear(): number {
+  return new Date().getFullYear();
+}
+
+/** Fetch + parse every statewide office page, deduped by slug to one fetch each. */
+async function scrapeAllOffices(): Promise<CaSosStatement[]> {
+  const slugs = [...new Set(OFFICE_SLUGS.map((o) => o.slug))];
+  const all: CaSosStatement[] = [];
+  for (const slug of slugs) {
+    const html = await fetchText(officeUrl(slug));
+    if (!html) {
+      logger.warn(`${slug}: page fetch failed.`);
+      continue;
+    }
+    const statements = parseOfficePage(html, slug);
+    logger.info(`${slug}: parsed ${statements.length} statements.`);
+    all.push(...statements);
+  }
+  return all;
+}
+
+async function scrape(): Promise<void> {
+  const year = targetYear();
+  logger.info(`Scraping CA SOS voter guide for ${year}…`);
+
+  const statements = await scrapeAllOffices();
+  if (statements.length === 0) {
+    logger.warn(`CA SOS ${year}: no statements extracted — skipping cache write.`);
+    return;
+  }
+
+  const payload: CaSosPayload = { statements };
+  const now = new Date();
+  const params = caSosCacheParams(year);
+  try {
+    await db
+      .insert(CivicApiCache)
+      .values({
+        addressHash: CA_SOS_ADDRESS_HASH,
+        endpoint: CA_SOS_ENDPOINT,
+        params,
+        responseData: payload,
+        fetchedAt: now,
+        expiresAt: new Date(now.getTime() + CACHE_TTL_MS),
+      })
+      .onConflictDoUpdate({
+        target: [
+          CivicApiCache.addressHash,
+          CivicApiCache.endpoint,
+          CivicApiCache.params,
+        ],
+        set: {
+          responseData: payload,
+          fetchedAt: now,
+          expiresAt: new Date(now.getTime() + CACHE_TTL_MS),
+        },
+      });
+    logger.success(`CA SOS ${year}: cached ${statements.length} statements.`);
+  } catch (err) {
+    logger.error(`CA SOS ${year}: cache write failed:`, err);
+  }
+}
+
+export const caSosStatements: Scraper = { name: "ca-sos-statements", scrape };

--- a/apps/scraper/src/scrapers/scc-cvig.ts
+++ b/apps/scraper/src/scrapers/scc-cvig.ts
@@ -1,0 +1,362 @@
+/**
+ * Santa Clara County Voter Information Guide (CVIG) statement scraper.
+ *
+ * Extracts candidate statements of qualifications (§13307) from the county's
+ * official voter-guide PDFs and writes ONE CivicApiCache row per election. The
+ * thin API adapter (packages/api .../scc-registrar.ts) reads that row at request
+ * time and matches a candidate by name — keeping the heavy PDF work out of the
+ * serverless API path.
+ *
+ * Source: https://stgenrov.sccgov.org/voterguide/{electionId}/{docCode}.pdf
+ * These PDFs have a real text layer (no OCR needed) but a two-column layout that
+ * naive extraction interleaves. We extract with positional data and split each
+ * page into left/right columns before segmenting. When that yields too little,
+ * we fall back to multimodal extraction (Gemini) on the raw PDF bytes.
+ *
+ * Discovery is a hand-maintained {year → electionId, docCodes} map for v1: the
+ * blob LIST API can't enumerate recent elections and the county's lookup tools
+ * are Cloudflare-gated. A future discovery script can bridge the electionId via
+ * Clarity ENR (results.enr.clarityelections.com/CA/Santa_Clara) by election date
+ * — see issues #100 / #102.
+ */
+
+import { generateObject } from "ai";
+import { getDocumentProxy } from "unpdf";
+import { z } from "zod/v4";
+
+import { db } from "@acme/db/client";
+import { CivicApiCache } from "@acme/db/schema";
+import {
+  SCC_CVIG_ADDRESS_HASH,
+  SCC_CVIG_ENDPOINT,
+  sccCvigCacheParams,
+} from "@acme/api/lib/candidate-sources/scc-cvig-cache";
+import type {
+  SccCvigPayload,
+  SccCvigStatement,
+} from "@acme/api/lib/candidate-sources/scc-cvig-cache";
+
+import type { Scraper } from "../utils/types.js";
+import { createLogger } from "../utils/log.js";
+import { visionLlm } from "../utils/ai/provider.js";
+
+const logger = createLogger("scc-cvig");
+
+const PDF_BASE = "https://stgenrov.sccgov.org/voterguide";
+const FETCH_TIMEOUT_MS = 30_000;
+/** Browser UA — the stgenrov host is WAF-free but bare clients can be blocked. */
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+/** Cache rows live well past a single election cycle; re-runs upsert. */
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+/** Below this many parsed statements per doc, fall back to multimodal extraction. */
+const MIN_STATEMENTS_BEFORE_FALLBACK = 2;
+
+/**
+ * Hand-maintained discovery map. Refresh ~6 weeks before each SCC election:
+ * capture the electionId (the `/voterguide/{id}/` folder) and the candidate
+ * statement docCodes for the ballot types you want to cover.
+ *
+ * TODO(#102): replace with Clarity-ENR-based discovery (electiondate → folder).
+ */
+const SCC_GUIDES: Record<number, { electionId: string; docCodes: string[] }> = {
+  // 2024 General — known-good sample doc (verified reachable, real text layer).
+  2024: { electionId: "137", docCodes: ["SC341ENG-508"] },
+  // 2026 Primary — fill in once the guide is published.
+  // 2026: { electionId: "<id>", docCodes: ["<docCode>", ...] },
+};
+
+interface TextItem {
+  str: string;
+  x: number;
+  y: number;
+}
+
+/** Fetch a PDF as bytes, or null on any failure (never throws). */
+async function fetchPdf(url: string): Promise<Uint8Array | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const resp = await fetch(url, {
+      signal: controller.signal,
+      headers: { "User-Agent": USER_AGENT, Accept: "application/pdf" },
+    });
+    if (!resp.ok) {
+      logger.warn(`PDF fetch ${resp.status} for ${url}`);
+      return null;
+    }
+    return new Uint8Array(await resp.arrayBuffer());
+  } catch (err) {
+    logger.warn(`PDF fetch failed for ${url}:`, err);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Extract page text with two-column de-interleaving. SCC guides lay candidate
+ * statements out in two columns; sorting items by (column, y, x) recovers the
+ * natural top-to-bottom-then-next-column reading order that a plain text dump
+ * scrambles.
+ */
+async function extractColumnAwareText(pdf: Uint8Array): Promise<string> {
+  const proxy = await getDocumentProxy(pdf);
+  const pages: string[] = [];
+
+  for (let p = 1; p <= proxy.numPages; p++) {
+    const page = await proxy.getPage(p);
+    const viewport = page.getViewport({ scale: 1 });
+    const content = await page.getTextContent();
+    const rawItems = content.items as unknown[];
+    const items: TextItem[] = rawItems
+      .map((it): TextItem | null => {
+        const t = it as { str?: string; transform?: number[] };
+        if (typeof t.str !== "string" || !t.transform) return null;
+        return { str: t.str, x: t.transform[4] ?? 0, y: t.transform[5] ?? 0 };
+      })
+      .filter((v): v is TextItem => v !== null && v.str.trim().length > 0);
+
+    const midX = viewport.width / 2;
+    const sortColumn = (col: TextItem[]) =>
+      col
+        // top-to-bottom (PDF y grows upward), then left-to-right
+        .sort((a, b) => (Math.abs(a.y - b.y) > 2 ? b.y - a.y : a.x - b.x))
+        .map((i) => i.str)
+        .join(" ");
+
+    const left = sortColumn(items.filter((i) => i.x < midX));
+    const right = sortColumn(items.filter((i) => i.x >= midX));
+    pages.push([left, right].filter(Boolean).join("\n"));
+  }
+
+  return pages.join("\n\n");
+}
+
+/**
+ * Regex-segment de-interleaved guide text into candidate statements.
+ *
+ * The guide flows each statement on one continuous run (column extraction does
+ * not preserve line breaks):
+ *   CANDIDATE STATEMENTS FOR <OFFICE>
+ *   <NAME IN CAPS> Occupation: <occ> Age: <age> Education and Qualifications: <body> CS-####
+ *
+ * We capture the office heading, then each `<NAME> Occupation: … Education and
+ * Qualifications: <body>` block, ending the body at the next candidate name, the
+ * next office heading, a `CS-####` doc code, or a page footer.
+ */
+function segmentStatements(text: string, sourceUrl: string): SccCvigStatement[] {
+  const out: SccCvigStatement[] = [];
+
+  // Split the doc by office headings so each candidate inherits its office.
+  const headingRe = /CANDIDATE STATEMENTS? FOR\s+([^\n]+?)(?=\s+[A-Z][A-Z.'' -]+\s+Occupation:)/g;
+  // Within a section, a candidate block runs from a CAPS name + "Occupation:"
+  // through "Education and Qualifications:" and its body, up to the next such
+  // name, the next office heading, a CS-#### code, or a page footer.
+  const candRe =
+    /([A-Z][A-Z.'' -]{2,40}?)\s+Occupation:\s*(.*?)\s+Education and Qualifications:\s*(.*?)(?=\s+[A-Z][A-Z.'' -]{2,40}?\s+Occupation:|\s+CANDIDATE STATEMENTS? FOR|\s+CS-\d|\s+SC Ballot Type|$)/gs;
+
+  // Build (office, startIndex) markers so we can label each candidate by office.
+  const offices: { office: string; index: number }[] = [];
+  let hm: RegExpExecArray | null;
+  while ((hm = headingRe.exec(text)) !== null) {
+    offices.push({ office: hm[1]?.trim() ?? "", index: hm.index });
+  }
+  const officeAt = (index: number): string | undefined => {
+    let current: string | undefined;
+    for (const o of offices) {
+      if (o.index <= index) current = o.office;
+      else break;
+    }
+    return current;
+  };
+
+  let cm: RegExpExecArray | null;
+  while ((cm = candRe.exec(text)) !== null) {
+    const name = cleanName(cm[1]);
+    // Occupation runs up to an "Age:" marker when present.
+    const occupation = cm[2]?.split(/\s+Age:/)[0]?.trim();
+    const body = cm[3]?.trim().replace(/\s+/g, " ");
+    if (!name || !body || body.length < 40) continue;
+    const parts = [
+      occupation ? `Occupation: ${occupation}` : "",
+      body,
+    ].filter(Boolean);
+    out.push({
+      name,
+      office: officeAt(cm.index),
+      statement: parts.join("\n\n"),
+      sourceUrl,
+    });
+  }
+  return out;
+}
+
+/**
+ * Clean a captured name. Column wrapping sometimes prefixes the contest's
+ * jurisdiction onto the name (e.g. an office heading "CITY CLERK, CITY OF SANTA
+ * CLARA" wraps so "CITY OF SANTA CLARA" bleeds into the next candidate). Strip
+ * a leading "CITY/COUNTY/TOWN OF <Place>" jurisdiction phrase. Downstream name
+ * matching is fuzzy, so over-stripping is safer than leaving the prefix in.
+ */
+function cleanName(raw: string | undefined): string {
+  return (raw ?? "")
+    .trim()
+    .replace(/\s+/g, " ")
+    .replace(/^(?:CITY|COUNTY|TOWN)\s+OF\s+SANTA\s+CLARA\s+/i, "")
+    .replace(/^(?:CITY|COUNTY|TOWN)\s+OF\s+[A-Z][a-z]+(?:\s+[A-Z][a-z]+)?\s+/, "")
+    .trim();
+}
+
+const StatementSchema = z.object({
+  statements: z.array(
+    z.object({
+      name: z.string(),
+      office: z.string().optional(),
+      statement: z.string(),
+    }),
+  ),
+});
+
+/**
+ * Multimodal fallback: hand the whole PDF to Gemini and ask for structured,
+ * verbatim candidate statements. Used only when text-layer segmentation comes
+ * up short (e.g. a page whose columns don't split cleanly). Null when no vision
+ * model is configured.
+ */
+async function extractWithVision(
+  pdf: Uint8Array,
+  sourceUrl: string,
+): Promise<SccCvigStatement[] | null> {
+  if (!visionLlm) {
+    logger.info("No vision model configured — skipping multimodal fallback.");
+    return null;
+  }
+  try {
+    const { object } = await generateObject({
+      model: visionLlm,
+      schema: StatementSchema,
+      temperature: 0.2,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "This is an official county voter information guide. Extract every CANDIDATE STATEMENT of qualifications, VERBATIM. For each, return the candidate name, the office/contest it appears under (if shown), and the full statement text. Do NOT summarize, paraphrase, or invent — copy the statement text exactly as printed. Ignore ballot measure text, instructions, and boilerplate.",
+            },
+            { type: "file", data: pdf, mediaType: "application/pdf" },
+          ],
+        },
+      ],
+    });
+    return object.statements
+      .filter((s) => s.statement.trim().length >= 40)
+      .map((s) => ({
+        name: s.name.trim(),
+        office: s.office?.trim() || undefined,
+        statement: s.statement.trim(),
+        sourceUrl,
+      }));
+  } catch (err) {
+    logger.warn("Vision extraction failed:", err);
+    return null;
+  }
+}
+
+async function scrapeGuide(
+  electionYear: number,
+  guide: { electionId: string; docCodes: string[] },
+): Promise<SccCvigStatement[]> {
+  const all: SccCvigStatement[] = [];
+  for (const docCode of guide.docCodes) {
+    const url = `${PDF_BASE}/${guide.electionId}/${docCode}.pdf`;
+    const pdf = await fetchPdf(url);
+    if (!pdf) continue;
+
+    let statements: SccCvigStatement[] = [];
+    try {
+      const text = await extractColumnAwareText(pdf);
+      statements = segmentStatements(text, url);
+      logger.info(`${docCode}: text-layer parsed ${statements.length}`);
+    } catch (err) {
+      logger.warn(`${docCode}: text extraction failed:`, err);
+    }
+
+    if (statements.length < MIN_STATEMENTS_BEFORE_FALLBACK) {
+      const viaVision = await extractWithVision(pdf, url);
+      if (viaVision && viaVision.length > statements.length) {
+        logger.info(`${docCode}: vision parsed ${viaVision.length}`);
+        statements = viaVision;
+      }
+    }
+    all.push(...statements);
+  }
+  return all;
+}
+
+/** Merge statements, keeping the longest per candidate name (dedupe across docs). */
+function dedupe(statements: SccCvigStatement[]): SccCvigStatement[] {
+  const byKey = new Map<string, SccCvigStatement>();
+  for (const s of statements) {
+    const key = s.name.toLowerCase().replace(/[^a-z0-9]/g, "");
+    const existing = byKey.get(key);
+    if (!existing || s.statement.length > existing.statement.length) {
+      byKey.set(key, s);
+    }
+  }
+  return [...byKey.values()];
+}
+
+async function scrape(): Promise<void> {
+  const years = Object.keys(SCC_GUIDES).map(Number);
+  if (years.length === 0) {
+    logger.warn("No SCC guides configured — nothing to scrape.");
+    return;
+  }
+
+  for (const year of years) {
+    const guide = SCC_GUIDES[year];
+    if (!guide) continue;
+    logger.info(`Scraping SCC ${year} guide (election ${guide.electionId})…`);
+
+    const statements = dedupe(await scrapeGuide(year, guide));
+    if (statements.length === 0) {
+      logger.warn(`SCC ${year}: no statements extracted — skipping cache write.`);
+      continue;
+    }
+
+    const payload: SccCvigPayload = { statements };
+    const now = new Date();
+    const params = sccCvigCacheParams(year);
+    try {
+      await db
+        .insert(CivicApiCache)
+        .values({
+          addressHash: SCC_CVIG_ADDRESS_HASH,
+          endpoint: SCC_CVIG_ENDPOINT,
+          params,
+          responseData: payload,
+          fetchedAt: now,
+          expiresAt: new Date(now.getTime() + CACHE_TTL_MS),
+        })
+        .onConflictDoUpdate({
+          target: [
+            CivicApiCache.addressHash,
+            CivicApiCache.endpoint,
+            CivicApiCache.params,
+          ],
+          set: {
+            responseData: payload,
+            fetchedAt: now,
+            expiresAt: new Date(now.getTime() + CACHE_TTL_MS),
+          },
+        });
+      logger.success(`SCC ${year}: cached ${statements.length} statements.`);
+    } catch (err) {
+      logger.error(`SCC ${year}: cache write failed:`, err);
+    }
+  }
+}
+
+export const sccCvig: Scraper = { name: "scc-cvig", scrape };

--- a/apps/scraper/src/utils/ai/provider.ts
+++ b/apps/scraper/src/utils/ai/provider.ts
@@ -1,4 +1,6 @@
+import type { LanguageModel } from "ai";
 import { createDeepSeek } from "@ai-sdk/deepseek";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createVertex } from "@ai-sdk/google-vertex";
 
 const deepseekApiKey = process.env.DEEPSEEK_API_KEY;
@@ -12,6 +14,14 @@ const deepseekProvider = createDeepSeek({
 });
 
 export const llm = deepseekProvider("deepseek-v4-flash");
+
+// Multimodal (PDF/vision) model for document extraction — DeepSeek is text-only.
+// Gated on the API key so the scraper still runs without it (callers that need
+// multimodal extraction must null-check and skip when this is null).
+const googleApiKey = process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+export const visionLlm: LanguageModel | null = googleApiKey
+  ? createGoogleGenerativeAI({ apiKey: googleApiKey })("gemini-2.5-flash")
+  : null;
 
 // Keep Vertex for Imagen image generation
 const project = process.env.GOOGLE_VERTEX_PROJECT;

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,6 +22,10 @@
     "./lib/civic-ai": {
       "types": "./dist/lib/civic-ai.d.ts",
       "default": "./src/lib/civic-ai.ts"
+    },
+    "./lib/candidate-sources/scc-cvig-cache": {
+      "types": "./dist/lib/candidate-sources/scc-cvig-cache.d.ts",
+      "default": "./src/lib/candidate-sources/scc-cvig-cache.ts"
     }
   },
   "license": "MIT",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -26,6 +26,14 @@
     "./lib/candidate-sources/scc-cvig-cache": {
       "types": "./dist/lib/candidate-sources/scc-cvig-cache.d.ts",
       "default": "./src/lib/candidate-sources/scc-cvig-cache.ts"
+    },
+    "./lib/candidate-sources/ca-sos-cache": {
+      "types": "./dist/lib/candidate-sources/ca-sos-cache.d.ts",
+      "default": "./src/lib/candidate-sources/ca-sos-cache.ts"
+    },
+    "./lib/candidate-sources/ca-sos-voterguide": {
+      "types": "./dist/lib/candidate-sources/ca-sos-voterguide.d.ts",
+      "default": "./src/lib/candidate-sources/ca-sos-voterguide.ts"
     }
   },
   "license": "MIT",

--- a/packages/api/src/lib/candidate-cache.ts
+++ b/packages/api/src/lib/candidate-cache.ts
@@ -19,16 +19,13 @@ import { db } from "@acme/db/client";
 import { CivicApiCache } from "@acme/db/schema";
 
 import type { CanonicalCandidate } from "./candidate-sources/types";
+import { stableStringify } from "./candidate-sources/types";
 
 const ENDPOINT = "candidate-enrich";
 /** Candidate cache is keyed globally (not per-address) — same as other global caches. */
 const ADDRESS_HASH = "__global__";
 /** Bios are slow-changing; cache for 7 days (>= the 24h voterinfo TTL). */
 const CANDIDATE_CACHE_TTL = 7 * 24 * 60 * 60 * 1000;
-
-function stableStringify(obj: Record<string, unknown>): string {
-  return JSON.stringify(obj, Object.keys(obj).sort());
-}
 
 /** Normalize an optional disambiguator: lowercased/trimmed, or undefined when absent. */
 function normOpt(v: string | undefined): string | undefined {

--- a/packages/api/src/lib/candidate-crossvalidate.ts
+++ b/packages/api/src/lib/candidate-crossvalidate.ts
@@ -24,12 +24,12 @@ import type {
 } from "./candidate-sources/types";
 import { enrichCandidateFromBallotpedia } from "./candidate-sources/ballotpedia";
 import { enrichCandidateFromCaSos } from "./candidate-sources/ca-sos-voterguide";
-import { generateCandidateStatementSummary } from "./civic-ai";
 import { enrichCandidateFromOpenStates } from "./candidate-sources/open-states";
 import { enrichCandidateFromScc } from "./candidate-sources/scc-registrar";
 import { byTierDesc, candidateCite } from "./candidate-sources/types";
 import { enrichCandidateFromVoteSmart } from "./candidate-sources/votesmart";
 import { enrichCandidateFromWikipedia } from "./candidate-sources/wikipedia";
+import { generateCandidateStatementSummary } from "./civic-ai";
 
 /**
  * Collect from all candidate sources and merge into a canonical, source-

--- a/packages/api/src/lib/candidate-crossvalidate.ts
+++ b/packages/api/src/lib/candidate-crossvalidate.ts
@@ -26,6 +26,7 @@ import { enrichCandidateFromBallotpedia } from "./candidate-sources/ballotpedia"
 import { enrichCandidateFromCaSos } from "./candidate-sources/ca-sos-voterguide";
 import { generateCandidateStatementSummary } from "./civic-ai";
 import { enrichCandidateFromOpenStates } from "./candidate-sources/open-states";
+import { enrichCandidateFromScc } from "./candidate-sources/scc-registrar";
 import { byTierDesc, candidateCite } from "./candidate-sources/types";
 import { enrichCandidateFromVoteSmart } from "./candidate-sources/votesmart";
 import { enrichCandidateFromWikipedia } from "./candidate-sources/wikipedia";
@@ -40,8 +41,14 @@ export async function crossValidateCandidate(
   input: CandidateInput,
   ctx: CandidateCrossValidateContext,
 ): Promise<CanonicalCandidate> {
-  const [caSos, openStates, voteSmart, ballotpedia, wikipedia] =
+  const [scc, caSos, openStates, voteSmart, ballotpedia, wikipedia] =
     await Promise.all([
+      enrichCandidateFromScc(input.name, {
+        office: input.office,
+        stateAbbrev: ctx.stateAbbrev,
+        county: ctx.county,
+        electionYear: ctx.electionYear,
+      }).catch(() => null),
       enrichCandidateFromCaSos(input.name, {
         office: input.office,
         stateAbbrev: ctx.stateAbbrev,
@@ -73,6 +80,7 @@ export async function crossValidateCandidate(
     ]);
 
   const sources: CandidateSourceData[] = [
+    scc,
     caSos,
     openStates,
     voteSmart,

--- a/packages/api/src/lib/candidate-crossvalidate.ts
+++ b/packages/api/src/lib/candidate-crossvalidate.ts
@@ -24,6 +24,7 @@ import type {
 } from "./candidate-sources/types";
 import { enrichCandidateFromBallotpedia } from "./candidate-sources/ballotpedia";
 import { enrichCandidateFromCaSos } from "./candidate-sources/ca-sos-voterguide";
+import { generateCandidateStatementSummary } from "./civic-ai";
 import { enrichCandidateFromOpenStates } from "./candidate-sources/open-states";
 import { byTierDesc, candidateCite } from "./candidate-sources/types";
 import { enrichCandidateFromVoteSmart } from "./candidate-sources/votesmart";
@@ -116,6 +117,18 @@ export async function crossValidateCandidate(
     }
   }
 
+  // --- statement: highest-tier source with a verbatim candidate statement
+  //     (county registrar > state SOS). Self-authored, kept distinct from the
+  //     neutral biography. ---
+  let statement: string | undefined;
+  for (const src of sources) {
+    if (src.statement?.trim()) {
+      statement = src.statement.trim();
+      citations.push(candidateCite("statement", src));
+      break;
+    }
+  }
+
   // --- contact fields: highest-tier source per field. ---
   // candidateUrl comes from a source `website`; phone / email likewise. Each is
   // picked independently so we can mix (e.g. Open States phone + Vote Smart web).
@@ -161,10 +174,40 @@ export async function crossValidateCandidate(
   // text" case cannot occur. We surface only source-supplied bios (each cited),
   // and show the sparse UI fallback when no source had one — never a guess.
 
+  // --- statement summary: AI summarizes the verbatim statement into plain
+  //     language, grounded ONLY on the statement (no authoring from a bare
+  //     name). Computed here, inside the cached path, so the LLM runs once per
+  //     candidate rather than per request. ---
+  let statementSummary: string | undefined;
+  let statementSummaryIsAiGenerated = false;
+  if (statement) {
+    try {
+      const { long } = await generateCandidateStatementSummary(
+        input.name,
+        statement,
+      );
+      statementSummary = long;
+      statementSummaryIsAiGenerated = true;
+      citations.push({
+        field: "statementSummary",
+        sourceName:
+          "AI summary — grounded on the candidate's statement, not an official source",
+        tier: "ai_generated",
+        official: false,
+      });
+    } catch {
+      // No LLM, statement too thin, or model judged it insufficient — leave the
+      // summary unset and let the UI fall back to the verbatim statement.
+    }
+  }
+
   return {
     name: input.name,
     party: input.party,
     biography,
+    statement,
+    statementSummary,
+    statementSummaryIsAiGenerated,
     photoUrl,
     candidateUrl,
     email,

--- a/packages/api/src/lib/candidate-sources/ca-sos-cache.ts
+++ b/packages/api/src/lib/candidate-sources/ca-sos-cache.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared shape for the CA Secretary of State voter-guide statement handoff cache.
+ *
+ * The CA SOS Official Voter Information Guide publishes verbatim candidate
+ * statements for the nine statewide offices on stable, election-agnostic URLs
+ * (`/candidates/{office}-candidate-statements.htm` — no electionId in the path).
+ * The scraper (apps/scraper) fetches and parses those pages on a cron and writes
+ * ONE CivicApiCache row per election year; the SOS adapter (./ca-sos-voterguide.ts)
+ * reads that row at request time and matches a candidate by name — keeping the
+ * page fetch + HTML parse out of the serverless API path.
+ *
+ * Both sides import these constants and `caSosCacheParams` so the written
+ * `params` string byte-matches the read `params` — a mismatch is a silent,
+ * error-free cache miss. Mirrors ./scc-cvig-cache.ts.
+ */
+
+import { stableStringify } from "./types";
+
+/** CivicApiCache.addressHash for the SOS statement handoff (global, not per-address). */
+export const CA_SOS_ADDRESS_HASH = "__global__";
+
+/** CivicApiCache.endpoint namespace for the SOS statement handoff. */
+export const CA_SOS_ENDPOINT = "ca-sos-statements";
+
+/** One parsed candidate statement from a CA SOS office page. */
+export interface CaSosStatement {
+  /** Candidate name as printed in the guide heading. */
+  name: string;
+  /** SOS office slug the statement appeared under (e.g. "governor"). */
+  officeSlug: string;
+  /** Verbatim statement prose. */
+  statement: string;
+  /** The office page this was parsed from (for attribution). */
+  sourceUrl: string;
+  photoUrl?: string;
+  website?: string;
+  email?: string;
+  phone?: string;
+  channels?: { type: string; id: string }[];
+}
+
+/** Payload stored in CivicApiCache.responseData for one election's guide. */
+export interface CaSosPayload {
+  statements: CaSosStatement[];
+}
+
+/**
+ * Build the CivicApiCache.params string for an election year. One row holds all
+ * statewide candidates for that election. Single source of truth for the key so
+ * the scraper write and the adapter read never drift.
+ */
+export function caSosCacheParams(electionYear: number): string {
+  return stableStringify({ electionYear });
+}

--- a/packages/api/src/lib/candidate-sources/ca-sos-voterguide.ts
+++ b/packages/api/src/lib/candidate-sources/ca-sos-voterguide.ts
@@ -26,7 +26,7 @@
 
 import type { CandidateChannel, CandidateSourceData } from "./types";
 import { decodeEntities, htmlToText } from "../measure-sources/html";
-import { candidateNameSimilarity } from "./types";
+import { candidateNameSimilarity, clamp, dropInitials } from "./types";
 
 const GUIDE_BASE = "https://voterguide.sos.ca.gov";
 const FETCH_TIMEOUT_MS = 12_000;
@@ -263,27 +263,13 @@ function extractChannels(contactText: string): CandidateChannel[] | undefined {
   return channels.length ? channels : undefined;
 }
 
-/** Drop single-letter tokens (middle initials) so "Tony K. Thurmond" ≈ "Tony Thurmond". */
-function dropInitials(name: string): string {
-  return name
-    .split(/\s+/)
-    .filter((t) => t.replace(/[^A-Za-z0-9]/g, "").length > 1)
-    .join(" ");
-}
-
-/** Clamp prose to a max length, adding an ellipsis when truncated. */
-function clamp(s: string, max: number): string {
-  const t = s.trim();
-  return t.length > max ? t.slice(0, max).trimEnd() + "…" : t;
-}
-
 /**
  * Enrich a candidate from the CA SOS Official Voter Information Guide.
  *
- * Returns the statement (as `biography`) plus any contact fields the guide
- * lists, all attributed to the official SOS office page — or `null` when the
- * state isn't CA, the office isn't a statewide one in the guide, the page can't
- * be fetched, or no heading matches the candidate's name.
+ * Returns the verbatim candidate statement (as `statement`) plus any contact
+ * fields the guide lists, all attributed to the official SOS office page — or
+ * `null` when the state isn't CA, the office isn't a statewide one in the guide,
+ * the page can't be fetched, or no heading matches the candidate's name.
  */
 export async function enrichCandidateFromCaSos(
   name: string,

--- a/packages/api/src/lib/candidate-sources/ca-sos-voterguide.ts
+++ b/packages/api/src/lib/candidate-sources/ca-sos-voterguide.ts
@@ -303,7 +303,7 @@ export async function enrichCandidateFromCaSos(
   if (paras.length === 0) return null;
 
   // Separate the contact paragraph (last one matching contact markers) from the
-  // statement prose. Everything that isn't the contact block is the biography.
+  // statement prose. Everything that isn't the contact block is the statement.
   const contactIdx = paras
     .map((p, i) => ({ p: htmlToText(p), i }))
     .filter(({ p }) => CONTACT_MARKERS.test(p))
@@ -313,9 +313,9 @@ export async function enrichCandidateFromCaSos(
   const contactHtml = contactIdx !== undefined ? (paras[contactIdx] ?? "") : "";
   const contactText = htmlToText(contactHtml);
 
-  const bioParas = paras.filter((_, i) => i !== contactIdx).map(htmlToText);
-  const biography = clamp(bioParas.join("\n\n"), MAX_BIO_CHARS);
-  if (!biography || biography.length < 40) return null;
+  const statementParas = paras.filter((_, i) => i !== contactIdx).map(htmlToText);
+  const statement = clamp(statementParas.join("\n\n"), MAX_BIO_CHARS);
+  if (!statement || statement.length < 40) return null;
 
   const data: CandidateSourceData = {
     tier: "state_sos",
@@ -323,15 +323,15 @@ export async function enrichCandidateFromCaSos(
     sourceUrl: url,
     official: true,
     matchedName: parseHeading(best.section.heading)?.name,
-    biography,
+    statement,
     photoUrl: findPhotoByAlt(html, name),
-    website: extractWebsite(biography),
+    website: extractWebsite(statement),
     email: extractEmail(contactHtml),
     phone: extractPhone(contactText),
     channels: extractChannels(contactText),
   };
 
-  // Surface only if we actually captured a real statement — the biography gate
+  // Surface only if we actually captured a real statement — the statement gate
   // above already guarantees that, so the source always contributes here.
   return data;
 }

--- a/packages/api/src/lib/candidate-sources/ca-sos-voterguide.ts
+++ b/packages/api/src/lib/candidate-sources/ca-sos-voterguide.ts
@@ -313,7 +313,9 @@ export async function enrichCandidateFromCaSos(
   const contactHtml = contactIdx !== undefined ? (paras[contactIdx] ?? "") : "";
   const contactText = htmlToText(contactHtml);
 
-  const statementParas = paras.filter((_, i) => i !== contactIdx).map(htmlToText);
+  const statementParas = paras
+    .filter((_, i) => i !== contactIdx)
+    .map(htmlToText);
   const statement = clamp(statementParas.join("\n\n"), MAX_BIO_CHARS);
   if (!statement || statement.length < 40) return null;
 

--- a/packages/api/src/lib/candidate-sources/ca-sos-voterguide.ts
+++ b/packages/api/src/lib/candidate-sources/ca-sos-voterguide.ts
@@ -24,11 +24,21 @@
  * registrar.
  */
 
+import { and, eq, gt } from "@acme/db";
+import { db } from "@acme/db/client";
+import { CivicApiCache } from "@acme/db/schema";
+
 import type { CandidateChannel, CandidateSourceData } from "./types";
+import type { CaSosStatement } from "./ca-sos-cache";
 import { decodeEntities, htmlToText } from "../measure-sources/html";
 import { candidateNameSimilarity, clamp, dropInitials } from "./types";
+import {
+  CA_SOS_ADDRESS_HASH,
+  CA_SOS_ENDPOINT,
+  caSosCacheParams,
+} from "./ca-sos-cache";
 
-const GUIDE_BASE = "https://voterguide.sos.ca.gov";
+export const GUIDE_BASE = "https://voterguide.sos.ca.gov";
 const FETCH_TIMEOUT_MS = 12_000;
 const SOURCE_NAME =
   "California Secretary of State — Official Voter Information Guide";
@@ -49,7 +59,7 @@ const MAX_BIO_CHARS = 2500;
  * Only the nine statewide offices the guide publishes are here; an unmatched
  * office yields null (the adapter returns no data, never a wrong page).
  */
-const OFFICE_SLUGS: { match: RegExp; slug: string }[] = [
+export const OFFICE_SLUGS: { match: RegExp; slug: string }[] = [
   { match: /lieutenant\s+governor|lt\.?\s+governor/i, slug: "lt-governor" },
   {
     match: /superintendent\s+of\s+public\s+instruction/i,
@@ -67,7 +77,7 @@ const OFFICE_SLUGS: { match: RegExp; slug: string }[] = [
   { match: /\bgovernor\b/i, slug: "governor" },
 ];
 
-function officeSlug(office: string | undefined): string | null {
+export function officeSlug(office: string | undefined): string | null {
   if (!office) return null;
   for (const { match, slug } of OFFICE_SLUGS) {
     if (match.test(office)) return slug;
@@ -75,7 +85,12 @@ function officeSlug(office: string | undefined): string | null {
   return null;
 }
 
-async function fetchText(url: string): Promise<string | null> {
+/** Build the office page URL for a slug. */
+export function officeUrl(slug: string): string {
+  return `${GUIDE_BASE}/candidates/${slug}-candidate-statements.htm`;
+}
+
+export async function fetchText(url: string): Promise<string | null> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
@@ -264,12 +279,116 @@ function extractChannels(contactText: string): CandidateChannel[] | undefined {
 }
 
 /**
+ * Parse one fetched SOS office page into per-candidate statement records.
+ *
+ * Pure: takes the page HTML and its slug, returns every candidate with a real
+ * statement (>= 40 chars). Shared by the live adapter path below and the cron
+ * scraper (apps/scraper) so both extract identically from one source of truth.
+ */
+export function parseOfficePage(
+  html: string,
+  slug: string,
+): CaSosStatement[] {
+  if (!html || html.length < 500) return [];
+  const url = officeUrl(slug);
+  const out: CaSosStatement[] = [];
+
+  for (const section of splitSections(html)) {
+    const parsed = parseHeading(section.heading);
+    if (!parsed) continue;
+
+    const paras = paragraphs(section.body);
+    if (paras.length === 0) continue;
+
+    // Separate the contact paragraph (last one matching contact markers) from
+    // the statement prose. Everything that isn't the contact block is the
+    // statement.
+    const contactIdx = paras
+      .map((p, i) => ({ p: htmlToText(p), i }))
+      .filter(({ p }) => CONTACT_MARKERS.test(p))
+      .map(({ i }) => i)
+      .pop();
+
+    const contactHtml = contactIdx !== undefined ? (paras[contactIdx] ?? "") : "";
+    const contactText = htmlToText(contactHtml);
+
+    const statementParas = paras
+      .filter((_, i) => i !== contactIdx)
+      .map(htmlToText);
+    const statement = clamp(statementParas.join("\n\n"), MAX_BIO_CHARS);
+    if (!statement || statement.length < 40) continue;
+
+    out.push({
+      name: parsed.name,
+      officeSlug: slug,
+      statement,
+      sourceUrl: url,
+      photoUrl: findPhotoByAlt(html, parsed.name),
+      website: extractWebsite(statement),
+      email: extractEmail(contactHtml),
+      phone: extractPhone(contactText),
+      channels: extractChannels(contactText),
+    });
+  }
+  return out;
+}
+
+/**
+ * Read the scraper's handoff cache row for an election year, or null on miss /
+ * expiry / DB error. Best-effort: never throws.
+ */
+async function readCachedStatements(
+  electionYear: number,
+): Promise<CaSosStatement[] | null> {
+  try {
+    const [row] = await db
+      .select()
+      .from(CivicApiCache)
+      .where(
+        and(
+          eq(CivicApiCache.addressHash, CA_SOS_ADDRESS_HASH),
+          eq(CivicApiCache.endpoint, CA_SOS_ENDPOINT),
+          eq(CivicApiCache.params, caSosCacheParams(electionYear)),
+          gt(CivicApiCache.expiresAt, new Date()),
+        ),
+      )
+      .limit(1);
+    if (!row) return null;
+    const payload = row.responseData as { statements?: CaSosStatement[] };
+    return Array.isArray(payload.statements) ? payload.statements : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Best name match among candidates for a slug, at/above the threshold. */
+function matchCandidate(
+  statements: CaSosStatement[],
+  slug: string,
+  name: string,
+): CaSosStatement | null {
+  const query = dropInitials(name);
+  let best: { s: CaSosStatement; score: number } | null = null;
+  for (const s of statements) {
+    if (s.officeSlug !== slug) continue;
+    const score = candidateNameSimilarity(query, dropInitials(s.name));
+    if (score >= NAME_MATCH_THRESHOLD && (!best || score > best.score)) {
+      best = { s, score };
+    }
+  }
+  return best?.s ?? null;
+}
+
+/**
  * Enrich a candidate from the CA SOS Official Voter Information Guide.
  *
- * Returns the verbatim candidate statement (as `statement`) plus any contact
- * fields the guide lists, all attributed to the official SOS office page — or
- * `null` when the state isn't CA, the office isn't a statewide one in the guide,
- * the page can't be fetched, or no heading matches the candidate's name.
+ * Prefers the scraper's handoff cache (the cron pre-fetches and parses all nine
+ * office pages into one row per election), falling back to a live page fetch +
+ * parse when the cache is cold so the adapter still works before the first cron
+ * run. Returns the verbatim statement plus any contact fields the guide lists,
+ * attributed to the official SOS office page — or `null` when the state isn't
+ * CA, the office isn't a statewide one in the guide, nothing can be fetched, or
+ * no candidate matches by name.
  */
 export async function enrichCandidateFromCaSos(
   name: string,
@@ -281,59 +400,27 @@ export async function enrichCandidateFromCaSos(
   const slug = officeSlug(ctx.office);
   if (!slug) return null;
 
-  const url = `${GUIDE_BASE}/candidates/${slug}-candidate-statements.htm`;
-  const html = await fetchText(url);
-  if (!html || html.length < 500) return null;
-
-  // Find the section whose heading name best matches the candidate. Compare
-  // with middle initials dropped so "Tony K. Thurmond" matches "Tony Thurmond".
-  const queryName = dropInitials(name);
-  let best: { section: RawSection; party: string; score: number } | null = null;
-  for (const section of splitSections(html)) {
-    const parsed = parseHeading(section.heading);
-    if (!parsed) continue;
-    const score = candidateNameSimilarity(queryName, dropInitials(parsed.name));
-    if (score >= NAME_MATCH_THRESHOLD && (!best || score > best.score)) {
-      best = { section, party: parsed.party, score };
-    }
+  // Cache-first (scraper handoff), then live fetch fallback for this one page.
+  let statements = await readCachedStatements(ctx.electionYear);
+  if (!statements) {
+    const html = await fetchText(officeUrl(slug));
+    statements = html ? parseOfficePage(html, slug) : [];
   }
-  if (!best) return null;
 
-  const paras = paragraphs(best.section.body);
-  if (paras.length === 0) return null;
+  const match = matchCandidate(statements, slug, name);
+  if (!match) return null;
 
-  // Separate the contact paragraph (last one matching contact markers) from the
-  // statement prose. Everything that isn't the contact block is the statement.
-  const contactIdx = paras
-    .map((p, i) => ({ p: htmlToText(p), i }))
-    .filter(({ p }) => CONTACT_MARKERS.test(p))
-    .map(({ i }) => i)
-    .pop();
-
-  const contactHtml = contactIdx !== undefined ? (paras[contactIdx] ?? "") : "";
-  const contactText = htmlToText(contactHtml);
-
-  const statementParas = paras
-    .filter((_, i) => i !== contactIdx)
-    .map(htmlToText);
-  const statement = clamp(statementParas.join("\n\n"), MAX_BIO_CHARS);
-  if (!statement || statement.length < 40) return null;
-
-  const data: CandidateSourceData = {
+  return {
     tier: "state_sos",
     sourceName: SOURCE_NAME,
-    sourceUrl: url,
+    sourceUrl: match.sourceUrl,
     official: true,
-    matchedName: parseHeading(best.section.heading)?.name,
-    statement,
-    photoUrl: findPhotoByAlt(html, name),
-    website: extractWebsite(statement),
-    email: extractEmail(contactHtml),
-    phone: extractPhone(contactText),
-    channels: extractChannels(contactText),
+    matchedName: match.name,
+    statement: match.statement,
+    photoUrl: match.photoUrl,
+    website: match.website,
+    email: match.email,
+    phone: match.phone,
+    channels: match.channels,
   };
-
-  // Surface only if we actually captured a real statement — the statement gate
-  // above already guarantees that, so the source always contributes here.
-  return data;
 }

--- a/packages/api/src/lib/candidate-sources/ca-sos-voterguide.ts
+++ b/packages/api/src/lib/candidate-sources/ca-sos-voterguide.ts
@@ -28,15 +28,15 @@ import { and, eq, gt } from "@acme/db";
 import { db } from "@acme/db/client";
 import { CivicApiCache } from "@acme/db/schema";
 
-import type { CandidateChannel, CandidateSourceData } from "./types";
 import type { CaSosStatement } from "./ca-sos-cache";
+import type { CandidateChannel, CandidateSourceData } from "./types";
 import { decodeEntities, htmlToText } from "../measure-sources/html";
-import { candidateNameSimilarity, clamp, dropInitials } from "./types";
 import {
   CA_SOS_ADDRESS_HASH,
   CA_SOS_ENDPOINT,
   caSosCacheParams,
 } from "./ca-sos-cache";
+import { candidateNameSimilarity, clamp, dropInitials } from "./types";
 
 export const GUIDE_BASE = "https://voterguide.sos.ca.gov";
 const FETCH_TIMEOUT_MS = 12_000;
@@ -285,10 +285,7 @@ function extractChannels(contactText: string): CandidateChannel[] | undefined {
  * statement (>= 40 chars). Shared by the live adapter path below and the cron
  * scraper (apps/scraper) so both extract identically from one source of truth.
  */
-export function parseOfficePage(
-  html: string,
-  slug: string,
-): CaSosStatement[] {
+export function parseOfficePage(html: string, slug: string): CaSosStatement[] {
   if (!html || html.length < 500) return [];
   const url = officeUrl(slug);
   const out: CaSosStatement[] = [];
@@ -309,7 +306,8 @@ export function parseOfficePage(
       .map(({ i }) => i)
       .pop();
 
-    const contactHtml = contactIdx !== undefined ? (paras[contactIdx] ?? "") : "";
+    const contactHtml =
+      contactIdx !== undefined ? (paras[contactIdx] ?? "") : "";
     const contactText = htmlToText(contactHtml);
 
     const statementParas = paras

--- a/packages/api/src/lib/candidate-sources/scc-cvig-cache.ts
+++ b/packages/api/src/lib/candidate-sources/scc-cvig-cache.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared shape for the Santa Clara County voter-guide statement handoff cache.
+ *
+ * The scraper (apps/scraper) extracts candidate statements from the county's
+ * voter information guide PDFs and writes ONE CivicApiCache row per election;
+ * the registrar adapter (./scc-registrar.ts) reads it. Both sides import these
+ * constants and `sccCvigCacheParams` so the written `params` string byte-matches
+ * the read `params` — a mismatch is a silent, error-free cache miss.
+ */
+
+import { stableStringify } from "./types";
+
+/** CivicApiCache.addressHash for the SCC statement handoff (global, not per-address). */
+export const SCC_CVIG_ADDRESS_HASH = "__global__";
+
+/** CivicApiCache.endpoint namespace for the SCC statement handoff. */
+export const SCC_CVIG_ENDPOINT = "scc-cvig-statements";
+
+/** One extracted candidate statement from the SCC voter information guide. */
+export interface SccCvigStatement {
+  /** Candidate name as printed in the guide. */
+  name: string;
+  /** Office/contest heading the statement appeared under, when captured. */
+  office?: string;
+  /** Verbatim statement prose. */
+  statement: string;
+  /** The guide PDF this statement was extracted from (for attribution). */
+  sourceUrl: string;
+}
+
+/** Payload stored in CivicApiCache.responseData for one election's guide. */
+export interface SccCvigPayload {
+  statements: SccCvigStatement[];
+}
+
+/**
+ * Build the CivicApiCache.params string for an election year. One row holds all
+ * candidates for that election. Keep this the single source of truth for the key
+ * so the scraper write and the adapter read never drift.
+ */
+export function sccCvigCacheParams(electionYear: number): string {
+  return stableStringify({ electionYear });
+}

--- a/packages/api/src/lib/candidate-sources/scc-registrar.ts
+++ b/packages/api/src/lib/candidate-sources/scc-registrar.ts
@@ -1,0 +1,109 @@
+/**
+ * Santa Clara County Registrar of Voters — local candidate statement adapter.
+ *
+ * Source: the county's official Voter Information Guide. Down-ballot candidates
+ * (city council, school board, judges, water/special districts) submit a §13307
+ * statement of qualifications that no statewide/aggregator source carries. The
+ * heavy extraction (PDF fetch + parse) runs in apps/scraper, which writes one
+ * CivicApiCache row per election; this adapter just reads that row and matches a
+ * candidate by name. It therefore needs no network of its own.
+ *
+ * Scope: California, Santa Clara County only. Gates hard on stateAbbrev === "CA"
+ * and (when Civic supplies it) a Santa Clara county string. Best-effort: never
+ * throws, returns `null` (not a partial object) when there's no cache row or no
+ * confident name match.
+ *
+ * Trust: tier `county_registrar`, `official: true` — the highest tier, so a
+ * registrar statement outranks the CA SOS statewide guide and every aggregator.
+ * Registrars publish text-only statements (no headshots), so v1 contributes only
+ * `statement`.
+ */
+
+import { and, eq, gt } from "@acme/db";
+import { db } from "@acme/db/client";
+import { CivicApiCache } from "@acme/db/schema";
+
+import type { CandidateSourceData } from "./types";
+import {
+  SCC_CVIG_ADDRESS_HASH,
+  SCC_CVIG_ENDPOINT,
+  sccCvigCacheParams,
+} from "./scc-cvig-cache";
+import type { SccCvigPayload, SccCvigStatement } from "./scc-cvig-cache";
+import { candidateNameSimilarity, clamp, dropInitials } from "./types";
+
+const SOURCE_NAME =
+  "Santa Clara County Registrar of Voters — Official Voter Information Guide";
+/** Token-overlap threshold to accept a name match (handles nicknames/initials). */
+const NAME_MATCH_THRESHOLD = 0.7;
+/** Statements run long; clamp to keep the cached record bounded. */
+const MAX_STATEMENT_CHARS = 2500;
+
+/**
+ * Enrich a candidate from the SCC registrar voter-guide handoff cache.
+ *
+ * @param name Candidate name from Google Civic.
+ * @param ctx  Contest + enrichment context.
+ * @returns Source data with the verbatim statement at `county_registrar` tier
+ *          when a guide statement matches the candidate, otherwise null.
+ */
+export async function enrichCandidateFromScc(
+  name: string,
+  ctx: {
+    office?: string;
+    stateAbbrev?: string;
+    county?: string;
+    electionYear: number;
+  },
+): Promise<CandidateSourceData | null> {
+  if (!name.trim()) return null;
+  if (ctx.stateAbbrev && ctx.stateAbbrev.toUpperCase() !== "CA") return null;
+  // Gate on county when Civic supplies it. Civic sometimes omits county; allow
+  // through in that case (the election-scoped cache + name match disambiguate).
+  if (ctx.county && !/santa\s*clara/i.test(ctx.county)) return null;
+
+  try {
+    const [row] = await db
+      .select()
+      .from(CivicApiCache)
+      .where(
+        and(
+          eq(CivicApiCache.addressHash, SCC_CVIG_ADDRESS_HASH),
+          eq(CivicApiCache.endpoint, SCC_CVIG_ENDPOINT),
+          eq(CivicApiCache.params, sccCvigCacheParams(ctx.electionYear)),
+          gt(CivicApiCache.expiresAt, new Date()),
+        ),
+      )
+      .limit(1);
+    if (!row) return null;
+
+    // responseData is untyped JSONB written by the scraper; validate defensively.
+    const payload: Partial<SccCvigPayload> = row.responseData as SccCvigPayload;
+    const statements = Array.isArray(payload.statements)
+      ? payload.statements
+      : [];
+    if (statements.length === 0) return null;
+
+    const query = dropInitials(name);
+    let best: { statement: SccCvigStatement; score: number } | null = null;
+    for (const s of statements) {
+      if (!s.statement.trim()) continue;
+      const score = candidateNameSimilarity(query, dropInitials(s.name));
+      if (score < NAME_MATCH_THRESHOLD) continue;
+      if (!best || score > best.score) best = { statement: s, score };
+    }
+    if (!best) return null;
+
+    return {
+      tier: "county_registrar",
+      sourceName: SOURCE_NAME,
+      sourceUrl: best.statement.sourceUrl,
+      official: true,
+      matchedName: best.statement.name,
+      statement: clamp(best.statement.statement, MAX_STATEMENT_CHARS),
+    };
+  } catch {
+    // DB error or unexpected payload shape — degrade to "no data from this tier".
+    return null;
+  }
+}

--- a/packages/api/src/lib/candidate-sources/scc-registrar.ts
+++ b/packages/api/src/lib/candidate-sources/scc-registrar.ts
@@ -23,13 +23,13 @@ import { and, eq, gt } from "@acme/db";
 import { db } from "@acme/db/client";
 import { CivicApiCache } from "@acme/db/schema";
 
+import type { SccCvigPayload, SccCvigStatement } from "./scc-cvig-cache";
 import type { CandidateSourceData } from "./types";
 import {
   SCC_CVIG_ADDRESS_HASH,
   SCC_CVIG_ENDPOINT,
   sccCvigCacheParams,
 } from "./scc-cvig-cache";
-import type { SccCvigPayload, SccCvigStatement } from "./scc-cvig-cache";
 import { candidateNameSimilarity, clamp, dropInitials } from "./types";
 
 const SOURCE_NAME =

--- a/packages/api/src/lib/candidate-sources/types.ts
+++ b/packages/api/src/lib/candidate-sources/types.ts
@@ -51,6 +51,12 @@ export interface CandidateSourceData {
   matchedName?: string;
 
   biography?: string;
+  /**
+   * Verbatim candidate-authored statement of qualifications (e.g. §13307, as
+   * printed in an official voter information guide). Distinct from `biography`,
+   * which is neutral third-party prose.
+   */
+  statement?: string;
   photoUrl?: string;
   website?: string;
   email?: string;
@@ -69,6 +75,12 @@ export interface CanonicalCandidate {
   name: string;
   party?: string;
   biography?: string;
+  /** Verbatim candidate-authored statement (county registrar / state SOS guide). */
+  statement?: string;
+  /** Citizen-friendly summary of `statement` (AI-generated from the statement). */
+  statementSummary?: string;
+  /** True when `statementSummary` was produced by AI, not an official source. */
+  statementSummaryIsAiGenerated?: boolean;
   photoUrl?: string;
   candidateUrl?: string;
   email?: string;

--- a/packages/api/src/lib/candidate-sources/types.ts
+++ b/packages/api/src/lib/candidate-sources/types.ts
@@ -158,3 +158,27 @@ export function candidateNameSimilarity(a: string, b: string): number {
   const union = wa.size + wb.size - intersection;
   return union === 0 ? 0 : intersection / union;
 }
+
+/** Drop single-letter tokens (middle initials) so "Tony K. Thurmond" ≈ "Tony Thurmond". */
+export function dropInitials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter((t) => t.replace(/[^A-Za-z0-9]/g, "").length > 1)
+    .join(" ");
+}
+
+/** Clamp prose to a max length, adding an ellipsis when truncated. */
+export function clamp(s: string, max: number): string {
+  const t = s.trim();
+  return t.length > max ? t.slice(0, max).trimEnd() + "…" : t;
+}
+
+/**
+ * Deterministic JSON string for cache keys (sorted keys). Shared by the
+ * candidate cache, the scraper handoff write, and the registrar adapter read so
+ * a written `params` byte-matches the read `params` — a mismatch is a silent
+ * cache miss.
+ */
+export function stableStringify(obj: Record<string, unknown>): string {
+  return JSON.stringify(obj, Object.keys(obj).sort());
+}

--- a/packages/api/src/lib/civic-ai.ts
+++ b/packages/api/src/lib/civic-ai.ts
@@ -122,6 +122,68 @@ Return only the JSON object, or exactly ${INSUFFICIENT}.`;
 }
 
 /**
+ * Summarize a candidate's own statement of qualifications into plain language,
+ * **from the statement text only**.
+ *
+ * Unlike a ballot measure, the source here is the candidate's self-authored
+ * pitch, so we do NOT strip advocacy — we plainly restate what the candidate
+ * says about their background and priorities, without endorsing or fact-checking.
+ *
+ * @param name      The candidate's name (for orientation, NOT a content source).
+ * @param statement The verbatim candidate statement. Must be substantive — we
+ *                  refuse to summarize from a near-empty statement.
+ * @throws if no AI provider is configured, the statement is too thin, or the
+ *         model judges the text insufficient.
+ */
+export async function generateCandidateStatementSummary(
+  name: string,
+  statement: string,
+): Promise<MeasureSummaries> {
+  if (!llm) throw new Error("no AI provider configured");
+  if (statement.trim().length < MIN_GROUNDING_CHARS) {
+    throw new Error("insufficient statement text — refusing to summarize");
+  }
+
+  const prompt = `You write plain-language summaries of candidate statements for a voter information app.
+
+Summarize what this candidate says about themselves — their background, qualifications, and priorities — using ONLY the STATEMENT TEXT below. This is the candidate's own statement, written by them.
+
+Hard rules:
+- Use ONLY facts present in the STATEMENT TEXT. Do not use any outside knowledge.
+- If the STATEMENT TEXT does not actually contain a candidate statement (e.g. it is only a name, heading, or boilerplate), reply with exactly: ${INSUFFICIENT}
+- This is the candidate's own pitch — restate what THEY say (their priorities and background). Do NOT fact-check, endorse, oppose, or add your own judgment.
+- Attribute claims to the candidate where natural ("they say", "their priorities include") rather than asserting them as fact.
+- Plain English, no jargon. Do not repeat the candidate's name verbatim.
+
+Produce TWO summaries and return them as a JSON object on a single line:
+{"short": "...", "long": "..."}
+- "short": ONE sentence capturing who they are and their top priority, for a list preview.
+- "long": 3-4 sentences covering their background and main priorities as stated.
+
+CANDIDATE NAME: ${name}
+
+STATEMENT TEXT:
+"""
+${statement.slice(0, 6000)}
+"""
+
+Return only the JSON object, or exactly ${INSUFFICIENT}.`;
+
+  const { text } = await generateText({ model: llm, temperature: 0.2, prompt });
+  const out = text.trim();
+  if (!out || out.toUpperCase().includes(INSUFFICIENT)) {
+    throw new Error("model judged statement text insufficient");
+  }
+  const parsed = parseJsonObject(out);
+  const short = typeof parsed?.short === "string" ? parsed.short.trim() : "";
+  const long = typeof parsed?.long === "string" ? parsed.long.trim() : "";
+  if (!short && !long) {
+    return { short: firstSentence(out), long: out };
+  }
+  return { short: short || firstSentence(long), long: long || short };
+}
+
+/**
  * Generate neutral pro/con bullet points from fetched source text, used only as
  * a fallback when no source supplied real, human-written arguments.
  *

--- a/packages/api/src/lib/civic.ts
+++ b/packages/api/src/lib/civic.ts
@@ -840,7 +840,10 @@ async function enrichContest(
               ["phone", candidate.phone],
               ["email", candidate.email],
               ["photoUrl", candidate.photoUrl],
-              ["channels", candidate.channels?.length ? candidate.channels : undefined],
+              [
+                "channels",
+                candidate.channels?.length ? candidate.channels : undefined,
+              ],
             ];
             for (const [field, value] of rawCivicFields) {
               if (value && !cited.has(field)) {

--- a/packages/api/src/lib/civic.ts
+++ b/packages/api/src/lib/civic.ts
@@ -219,6 +219,12 @@ export interface Candidate {
   channels?: Channel[];
   /** Biography merged from candidate sources (Ballotpedia/Wikipedia/Vote Smart). */
   biography?: string;
+  /** Verbatim candidate statement (county registrar / state SOS voter guide). */
+  statement?: string;
+  /** Citizen-friendly summary of `statement`. */
+  statementSummary?: string;
+  /** True when `statementSummary` was AI-generated, not from an official source. */
+  statementSummaryIsAiGenerated?: boolean;
   /** True when the candidate currently holds the office (per Open States / Vote Smart). */
   incumbent?: boolean;
   /** Per-field source attribution for the enriched fields above. */
@@ -809,6 +815,12 @@ async function enrichContest(
             // Merge canonical fields back onto the candidate, preferring enriched
             // values but never clobbering existing Google Civic data with empties.
             candidate.biography = merged.biography ?? candidate.biography;
+            candidate.statement = merged.statement ?? candidate.statement;
+            candidate.statementSummary =
+              merged.statementSummary ?? candidate.statementSummary;
+            candidate.statementSummaryIsAiGenerated =
+              merged.statementSummaryIsAiGenerated ??
+              candidate.statementSummaryIsAiGenerated;
             candidate.incumbent = merged.incumbent ?? candidate.incumbent;
             candidate.photoUrl = merged.photoUrl ?? candidate.photoUrl;
             candidate.candidateUrl =

--- a/packages/api/src/lib/civic.ts
+++ b/packages/api/src/lib/civic.ts
@@ -816,9 +816,32 @@ async function enrichContest(
             candidate.email = merged.email ?? candidate.email;
             candidate.phone = merged.phone ?? candidate.phone;
             candidate.channels = merged.channels ?? candidate.channels;
-            candidate.citations = merged.citations.length
-              ? merged.citations
-              : candidate.citations;
+
+            // Cite raw Google Civic fields that survived onto the candidate but
+            // no higher-tier source claimed. Better a cited official-ish link
+            // than a blank card; each field is cited once (enriched citation
+            // wins; google_civic only fills the gaps).
+            const citations: MeasureCitationRef[] = [...merged.citations];
+            const cited = new Set(citations.map((c) => c.field));
+            const rawCivicFields: [string, unknown][] = [
+              ["candidateUrl", candidate.candidateUrl],
+              ["phone", candidate.phone],
+              ["email", candidate.email],
+              ["photoUrl", candidate.photoUrl],
+              ["channels", candidate.channels?.length ? candidate.channels : undefined],
+            ];
+            for (const [field, value] of rawCivicFields) {
+              if (value && !cited.has(field)) {
+                citations.push({
+                  field,
+                  sourceName: "Google Civic Information API",
+                  tier: "google_civic",
+                  official: false,
+                });
+                cited.add(field);
+              }
+            }
+            candidate.citations = citations.length ? citations : undefined;
           } catch {
             // Best-effort per candidate: one failure must not break the contest
             // or the other candidates — leave the raw Google Civic data intact.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,9 @@ importers:
 
   apps/scraper:
     dependencies:
+      '@acme/api':
+        specifier: workspace:*
+        version: link:../../packages/api
       '@acme/db':
         specifier: workspace:*
         version: link:../../packages/db
@@ -420,6 +423,9 @@ importers:
       turndown:
         specifier: ^7.2.2
         version: 7.2.2
+      unpdf:
+        specifier: ^1.6.2
+        version: 1.6.2
       yargs:
         specifier: ^18.0.0
         version: 18.0.0
@@ -8008,6 +8014,14 @@ packages:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
 
+  unpdf@1.6.2:
+    resolution: {integrity: sha512-zQ80ySoPuPHOsvIoRp/nJyQt8TOUoTh1+WBCGcBvlddQNgKDLRwm0AY3x8Q35I7+kIiRSgqMx+Ma2pl9McIp7A==}
+    peerDependencies:
+      '@napi-rs/canvas': ^0.1.69
+    peerDependenciesMeta:
+      '@napi-rs/canvas':
+        optional: true
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -9749,7 +9763,7 @@ snapshots:
       metro-babel-transformer: 0.83.1
       metro-cache: 0.82.5
       metro-cache-key: 0.83.1
-      metro-config: 0.82.5(bufferutil@4.1.0)(utf-8-validate@6.0.4)
+      metro-config: 0.82.5(bufferutil@4.1.0)
       metro-core: 0.82.5
       metro-file-map: 0.82.5
       metro-resolver: 0.82.5
@@ -11314,7 +11328,7 @@ snapshots:
       debug: 2.6.9
       invariant: 2.2.4
       metro: 0.82.5(bufferutil@4.1.0)(utf-8-validate@6.0.4)
-      metro-config: 0.82.5(bufferutil@4.1.0)(utf-8-validate@6.0.4)
+      metro-config: 0.82.5(bufferutil@4.1.0)
       metro-core: 0.82.5
       semver: 7.7.4
     transitivePeerDependencies:
@@ -11328,7 +11342,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.82.5(bufferutil@4.1.0)
-      metro-config: 0.82.5(bufferutil@4.1.0)(utf-8-validate@6.0.4)
+      metro-config: 0.82.5(bufferutil@4.1.0)
       metro-core: 0.82.5
       semver: 7.7.4
     optionalDependencies:
@@ -11403,7 +11417,7 @@ snapshots:
     dependencies:
       '@react-native/js-polyfills': 0.84.1
       '@react-native/metro-babel-transformer': 0.84.1(@babel/core@7.29.0)
-      metro-config: 0.82.5(bufferutil@4.1.0)(utf-8-validate@6.0.4)
+      metro-config: 0.82.5(bufferutil@4.1.0)
       metro-runtime: 0.82.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -14603,13 +14617,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  metro-config@0.82.5(bufferutil@4.1.0)(utf-8-validate@6.0.4):
+  metro-config@0.82.5(bufferutil@4.1.0):
     dependencies:
       connect: 3.7.0
       cosmiconfig: 5.2.1
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
-      metro: 0.82.5(bufferutil@4.1.0)(utf-8-validate@6.0.4)
+      metro: 0.82.5(bufferutil@4.1.0)
       metro-cache: 0.82.5
       metro-core: 0.82.5
       metro-runtime: 0.82.5
@@ -14755,7 +14769,7 @@ snapshots:
       metro-babel-transformer: 0.82.5
       metro-cache: 0.82.5
       metro-cache-key: 0.82.5
-      metro-config: 0.82.5(bufferutil@4.1.0)(utf-8-validate@6.0.4)
+      metro-config: 0.82.5(bufferutil@4.1.0)
       metro-core: 0.82.5
       metro-file-map: 0.82.5
       metro-resolver: 0.82.5
@@ -14802,7 +14816,7 @@ snapshots:
       metro-babel-transformer: 0.82.5
       metro-cache: 0.82.5
       metro-cache-key: 0.82.5
-      metro-config: 0.82.5(bufferutil@4.1.0)(utf-8-validate@6.0.4)
+      metro-config: 0.82.5(bufferutil@4.1.0)
       metro-core: 0.82.5
       metro-file-map: 0.82.5
       metro-resolver: 0.82.5
@@ -16498,6 +16512,8 @@ snapshots:
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
+
+  unpdf@1.6.2: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## What

Makes local/down-ballot candidates show real information instead of blank cards, in two parts:

**Phase A — raw Google Civic passthrough (closes #103)**
The raw `voterinfo` response already carries `candidateUrl`/`phone`/`email`/`photoUrl`/`channels` per candidate, but they surfaced without citations so the UI attribution was empty. Now each raw field with no higher-tier source gets a `google_civic`-tier citation — a cited official-ish link beats a blank card.

**Phase B — candidate statements (closes #102)**
Adds a first-class candidate **statement** (the verbatim §13307 statement of qualifications from the official voter guide), distinct from the neutral `biography`:
- New `statement` field merged by trust tier; AI summary generated inside the cached cross-validate path (grounded only on the statement, restates the candidate's own pitch, never authors from a bare name).
- **Santa Clara County registrar source**: a scraper fetches the county voter-guide PDFs, de-interleaves the two-column layout via positional text extraction, regex-segments statements, and falls back to multimodal Gemini when the text layer is unreliable. It writes one cache row per election; a thin API adapter reads it at request time at the `county_registrar` tier — keeping PDF work out of the serverless path.
- CA SOS adapter retrofitted to surface its voter-guide text as `statement` (was `biography`).
- Two-tab UI (Plain summary / Statement) mirroring the measure UX, with an AI disclaimer.

## Verification

- `turbo run typecheck` — all 13 packages clean. `turbo run lint` — clean.
- **Live extraction test** against the real SCC 2024 guide PDF (`stgenrov.sccgov.org/voterguide/137/SC341ENG-508.pdf`): fetched 200 (4.4 MB, 46 pp), column de-interleave works, **17 local candidate statements parsed** — city council, judges, water district, board of education, police chief, exactly the races that were blank. unpdf text-layer path suffices; Gemini fallback won't trigger for this doc.

## Notes / follow-ups

- electionId discovery is a hand-maintained `SCC_GUIDES` map for v1 (2024 verified; 2026 TODO). Clarity-ENR auto-discovery is tracked in #102 / #100.
- One cosmetic artifact: a couple contests show `office` as `"CITY CLERK,"` (trailing comma) — display-only, not used for matching.
- Registrars publish text-only statements (no headshots); photos remain out of scope (see #100).
- Repo is **pnpm**-managed — `unpdf` and `@acme/api` added via pnpm.
- Multi-county generalization tracked in #100.

Closes #102
Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)
