### PR TITLE
Migrate waitlist from LaunchList to Supabase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ dist/
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+packages/db/seed-waitlist.sql

--- a/apps/nextjs/src/app/_components/waitlist-form.tsx
+++ b/apps/nextjs/src/app/_components/waitlist-form.tsx
@@ -21,18 +21,21 @@ export function WaitlistForm({
     setErrorMsg("");
 
     try {
-      const res = await fetch("https://getlaunchlist.com/s/m2zvn0", {
+      const res = await fetch("/api/waitlist", {
         method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: new URLSearchParams({ email }),
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
       });
 
       if (res.ok) {
         setStatus("success");
         setEmail("");
       } else {
+        const data = (await res.json().catch(() => null)) as {
+          error?: string;
+        } | null;
         setStatus("error");
-        setErrorMsg("Something went wrong. Please try again.");
+        setErrorMsg(data?.error ?? "Something went wrong. Please try again.");
       }
     } catch {
       setStatus("error");

--- a/apps/nextjs/src/app/api/waitlist/route.ts
+++ b/apps/nextjs/src/app/api/waitlist/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+
+import { db } from "@acme/db/client";
+import { CreateWaitlistSchema, Waitlist } from "@acme/db/schema";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const parsed = CreateWaitlistSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid email" },
+      { status: 400 },
+    );
+  }
+
+  const email = parsed.data.email.trim().toLowerCase();
+
+  try {
+    await db
+      .insert(Waitlist)
+      .values({ email })
+      .onConflictDoNothing({ target: Waitlist.email });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    console.error("waitlist insert failed", err);
+    return NextResponse.json(
+      { error: "Could not join waitlist" },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -581,6 +581,24 @@ export const LegistarVote = pgTable(
   }),
 );
 
+// Waitlist signups (migrated from LaunchList)
+export const Waitlist = pgTable(
+  "waitlist",
+  (t) => ({
+    id: t.uuid().notNull().primaryKey().defaultRandom(),
+    email: t.varchar({ length: 320 }).notNull(),
+    source: t.varchar({ length: 50 }).notNull().default("waitlist-form"),
+    createdAt: t.timestamp().defaultNow().notNull(),
+  }),
+  (table) => ({
+    uniqueEmail: unique().on(table.email),
+  }),
+);
+
+export const CreateWaitlistSchema = createInsertSchema(Waitlist, {
+  email: z.email().max(320),
+}).pick({ email: true });
+
 // Google Civic API response cache
 export const CivicApiCache = pgTable(
   "civic_api_cache",


### PR DESCRIPTION
## Summary

Replaces the LaunchList-hosted waitlist (`getlaunchlist.com/s/m2zvn0`) with a self-hosted Supabase-backed implementation. All future signups land in our own `waitlist` table; the 7 existing LaunchList entries have been migrated (run manually against Supabase, not via this PR).

## Changes

- **`packages/db/src/schema.ts`** — new `Waitlist` table (`id` uuid, `email` unique varchar(320), `source` varchar(50) defaulting to `"waitlist-form"`, `created_at` timestamp) plus a `CreateWaitlistSchema` zod validator.
- **`apps/nextjs/src/app/api/waitlist/route.ts`** — new `POST /api/waitlist` handler. Validates email server-side, lowercases + trims, inserts via Drizzle with `ON CONFLICT DO NOTHING` so resubmits are idempotent. Returns `{ ok: true }` on success, `{ error }` on validation/DB failure.
- **`apps/nextjs/src/app/_components/waitlist-form.tsx`** — POSTs JSON to `/api/waitlist` instead of LaunchList. Reads error messages from the response body.
- **`.gitignore`** — adds `packages/db/seed-waitlist.sql` (the local-only seed file containing the 7 migrated emails, kept out of the repo since i'm not tryna leak emails).

## Deployment notes

1. `pnpm --filter @acme/db push` has already been run against Supabase; the `waitlist` table is live.
2. The 7 historical LaunchList emails have been seeded (marked `source = 'launchlist'`).
3. **After merge:** disable LaunchList form `m2zvn0` so it stops collecting signups in parallel.

## Notes

- LaunchList referral IDs / positions were not preserved — schema is intentionally minimal (email + source + timestamp).
- The route uses `runtime = "nodejs"` because the `pg` driver needs Node, not Edge.