### PR TITLE
feat(scraper): CA SOS VIG archive proposition scraper

### DIFF
--- a/apps/scraper/src/main.ts
+++ b/apps/scraper/src/main.ts
@@ -8,6 +8,7 @@ import { vote411 } from "./scrapers/vote411.js";
 import { sccCvig } from "./scrapers/scc-cvig.js";
 import { caSosStatements } from "./scrapers/ca-sos-statements.js";
 import { caLaoFiscal } from "./scrapers/ca-lao-fiscal.js";
+import { caVigArchive } from "./scrapers/ca-vig-archive.js";
 import type { Scraper } from "./utils/types.js";
 import { createLogger } from "./utils/log.js";
 import { setConcurrency } from "./utils/concurrency.js";
@@ -15,7 +16,7 @@ import { resetMetrics, printMetricsSummary } from "./utils/db/metrics.js";
 
 const logger = createLogger("main");
 
-const scrapers: Scraper[] = [federalregister, congress, scotus, vote411, sccCvig, caSosStatements, caLaoFiscal];
+const scrapers: Scraper[] = [federalregister, congress, scotus, vote411, sccCvig, caSosStatements, caLaoFiscal, caVigArchive];
 const scraperNames = scrapers.map((s) => s.name);
 
 const argv = await yargs(hideBin(process.argv))

--- a/apps/scraper/src/scrapers/ca-vig-archive.ts
+++ b/apps/scraper/src/scrapers/ca-vig-archive.ts
@@ -1,0 +1,178 @@
+/**
+ * California SOS Voter Information Guide *archive* scraper.
+ *
+ * Walks https://vigarchive.sos.ca.gov — the historical VIG (statewide
+ * propositions, 1996–present) — and writes one CivicApiCache row per election
+ * (year + election-type), each holding every parsed proposition for that
+ * election. The measure cross-validation engine reads these rows back at request
+ * time keyed by year + proposition number, so the page fetch + HTML parse stays
+ * out of the serverless API path (same handoff pattern as ca-sos-statements).
+ *
+ * Why the archive and not the live guide: voterguide.sos.ca.gov 403s automated
+ * clients, but vigarchive.sos.ca.gov serves the same official content and is
+ * scrapable with a browser User-Agent. All parsing lives in the pure
+ * @acme/api/lib/measure-sources/vig-archive module; this file only fetches,
+ * orchestrates, throttles, and persists.
+ *
+ * Cadence: the archive is historical and effectively immutable once an election
+ * passes, so this is a low-frequency backfill — re-runs upsert idempotently.
+ */
+
+import { db } from "@acme/db/client";
+import { CivicApiCache } from "@acme/db/schema";
+import {
+  VIG_ARCHIVE_ROOT,
+  VIG_ARCHIVE_ADDRESS_HASH,
+  VIG_ARCHIVE_ENDPOINT,
+  parseArchiveIndex,
+  parsePropIndex,
+  parsePropPage,
+  parseArgsRebuttals,
+  propsIndexUrl,
+  propPageUrl,
+  argsRebuttalsUrl,
+  vigArchiveCacheParams,
+} from "@acme/api/lib/measure-sources/vig-archive";
+import type {
+  VigElection,
+  VigArchiveProp,
+  VigArchivePayload,
+} from "@acme/api/lib/measure-sources/vig-archive";
+
+import type { Scraper } from "../utils/types.js";
+import { fetchWithRetry } from "../utils/fetch.js";
+import { createLogger } from "../utils/log.js";
+
+const logger = createLogger("ca-vig-archive");
+
+/** Archive content is historical/immutable; keep cache rows for a year. */
+const CACHE_TTL_MS = 365 * 24 * 60 * 60 * 1000;
+
+/** Politeness delay between requests to a government archive host. */
+const POLITENESS_MS = 750;
+
+/** Some archive pages WAF-filter bare clients; send a real browser UA. */
+const BROWSER_UA =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+  "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Defensive HTML GET — non-200 / network error yields null, never a throw. */
+async function fetchHtml(url: string): Promise<string | null> {
+  try {
+    const res = await fetchWithRetry(url, {
+      headers: { Accept: "text/html", "User-Agent": BROWSER_UA },
+    });
+    return await res.text();
+  } catch (err) {
+    logger.warn(`fetch failed: ${url}`, err);
+    return null;
+  }
+}
+
+/** Fetch + parse every proposition for one election. */
+async function scrapeElection(el: VigElection): Promise<VigArchiveProp[]> {
+  const indexHtml = await fetchHtml(propsIndexUrl(el));
+  if (!indexHtml) {
+    logger.warn(`${el.path}: no propositions index — skipping.`);
+    return [];
+  }
+
+  const numbers = parsePropIndex(indexHtml);
+  if (numbers.length === 0) {
+    logger.info(`${el.path}: index had no propositions.`);
+    return [];
+  }
+
+  const props: VigArchiveProp[] = [];
+  for (const propNumber of numbers) {
+    await sleep(POLITENESS_MS);
+    const pageHtml = await fetchHtml(propPageUrl(el, propNumber));
+    if (!pageHtml) continue;
+    const page = parsePropPage(pageHtml);
+    if (!page) {
+      logger.warn(`${el.path}prop ${propNumber}: page parse yielded nothing.`);
+      continue;
+    }
+
+    // Full arguments + rebuttals live on a sibling page; absence is tolerated.
+    await sleep(POLITENESS_MS);
+    const argsHtml = await fetchHtml(argsRebuttalsUrl(el, propNumber));
+    const args = argsHtml ? parseArgsRebuttals(argsHtml) : {};
+
+    props.push({
+      year: el.year,
+      electionType: el.electionType,
+      sourceUrl: propPageUrl(el, propNumber),
+      ...page,
+      ...args,
+    });
+  }
+
+  logger.info(`${el.path}: parsed ${props.length}/${numbers.length} propositions.`);
+  return props;
+}
+
+/** Upsert one election's propositions into a single CivicApiCache row. */
+async function writeElection(
+  el: VigElection,
+  props: VigArchiveProp[],
+): Promise<void> {
+  const payload: VigArchivePayload = { props };
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + CACHE_TTL_MS);
+  const params = vigArchiveCacheParams(el.year, el.electionType);
+
+  try {
+    await db
+      .insert(CivicApiCache)
+      .values({
+        addressHash: VIG_ARCHIVE_ADDRESS_HASH,
+        endpoint: VIG_ARCHIVE_ENDPOINT,
+        params,
+        responseData: payload,
+        fetchedAt: now,
+        expiresAt,
+      })
+      .onConflictDoUpdate({
+        target: [
+          CivicApiCache.addressHash,
+          CivicApiCache.endpoint,
+          CivicApiCache.params,
+        ],
+        set: { responseData: payload, fetchedAt: now, expiresAt },
+      });
+    logger.success(`${el.path}: cached ${props.length} propositions.`);
+  } catch (err) {
+    logger.error(`${el.path}: cache write failed:`, err);
+  }
+}
+
+async function scrape(): Promise<void> {
+  logger.info("Scraping CA VIG archive…");
+
+  const rootHtml = await fetchHtml(`${VIG_ARCHIVE_ROOT}/`);
+  if (!rootHtml) {
+    logger.error("Could not fetch archive root — aborting.");
+    return;
+  }
+
+  const elections = parseArchiveIndex(rootHtml);
+  logger.info(`Found ${elections.length} elections in the archive index.`);
+
+  let total = 0;
+  for (const el of elections) {
+    const props = await scrapeElection(el);
+    if (props.length > 0) {
+      await writeElection(el, props);
+      total += props.length;
+    }
+  }
+
+  logger.success(`CA VIG archive: cached ${total} propositions across ${elections.length} elections.`);
+}
+
+export const caVigArchive: Scraper = { name: "ca-vig-archive", scrape };

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -46,6 +46,10 @@
     "./lib/measure-sources/types": {
       "types": "./dist/lib/measure-sources/types.d.ts",
       "default": "./src/lib/measure-sources/types.ts"
+    },
+    "./lib/measure-sources/vig-archive": {
+      "types": "./dist/lib/measure-sources/vig-archive.d.ts",
+      "default": "./src/lib/measure-sources/vig-archive.ts"
     }
   },
   "license": "MIT",

--- a/packages/api/src/lib/measure-sources/vig-archive.ts
+++ b/packages/api/src/lib/measure-sources/vig-archive.ts
@@ -1,0 +1,254 @@
+/**
+ * California SOS Voter Information Guide *archive* parser.
+ *
+ * Source: https://vigarchive.sos.ca.gov — the historical VIG covering statewide
+ * propositions from 1996 to present. Unlike the live voter guide
+ * (voterguide.sos.ca.gov, see ./ca-sos-voterguide.ts) the archive exposes one
+ * stable page per proposition per election:
+ *
+ *   /{year}/{election-type}/propositions/{N}/                  (summary + short pro/con)
+ *   /{year}/{election-type}/propositions/{N}/arguments-rebuttals.htm  (full pro/con + rebuttals)
+ *
+ * This module is PURE: HTML in, structured data out, no network and no DB. The
+ * scraper (apps/scraper/.../ca-vig-archive.ts) does the fetching and writes the
+ * parsed result into CivicApiCache; the cross-validation engine reads it back at
+ * request time keyed by election year + proposition number.
+ *
+ * Everything is best-effort and defensive — markup drift yields empty/undefined
+ * fields, never a throw — matching the rest of measure-sources/.
+ */
+
+import { stableStringify } from "../candidate-sources/types";
+import { htmlToText } from "./html";
+
+export const VIG_ARCHIVE_ROOT = "https://vigarchive.sos.ca.gov";
+export const VIG_ARCHIVE_SOURCE_NAME =
+  "California Secretary of State — Voter Information Guide Archive";
+
+/** A single election present in the archive index (e.g. 2024 general). */
+export interface VigElection {
+  year: number;
+  /** "general" | "primary" | "special" | "feb" | "june" | "" (bare-year specials). */
+  electionType: string;
+  /** Canonical path with leading + trailing slash, e.g. "/2024/general/". */
+  path: string;
+}
+
+/** Structured content for one archived proposition. */
+export interface VigArchiveProp {
+  year: number;
+  electionType: string;
+  /** Proposition number as printed, e.g. "2", "1A". */
+  propNumber: string;
+  title: string;
+  /** Official summary block (incl. fiscal impact / supporters / opponents lines). */
+  summary?: string;
+  /** "WHAT YOUR VOTE MEANS" block (YES/NO plain-language explanation). */
+  voteMeans?: string;
+  /** Short argument printed on the prop page itself. */
+  proShort?: string;
+  conShort?: string;
+  /** Full arguments + rebuttals from arguments-rebuttals.htm. */
+  proArgument?: string;
+  conArgument?: string;
+  proRebuttal?: string;
+  conRebuttal?: string;
+  sourceUrl: string;
+}
+
+/* ------------------------------------------------------------------ URLs -- */
+
+export function propsIndexUrl(el: VigElection): string {
+  return `${VIG_ARCHIVE_ROOT}${el.path}propositions/`;
+}
+
+export function propPageUrl(el: VigElection, propNumber: string): string {
+  return `${VIG_ARCHIVE_ROOT}${el.path}propositions/${propNumber}/`;
+}
+
+export function argsRebuttalsUrl(el: VigElection, propNumber: string): string {
+  return `${propPageUrl(el, propNumber)}arguments-rebuttals.htm`;
+}
+
+/* --------------------------------------------------------------- Indexes -- */
+
+/**
+ * Parse the archive root into the list of elections it links to. The root uses
+ * relative hrefs like `2024/general/`, `2008/feb/`, `2003/special/`, and a few
+ * bare `2021/` (the recall) — we normalise all of them to `/{year}/{type}/`.
+ */
+export function parseArchiveIndex(html: string): VigElection[] {
+  const seen = new Set<string>();
+  const out: VigElection[] = [];
+  const re = /href="\/?(?:past\/)?((?:19|20)\d{2})\/([a-z]*)\/?"/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html))) {
+    const year = Number(m[1]);
+    const electionType = (m[2] ?? "").toLowerCase();
+    const path = electionType ? `/${year}/${electionType}/` : `/${year}/`;
+    if (seen.has(path)) continue;
+    seen.add(path);
+    out.push({ year, electionType, path });
+  }
+  return out.sort((a, b) => a.year - b.year || a.electionType.localeCompare(b.electionType));
+}
+
+/**
+ * Parse a `/propositions/` index page into the ordered list of proposition
+ * numbers it links to (deduped, e.g. ["2", "3", "4", "5", "6", "32", ...]).
+ */
+export function parsePropIndex(html: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const re = /href="[^"]*\/propositions\/(\d+[a-z]?)\/?"/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html))) {
+    const n = m[1]!.toUpperCase();
+    if (seen.has(n)) continue;
+    seen.add(n);
+    out.push(n);
+  }
+  return out;
+}
+
+/* --------------------------------------------------------------- Slicing -- */
+
+/** Heading lines render on their own line; anchor markers to line starts. */
+function lineMarker(pattern: string): RegExp {
+  return new RegExp(`(?:^|\\n)\\s*${pattern}[^\\n]*`, "i");
+}
+
+/**
+ * Slice the text between `start` and the earliest of `stops`. Returns undefined
+ * when the section is missing or only a heading fragment.
+ */
+function sliceSection(
+  text: string,
+  start: RegExp,
+  stops: RegExp[],
+): string | undefined {
+  const startMatch = start.exec(text);
+  if (!startMatch) return undefined;
+  const from = startMatch.index + startMatch[0].length;
+  let to = text.length;
+  for (const stop of stops) {
+    const m = stop.exec(text.slice(from));
+    if (m && from + m.index < to) to = from + m.index;
+  }
+  const section = text.slice(from, to).trim();
+  return section.length >= 20 ? section : undefined;
+}
+
+function clamp(s: string | undefined, max: number): string | undefined {
+  if (!s) return undefined;
+  const t = s.trim();
+  if (!t) return undefined;
+  return t.length > max ? t.slice(0, max).trimEnd() + "…" : t;
+}
+
+/* ----------------------------------------------------------- Prop parser -- */
+
+const M = {
+  summary: lineMarker("SUMMARY"),
+  voteMeans: lineMarker("WHAT YOUR VOTE MEANS"),
+  args: lineMarker("ARGUMENTS"),
+  forInfo: lineMarker("FOR ADDITIONAL INFORMATION"),
+  pro: lineMarker("PRO"),
+  con: lineMarker("CON"),
+  // Sidebar headings that follow the main content in document order — used as
+  // hard stops so a missing section can't bleed into the nav rail.
+  sidebar: /(?:^|\n)\s*(Propositions|Dates to Remember|Voter Information Guide)\b/i,
+};
+
+/**
+ * Parse a single proposition page (the `/propositions/{N}/` URL) into its
+ * title, summary, vote-means block, and short pro/con arguments.
+ */
+export function parsePropPage(
+  html: string,
+): Pick<
+  VigArchiveProp,
+  "propNumber" | "title" | "summary" | "voteMeans" | "proShort" | "conShort"
+> | null {
+  const text = htmlToText(html);
+  if (text.length < 200) return null;
+
+  // "PROP 2" → number; the official title is the next non-empty line up to SUMMARY.
+  const propMatch = /(?:^|\n)\s*PROP\s+#?\s*(\d+[A-Z]?)\b/i.exec(text);
+  const propNumber = propMatch?.[1]?.toUpperCase();
+  if (!propNumber) return null;
+
+  const titleSlice = sliceSection(
+    text,
+    new RegExp(`PROP\\s+#?\\s*${propNumber}\\b`, "i"),
+    [M.summary],
+  );
+  const title = clamp(titleSlice, 300) ?? `Proposition ${propNumber}`;
+
+  const summary = clamp(
+    sliceSection(text, M.summary, [M.voteMeans, M.args, M.sidebar]),
+    2000,
+  );
+  const voteMeans = clamp(
+    sliceSection(text, M.voteMeans, [M.args, M.forInfo, M.sidebar]),
+    1500,
+  );
+
+  // The short arguments live under the ARGUMENTS heading as PRO / CON blocks.
+  const argsBlock = sliceSection(text, M.args, [M.forInfo, M.sidebar]) ?? "";
+  const proShort = clamp(sliceSection(argsBlock, M.pro, [M.con]), 1500);
+  const conShort = clamp(sliceSection(argsBlock, M.con, [M.sidebar]), 1500);
+
+  return { propNumber, title, summary, voteMeans, proShort, conShort };
+}
+
+/* ------------------------------------------------------ Args/rebuttals -- */
+
+const A = {
+  proArg: lineMarker("ARGUMENT IN FAVOR"),
+  proReb: lineMarker("REBUTTAL TO ARGUMENT IN FAVOR"),
+  conArg: lineMarker("ARGUMENT AGAINST"),
+  conReb: lineMarker("REBUTTAL TO ARGUMENT AGAINST"),
+  sidebar: M.sidebar,
+};
+
+/**
+ * Parse arguments-rebuttals.htm into the four full-length sections. The page
+ * always orders them FAVOR → REBUTTAL-TO-FAVOR → AGAINST → REBUTTAL-TO-AGAINST.
+ */
+export function parseArgsRebuttals(html: string): Pick<
+  VigArchiveProp,
+  "proArgument" | "conArgument" | "proRebuttal" | "conRebuttal"
+> {
+  const text = htmlToText(html);
+  return {
+    proArgument: clamp(sliceSection(text, A.proArg, [A.proReb]), 4000),
+    proRebuttal: clamp(sliceSection(text, A.proReb, [A.conArg]), 4000),
+    conArgument: clamp(sliceSection(text, A.conArg, [A.conReb]), 4000),
+    conRebuttal: clamp(sliceSection(text, A.conReb, [A.sidebar]), 4000),
+  };
+}
+
+/* --------------------------------------------------------- Cache handoff -- */
+
+/** CivicApiCache.addressHash for the VIG archive handoff (global, not per-address). */
+export const VIG_ARCHIVE_ADDRESS_HASH = "__global__";
+/** CivicApiCache.endpoint namespace for the VIG archive handoff. */
+export const VIG_ARCHIVE_ENDPOINT = "ca-vig-archive";
+
+/** Payload stored in CivicApiCache.responseData — one row per election. */
+export interface VigArchivePayload {
+  props: VigArchiveProp[];
+}
+
+/**
+ * Build the CivicApiCache.params string for one election. Single source of
+ * truth so the scraper write and the adapter read never drift (a mismatch is a
+ * silent cache miss). Mirrors caSosCacheParams in candidate-sources/ca-sos-cache.
+ */
+export function vigArchiveCacheParams(
+  year: number,
+  electionType: string,
+): string {
+  return stableStringify({ year, electionType });
+}


### PR DESCRIPTION
## What

Adds a scraper that backfills **historical California statewide ballot propositions (1996–present)** from the CA SOS **Voter Information Guide archive** (`vigarchive.sos.ca.gov`). The live voter guide (`voterguide.sos.ca.gov`) 403s automated clients; the archive serves the same official content and is scrapable with a browser User-Agent. P0 for CA measure content.

## How

- **`packages/api/src/lib/measure-sources/vig-archive.ts`** — pure parsers (no network/DB), mirroring the existing measure-source adapters:
  - `parseArchiveIndex` → elections (year + election-type) from the archive root
  - `parsePropIndex` → proposition numbers from a `/propositions/` index
  - `parsePropPage` → title, summary, "what your vote means", short pro/con
  - `parseArgsRebuttals` → full pro/con arguments + rebuttals
  - URL builders + `CivicApiCache` handoff constants (`vigArchiveCacheParams`)
- **`apps/scraper/src/scrapers/ca-vig-archive.ts`** — orchestrator: enumerates elections → fetches + parses each proposition → upserts **one `CivicApiCache` row per election** (`endpoint: ca-vig-archive`). Same cache-handoff pattern as `ca-sos-statements`; politeness delays + browser UA for the government host.
- Registered as the `ca-vig-archive` CLI scraper; `@acme/api` subpath export added.

Run with `pnpm scraper ca-vig-archive`.

## Verification

- Parsers validated against **live 2024 general** (props 2 & 3): title, summary, vote-means, short + full pro/con arguments, and both rebuttals all extract correctly.
- Full fetch→parse→assemble pipeline runs live end-to-end via tsx.
- `@acme/api` typecheck passes.
- Scraper registers and the module graph loads under the tsx runtime.

## Notes / follow-ups

- **DB-write not exercised against a live DB** in this PR (the `writeElection` upsert is structurally identical to the proven `ca-sos-statements` upsert). A first real run needs `POSTGRES_URL`.
- **Reader side is not wired yet:** this populates the cache; a follow-up should extend `measure-sources/ca-sos-voterguide.ts` (or a new archive adapter) to read these rows in the cross-validation engine so historical propositions surface in the app.
- `pnpm -F @acme/scraper build` (tsc) is **pre-existing broken on `main`** (repo-wide `nodenext` extension errors); the scraper ships via tsx/Docker, so this PR follows the package's extensionless convention. Not addressed here.