### PR TITLE
Surface bill evidence details

### DIFF
--- a/apps/expo/src/app/article-detail.tsx
+++ b/apps/expo/src/app/article-detail.tsx
@@ -14,6 +14,7 @@ import { useLocalSearchParams, useRouter } from "expo-router";
 import Markdown from "@ronradtke/react-native-markdown-display";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
+import { BillEvidenceCard } from "~/components/BillEvidenceCard";
 import { Text } from "~/components/Themed";
 import {
   Badge,
@@ -59,6 +60,13 @@ const PLACEHOLDER_LENS = {
     ],
   },
 };
+
+interface TimelineStep {
+  label: string;
+  date?: string;
+  done: boolean;
+  current: boolean;
+}
 
 export default function ArticleDetailScreen() {
   const router = useRouter();
@@ -224,22 +232,30 @@ export default function ArticleDetailScreen() {
     },
   };
 
-  const handleOpenOriginal = async () => {
-    if (!content.url) return;
+  const handleOpenSource = async (
+    url: string | undefined,
+    sourceKind: "official_text" | "bill_record" | "original_source",
+  ) => {
+    if (!url) return;
     posthog.capture("original_source_opened", {
       content_id: content.id,
       content_type: content.type,
       content_title: content.title,
-      source_url: content.url,
+      source_url: url,
+      source_kind: sourceKind,
     });
     try {
-      if (await Linking.canOpenURL(content.url)) {
-        await Linking.openURL(content.url);
+      if (await Linking.canOpenURL(url)) {
+        await Linking.openURL(url);
       }
     } catch (e) {
       posthog.captureException(e as Error, { content_id: content.id });
       console.error("Error opening URL:", e);
     }
+  };
+
+  const handleOpenOriginal = () => {
+    void handleOpenSource(content.url, "original_source");
   };
 
   const activeContent =
@@ -259,22 +275,42 @@ export default function ArticleDetailScreen() {
     "actions" in content
       ? (content.actions as { date: string; text: string }[])
       : [];
-  const timeline =
+  const timeline: TimelineStep[] =
     actions.length > 0
       ? actions
           .slice()
           .sort((a, b) => a.date.localeCompare(b.date))
           .map((a, i, arr) => ({
             label: a.text.length > 80 ? a.text.slice(0, 77) + "…" : a.text,
+            date: /^\d{4}-\d{2}-\d{2}/.exec(a.date)?.[0],
             done: true,
             current: i === arr.length - 1,
           }))
-      : [
-          { label: "Introduced", done: true, current: false },
-          { label: "Committee review", done: true, current: false },
-          { label: "Latest action", done: true, current: true },
-          { label: "Becomes law", done: false, current: false },
-        ];
+      : content.type === "bill"
+        ? []
+        : [
+            { label: "Introduced", done: true, current: false },
+            { label: "Committee review", done: true, current: false },
+            { label: "Latest action", done: true, current: true },
+            { label: "Becomes law", done: false, current: false },
+          ];
+  const billEvidence =
+    content.type === "bill" && "billNumber" in content
+      ? {
+          billNumber: content.billNumber,
+          jurisdiction: content.jurisdiction,
+          congress: content.congress,
+          chamber: content.chamber,
+          sponsor: content.sponsor,
+          introducedDate: content.introducedDate,
+          status: content.status,
+          statusAsOf: content.statusAsOf,
+          latestAction: content.latestAction,
+          officialTextUrl: content.officialTextUrl,
+          sourceName: content.sourceName,
+          sourceUpdatedAt: content.sourceUpdatedAt,
+        }
+      : undefined;
 
   return (
     <View style={s.screen}>
@@ -332,6 +368,14 @@ export default function ArticleDetailScreen() {
           </Text>
         ) : null}
 
+        {billEvidence ? (
+          <BillEvidenceCard
+            evidence={billEvidence}
+            recordUrl={content.url}
+            onOpenUrl={handleOpenSource}
+          />
+        ) : null}
+
         {/* explainer / source toggle */}
         <View style={{ marginTop: 18, marginBottom: 18 }}>
           <Segmented
@@ -386,6 +430,11 @@ export default function ArticleDetailScreen() {
         {/* timeline */}
         <Kicker>Where it stands</Kicker>
         <Card style={{ marginBottom: 24 }}>
+          {timeline.length === 0 ? (
+            <Text style={s.noTimelineText}>
+              No dated actions are available in this record yet.
+            </Text>
+          ) : null}
           {timeline.map((step, i) => (
             <View key={i} style={s.timelineRow}>
               <View style={s.timelineMarker}>
@@ -407,17 +456,24 @@ export default function ArticleDetailScreen() {
                   />
                 )}
               </View>
-              <Text
-                style={[
-                  s.timelineLabel,
-                  {
-                    color: step.done ? colors.white : colors.textSecondary,
-                    fontFamily: step.current ? fontBody.bold : fontBody.medium,
-                  },
-                ]}
-              >
-                {step.label}
-              </Text>
+              <View style={s.timelineContent}>
+                {step.date ? (
+                  <Text style={s.timelineDate}>{step.date}</Text>
+                ) : null}
+                <Text
+                  style={[
+                    s.timelineLabel,
+                    {
+                      color: step.done ? colors.white : colors.textSecondary,
+                      fontFamily: step.current
+                        ? fontBody.bold
+                        : fontBody.medium,
+                    },
+                  ]}
+                >
+                  {step.label}
+                </Text>
+              </View>
             </View>
           ))}
         </Card>
@@ -527,7 +583,20 @@ const s = StyleSheet.create({
   timelineMarker: { alignItems: "center" },
   timelineDot: { width: 14, height: 14, borderRadius: 7, borderWidth: 2 },
   timelineLine: { width: 2, flex: 1, minHeight: 22 },
-  timelineLabel: { fontSize: 14, paddingBottom: 14 },
+  timelineContent: { flex: 1, paddingBottom: 14 },
+  timelineDate: {
+    fontFamily: fontBody.semibold,
+    fontSize: 11,
+    letterSpacing: 0.5,
+    color: colors.textSecondary,
+    marginBottom: 3,
+  },
+  timelineLabel: { fontSize: 14 },
+  noTimelineText: {
+    fontFamily: fontBody.regular,
+    fontSize: 14,
+    color: colors.textSecondary,
+  },
   exit: {
     backgroundColor: planes.slate,
     borderWidth: 1,

--- a/apps/expo/src/components/BillEvidenceCard.tsx
+++ b/apps/expo/src/components/BillEvidenceCard.tsx
@@ -1,0 +1,207 @@
+import { StyleSheet, View } from "react-native";
+
+import { Text } from "~/components/Themed";
+import { Card, GhostButton, Kicker, PrimaryButton } from "~/components/ui";
+import { colors, fontBody, fontDisplay, hair, planes } from "~/styles";
+
+export interface BillEvidenceRecord {
+  billNumber: string;
+  jurisdiction: string;
+  congress?: number;
+  chamber?: string;
+  sponsor?: string;
+  introducedDate?: string;
+  status?: string;
+  statusAsOf?: string;
+  latestAction?: {
+    date: string;
+    text: string;
+    type?: string;
+  };
+  officialTextUrl: string;
+  sourceName: string;
+  sourceUpdatedAt: string;
+}
+
+interface BillEvidenceCardProps {
+  evidence: BillEvidenceRecord;
+  recordUrl?: string;
+  onOpenUrl: (url: string, kind: "official_text" | "bill_record") => void;
+}
+
+function exactDate(value?: string): string | undefined {
+  return value ? /^\d{4}-\d{2}-\d{2}/.exec(value)?.[0] : undefined;
+}
+
+function ordinal(value: number): string {
+  const remainder = value % 100;
+  if (remainder >= 11 && remainder <= 13) return `${value}th`;
+
+  switch (value % 10) {
+    case 1:
+      return `${value}st`;
+    case 2:
+      return `${value}nd`;
+    case 3:
+      return `${value}rd`;
+    default:
+      return `${value}th`;
+  }
+}
+
+export function BillEvidenceCard({
+  evidence,
+  recordUrl,
+  onOpenUrl,
+}: BillEvidenceCardProps) {
+  const introducedDate = exactDate(evidence.introducedDate);
+  const statusAsOf = exactDate(
+    evidence.statusAsOf ?? evidence.latestAction?.date,
+  );
+  const sourceUpdatedAt = exactDate(evidence.sourceUpdatedAt);
+  const legislature = [
+    evidence.congress ? `${ordinal(evidence.congress)} Congress` : undefined,
+    evidence.chamber,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const facts = [
+    { label: "Bill", value: evidence.billNumber },
+    { label: "Jurisdiction", value: evidence.jurisdiction },
+    { label: "Legislature", value: legislature || undefined },
+    { label: "Primary sponsor", value: evidence.sponsor },
+    { label: "Introduced", value: introducedDate },
+  ].filter((fact): fact is { label: string; value: string } => !!fact.value);
+
+  return (
+    <View testID="bill-evidence" style={styles.section}>
+      <Kicker>Official record</Kicker>
+      <Card>
+        <View style={styles.statusBlock}>
+          <Text style={styles.statusLabel}>
+            {statusAsOf
+              ? `CURRENT STATUS · AS OF ${statusAsOf}`
+              : "CURRENT STATUS"}
+          </Text>
+          <Text style={styles.statusValue}>
+            {evidence.status ?? "Status unavailable"}
+          </Text>
+        </View>
+
+        <View style={styles.factList}>
+          {facts.map((fact) => (
+            <View key={fact.label} style={styles.factRow}>
+              <Text style={styles.factLabel}>{fact.label}</Text>
+              <Text selectable style={styles.factValue}>
+                {fact.value}
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        {evidence.latestAction ? (
+          <View style={styles.latestAction}>
+            <Text style={styles.latestActionLabel}>
+              LATEST ACTION · {exactDate(evidence.latestAction.date)}
+            </Text>
+            <Text style={styles.latestActionText}>
+              {evidence.latestAction.text}
+            </Text>
+          </View>
+        ) : null}
+
+        <Text style={styles.sourceNote}>
+          Source: {evidence.sourceName}
+          {sourceUpdatedAt ? ` · Record checked ${sourceUpdatedAt}` : ""}
+        </Text>
+
+        <PrimaryButton
+          label="Read official text"
+          icon="external"
+          onPress={() => onOpenUrl(evidence.officialTextUrl, "official_text")}
+          style={styles.primaryButton}
+        />
+        {recordUrl ? (
+          <GhostButton
+            label="Open full bill record"
+            onPress={() => onOpenUrl(recordUrl, "bill_record")}
+            style={styles.recordButton}
+          />
+        ) : null}
+      </Card>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  section: { marginTop: 22, marginBottom: 4 },
+  statusBlock: {
+    paddingBottom: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: hair[2],
+  },
+  statusLabel: {
+    fontFamily: fontBody.bold,
+    fontSize: 10.5,
+    letterSpacing: 0.9,
+    color: colors.civicBlue,
+    marginBottom: 7,
+  },
+  statusValue: {
+    fontFamily: fontDisplay.bold,
+    fontSize: 17,
+    lineHeight: 23,
+    color: colors.white,
+  },
+  factList: { paddingVertical: 5 },
+  factRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 14,
+    paddingVertical: 10,
+    borderBottomWidth: 1,
+    borderBottomColor: hair[1],
+  },
+  factLabel: {
+    width: 98,
+    fontFamily: fontBody.semibold,
+    fontSize: 12,
+    color: colors.textSecondary,
+  },
+  factValue: {
+    flex: 1,
+    fontFamily: fontBody.medium,
+    fontSize: 13.5,
+    lineHeight: 19,
+    color: colors.white,
+  },
+  latestAction: {
+    marginTop: 12,
+    padding: 14,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: hair[2],
+    backgroundColor: planes.surface,
+  },
+  latestActionLabel: {
+    fontFamily: fontBody.bold,
+    fontSize: 10.5,
+    letterSpacing: 0.8,
+    color: colors.civicBlue,
+    marginBottom: 7,
+  },
+  latestActionText: {
+    fontFamily: fontBody.regular,
+    fontSize: 13.5,
+    lineHeight: 20,
+    color: colors.white,
+  },
+  sourceNote: {
+    marginTop: 13,
+    fontFamily: fontBody.regular,
+    fontSize: 11.5,
+    color: colors.textSecondary,
+  },
+  primaryButton: { marginTop: 16 },
+  recordButton: { width: "100%", marginTop: 6 },
+});

--- a/packages/api/src/router/content.ts
+++ b/packages/api/src/router/content.ts
@@ -341,6 +341,22 @@ export const contentRouter = {
         .limit(1);
       if (bill[0]) {
         const b = bill[0];
+        const actions = (b.actions ?? []) as {
+          date: string;
+          text: string;
+          type?: string;
+        }[];
+        const latestAction = actions.reduce<
+          (typeof actions)[number] | undefined
+        >(
+          (latest, action) =>
+            !latest || action.date > latest.date ? action : latest,
+          undefined,
+        );
+        const officialTextUrl =
+          b.sourceWebsite === "congress.gov"
+            ? `${b.url.replace(/\/$/, "")}/text`
+            : b.url;
         const [result] = await attachVideoImages([
           {
             id: b.id,
@@ -353,12 +369,21 @@ export const contentRouter = {
               b.aiGeneratedArticle ?? b.fullText ?? "No content available",
             originalContent: b.fullText ?? "Full text not available",
             url: b.url,
-            actions: (b.actions ?? []) as {
-              date: string;
-              text: string;
-              type?: string;
-            }[],
-            status: b.status ?? undefined,
+            actions,
+            billNumber: b.billNumber,
+            jurisdiction: "United States Congress",
+            congress: b.congress ?? undefined,
+            chamber: b.chamber ?? undefined,
+            sponsor: b.sponsor ?? undefined,
+            introducedDate: b.introducedDate?.toISOString(),
+            // The denormalized status field is intentionally short for feeds;
+            // the full latest action is the more precise record for bill detail.
+            status: latestAction?.text ?? b.status ?? undefined,
+            statusAsOf: latestAction?.date,
+            latestAction,
+            officialTextUrl,
+            sourceName: b.sourceWebsite,
+            sourceUpdatedAt: (b.updatedAt ?? b.createdAt).toISOString(),
           },
         ]);
         if (!result) throw new Error(`Failed to decorate bill ${b.id}`);


### PR DESCRIPTION
## Summary

- surface an Official record card for federal bills with bill number, jurisdiction, chamber, Congress, primary sponsor, and introduction date
- show the full latest official action with its exact status-as-of date rather than only a shortened feed status
- preserve exact dates alongside every recorded legislative action
- add direct links to the official Congress.gov text and full bill record, with source-check provenance

## Why

The bill scraper already stores these facts, but `content.getById` discarded them and the article screen removed action dates. This made source-backed reporting details unnecessarily hard to find.

## Verification

- `pnpm --filter @acme/api typecheck`
- `pnpm --filter @acme/api lint`
- `pnpm --filter @acme/expo typecheck`
- `pnpm --filter @acme/expo lint`
- `pnpm format`
- `expo export --platform ios`
