### PR TITLE
Add bill sponsor profiles

### DIFF
--- a/apps/expo/src/app/article-detail.tsx
+++ b/apps/expo/src/app/article-detail.tsx
@@ -16,6 +16,7 @@ import { useMutation, useQuery } from "@tanstack/react-query";
 
 import { Text } from "~/components/Themed";
 import {
+  Avatar,
   Badge,
   Card,
   GhostButton,
@@ -308,6 +309,20 @@ export default function ArticleDetailScreen() {
       ];
   // Actions are the official legislative record from the source (congress.gov).
   const timelineSourceUrl = hasRealActions ? content.url : undefined;
+  const sponsor = content.type === "bill" ? content.sponsor : undefined;
+
+  const openSponsorProfile = () => {
+    if (!sponsor) return;
+    posthog.capture("bill_sponsor_profile_opened", {
+      content_id: content.id,
+      bill_number: content.billNumber ?? null,
+      sponsor_name: sponsor.name,
+    });
+    router.push({
+      pathname: "/bill-sponsor-profile",
+      params: { id: content.id },
+    });
+  };
 
   return (
     <View style={s.screen}>
@@ -370,6 +385,31 @@ export default function ArticleDetailScreen() {
           <Text style={s.desc} testID="article-description">
             {content.description}
           </Text>
+        ) : null}
+
+        {sponsor ? (
+          <TouchableOpacity
+            style={s.sponsorCard}
+            activeOpacity={0.75}
+            onPress={openSponsorProfile}
+            accessibilityRole="button"
+            accessibilityLabel={`View sponsor profile for ${sponsor.name}`}
+            testID="bill-sponsor-card"
+          >
+            <Avatar name={sponsor.initials} size={44} />
+            <View style={s.sponsorBody}>
+              <Text style={s.sponsorLabel}>Sponsored by</Text>
+              <Text style={s.sponsorName} numberOfLines={1}>
+                {sponsor.name}
+              </Text>
+              <Text style={s.sponsorMeta} numberOfLines={1}>
+                {[sponsor.role, sponsor.party, sponsor.state]
+                  .filter(Boolean)
+                  .join(" · ")}
+              </Text>
+            </View>
+            <Icon name="chevR" size={17} color={colors.textSecondary} />
+          </TouchableOpacity>
         ) : null}
 
         {/* explainer / source toggle */}
@@ -579,6 +619,35 @@ const s = StyleSheet.create({
     fontSize: 15,
     color: colors.textSecondary,
     lineHeight: 22,
+  },
+  sponsorCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 12,
+    marginTop: 18,
+    padding: 14,
+    backgroundColor: planes.slate,
+    borderWidth: 1,
+    borderColor: hair[2],
+    borderRadius: 14,
+  },
+  sponsorBody: { flex: 1, gap: 1 },
+  sponsorLabel: {
+    fontFamily: fontBody.medium,
+    fontSize: 10.5,
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+    color: colors.textSecondary,
+  },
+  sponsorName: {
+    fontFamily: fontBody.semibold,
+    fontSize: 15,
+    color: colors.white,
+  },
+  sponsorMeta: {
+    fontFamily: fontBody.regular,
+    fontSize: 11.5,
+    color: colors.textSecondary,
   },
   disclaimer: {
     flexDirection: "row",

--- a/apps/expo/src/app/bill-sponsor-profile.tsx
+++ b/apps/expo/src/app/bill-sponsor-profile.tsx
@@ -1,0 +1,202 @@
+import {
+  ActivityIndicator,
+  Linking,
+  ScrollView,
+  StyleSheet,
+  View,
+} from "react-native";
+import { useLocalSearchParams, useRouter } from "expo-router";
+import { useQuery } from "@tanstack/react-query";
+
+import { Text } from "~/components/Themed";
+import {
+  Avatar,
+  Card,
+  ContentCard,
+  Kicker,
+  NavHeader,
+  PrimaryButton,
+} from "~/components/ui";
+import { colors, fontBody, fontDisplay, planes } from "~/styles";
+import { trpc } from "~/utils/api";
+import { formatDate } from "~/utils/dates";
+
+export default function BillSponsorProfileScreen() {
+  const router = useRouter();
+  const params = useLocalSearchParams<{ id?: string | string[] }>();
+  const billId = Array.isArray(params.id) ? params.id[0] : params.id;
+  const query = useQuery({
+    ...trpc.content.getSponsorProfile.queryOptions({
+      billId: billId ?? "00000000-0000-0000-0000-000000000000",
+    }),
+    enabled: !!billId,
+  });
+
+  if (query.isLoading) {
+    return (
+      <View style={s.fullCenter}>
+        <ActivityIndicator size="large" color={colors.bill} />
+        <Text style={s.loadingText}>Loading sponsor profile…</Text>
+      </View>
+    );
+  }
+
+  if (query.isError || !query.data) {
+    return (
+      <View style={s.screen}>
+        <NavHeader title="Bill sponsor" onBack={() => router.back()} />
+        <View style={s.fullCenter}>
+          <Text style={s.errorTitle}>Sponsor profile unavailable</Text>
+          <Text style={s.errorText}>
+            This bill does not include sponsor information yet.
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  const { sponsor, sponsoredBills, sourceUrl } = query.data;
+  const location = [
+    sponsor.state,
+    sponsor.district && `District ${sponsor.district}`,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  return (
+    <View style={s.screen}>
+      <NavHeader title="Bill sponsor" onBack={() => router.back()} />
+      <ScrollView
+        style={s.scroll}
+        contentContainerStyle={s.content}
+        showsVerticalScrollIndicator={false}
+      >
+        <Card style={s.hero}>
+          <Avatar name={sponsor.initials} size={76} />
+          <Text style={s.eyebrow}>Primary sponsor</Text>
+          <Text style={s.name}>{sponsor.name}</Text>
+          <Text style={s.role}>{sponsor.role}</Text>
+          {sponsor.party || location ? (
+            <Text style={s.meta}>
+              {[sponsor.party, location].filter(Boolean).join(" · ")}
+            </Text>
+          ) : null}
+        </Card>
+
+        <View style={s.section}>
+          <Kicker>About this role</Kicker>
+          <Card>
+            <Text style={s.body}>
+              The primary sponsor is the member of Congress who formally
+              introduced the bill. Sponsors guide legislation through the
+              process, while other members may join as cosponsors.
+            </Text>
+          </Card>
+        </View>
+
+        <View style={s.section}>
+          <Kicker>{`Sponsored legislation · ${sponsoredBills.length}`}</Kicker>
+          <View style={s.billList}>
+            {sponsoredBills.map((bill) => (
+              <ContentCard
+                key={bill.id}
+                item={{
+                  id: bill.id,
+                  type: "bill",
+                  tag: bill.billNumber,
+                  title: bill.title,
+                  gist: bill.description,
+                  status: bill.status,
+                  updated: bill.introducedDate
+                    ? `Introduced ${formatDate(bill.introducedDate)}`
+                    : undefined,
+                  thumbnailUrl: bill.thumbnailUrl,
+                }}
+                onPress={() =>
+                  router.push({
+                    pathname: "/article-detail",
+                    params: { id: bill.id },
+                  })
+                }
+              />
+            ))}
+          </View>
+        </View>
+
+        <PrimaryButton
+          label="View official bill record"
+          icon="external"
+          onPress={() => void Linking.openURL(sourceUrl)}
+          style={s.sourceButton}
+        />
+      </ScrollView>
+    </View>
+  );
+}
+
+const s = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: planes.navy },
+  scroll: { flex: 1 },
+  content: { paddingHorizontal: 20, paddingBottom: 40 },
+  fullCenter: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 24,
+    backgroundColor: planes.navy,
+  },
+  loadingText: {
+    marginTop: 14,
+    fontFamily: fontBody.regular,
+    color: colors.textSecondary,
+  },
+  errorTitle: {
+    fontFamily: fontDisplay.bold,
+    fontSize: 22,
+    color: colors.white,
+  },
+  errorText: {
+    marginTop: 8,
+    textAlign: "center",
+    fontFamily: fontBody.regular,
+    color: colors.textSecondary,
+  },
+  hero: { alignItems: "center", paddingVertical: 24 },
+  eyebrow: {
+    marginTop: 14,
+    fontFamily: fontBody.semibold,
+    fontSize: 11,
+    letterSpacing: 0.7,
+    textTransform: "uppercase",
+    color: colors.bill,
+  },
+  name: {
+    marginTop: 5,
+    textAlign: "center",
+    fontFamily: fontDisplay.bold,
+    fontSize: 28,
+    lineHeight: 34,
+    color: colors.white,
+  },
+  role: {
+    marginTop: 5,
+    fontFamily: fontBody.semibold,
+    fontSize: 14,
+    color: colors.white,
+  },
+  meta: {
+    marginTop: 3,
+    fontFamily: fontBody.regular,
+    fontSize: 13,
+    color: colors.textSecondary,
+  },
+  section: { marginTop: 24 },
+  body: {
+    fontFamily: fontBody.regular,
+    fontSize: 15,
+    lineHeight: 22,
+    color: "rgba(255,255,255,0.86)",
+  },
+  billList: { gap: 12 },
+  sourceButton: { marginTop: 24, width: "100%" },
+});

--- a/packages/api/src/lib/bill-sponsor.test.ts
+++ b/packages/api/src/lib/bill-sponsor.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseBillSponsor, sponsorRole } from "./bill-sponsor";
+
+void test("parses scraper sponsor labels", () => {
+  assert.deepEqual(parseBillSponsor("John Smith (D-CA)"), {
+    raw: "John Smith (D-CA)",
+    name: "John Smith",
+    initials: "JS",
+    partyCode: "D",
+    party: "Democratic",
+    state: "CA",
+    district: undefined,
+  });
+});
+
+void test("parses seeded labels with titles and districts", () => {
+  assert.deepEqual(parseBillSponsor("Rep. Maria Torres (R-TX-12)"), {
+    raw: "Rep. Maria Torres (R-TX-12)",
+    name: "Maria Torres",
+    initials: "MT",
+    partyCode: "R",
+    party: "Republican",
+    state: "TX",
+    district: "12",
+  });
+});
+
+void test("keeps a useful name when metadata is unavailable", () => {
+  assert.deepEqual(parseBillSponsor("Sen. Jane Doe"), {
+    raw: "Sen. Jane Doe",
+    name: "Jane Doe",
+    initials: "JD",
+    partyCode: undefined,
+    party: undefined,
+    state: undefined,
+    district: undefined,
+  });
+});
+
+void test("maps bill chamber to the sponsor's role", () => {
+  assert.equal(sponsorRole("Senate"), "U.S. Senator");
+  assert.equal(sponsorRole("House"), "U.S. Representative");
+});

--- a/packages/api/src/lib/bill-sponsor.ts
+++ b/packages/api/src/lib/bill-sponsor.ts
@@ -1,0 +1,50 @@
+export interface BillSponsorIdentity {
+  raw: string;
+  name: string;
+  initials: string;
+  partyCode?: string;
+  party?: string;
+  state?: string;
+  district?: string;
+}
+
+const PARTY_NAMES: Record<string, string> = {
+  D: "Democratic",
+  R: "Republican",
+  I: "Independent",
+  L: "Libertarian",
+};
+
+/** Parse the normalized sponsor label stored by the Congress.gov scraper. */
+export function parseBillSponsor(raw: string): BillSponsorIdentity {
+  const value = raw.trim();
+  const match = /^(.*?)\s*\(([^)]+)\)\s*$/.exec(value);
+  const name = (match?.[1] ?? value)
+    .replace(/^(?:Rep(?:resentative)?|Sen(?:ator)?)\.?\s+/i, "")
+    .trim();
+  const [partyCode, state, ...districtParts] = (match?.[2] ?? "")
+    .split("-")
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const nameParts = name.split(/\s+/).filter(Boolean);
+  const initials = [nameParts[0], nameParts.at(-1)]
+    .filter(Boolean)
+    .map((part) => part?.[0]?.toUpperCase())
+    .join("");
+
+  return {
+    raw: value,
+    name,
+    initials,
+    partyCode,
+    party: partyCode ? (PARTY_NAMES[partyCode] ?? partyCode) : undefined,
+    state,
+    district: districtParts.length > 0 ? districtParts.join("-") : undefined,
+  };
+}
+
+export function sponsorRole(chamber?: string | null): string {
+  return chamber?.toLowerCase() === "senate"
+    ? "U.S. Senator"
+    : "U.S. Representative";
+}

--- a/packages/api/src/router/content.ts
+++ b/packages/api/src/router/content.ts
@@ -12,6 +12,7 @@ import {
   Video,
 } from "@acme/db/schema";
 
+import { parseBillSponsor, sponsorRole } from "../lib/bill-sponsor";
 import { protectedProcedure, publicProcedure } from "../trpc";
 
 const SAVED_CONTENT_TYPES = [
@@ -560,6 +561,12 @@ export const contentRouter = {
         .limit(1);
       if (bill[0]) {
         const b = bill[0];
+        const sponsor = b.sponsor
+          ? {
+              ...parseBillSponsor(b.sponsor),
+              role: sponsorRole(b.chamber),
+            }
+          : undefined;
         const [result] = await attachVideoImages([
           {
             id: b.id,
@@ -569,6 +576,7 @@ export const contentRouter = {
             isAIGenerated: !!b.aiGeneratedArticle,
             thumbnailUrl: b.thumbnailUrl ?? undefined,
             billNumber: b.billNumber,
+            sponsor,
             articleContent:
               b.aiGeneratedArticle ?? b.fullText ?? "No content available",
             originalContent: b.fullText ?? "Full text not available",
@@ -645,6 +653,53 @@ export const contentRouter = {
       }
 
       throw new Error(`Content with id ${input.id} not found`);
+    }),
+
+  // Profile and related legislation for the member who formally sponsored a bill.
+  getSponsorProfile: publicProcedure
+    .input(z.object({ billId: z.string().uuid() }))
+    .query(async ({ input }) => {
+      const [bill] = await db
+        .select()
+        .from(Bill)
+        .where(eq(Bill.id, input.billId))
+        .limit(1);
+
+      if (!bill) throw new Error(`Bill with id ${input.billId} not found`);
+      if (!bill.sponsor) return null;
+
+      const sponsoredBills = await db
+        .select({
+          id: Bill.id,
+          title: Bill.title,
+          description: Bill.description,
+          summary: Bill.summary,
+          billNumber: Bill.billNumber,
+          status: Bill.status,
+          thumbnailUrl: Bill.thumbnailUrl,
+          introducedDate: Bill.introducedDate,
+        })
+        .from(Bill)
+        .where(eq(Bill.sponsor, bill.sponsor))
+        .orderBy(desc(Bill.introducedDate), desc(Bill.createdAt))
+        .limit(20);
+
+      return {
+        sponsor: {
+          ...parseBillSponsor(bill.sponsor),
+          role: sponsorRole(bill.chamber),
+        },
+        sourceUrl: bill.url,
+        sponsoredBills: sponsoredBills.map((item) => ({
+          id: item.id,
+          title: item.title,
+          description: item.description ?? item.summary ?? "",
+          billNumber: item.billNumber,
+          status: item.status ?? undefined,
+          thumbnailUrl: item.thumbnailUrl ?? undefined,
+          introducedDate: item.introducedDate?.toISOString(),
+        })),
+      };
     }),
 
   // --- Saved Articles ---


### PR DESCRIPTION
## What changed

- adds a tappable **Sponsored by** card to federal bill details
- adds a dedicated sponsor profile with party, state, chamber role, and related sponsored bills
- exposes structured sponsor metadata and related legislation through the content API
- adds focused parsing coverage for Congress.gov and seeded sponsor formats

## Why

Bill readers should be able to see who formally introduced the legislation and explore that sponsor in the same way ballot readers can inspect candidate details.

## User impact

Users can move directly from a bill to its sponsor profile, understand the sponsor's role, and open other bills attributed to the same sponsor. Bills without sponsor metadata continue to render unchanged.

## Validation

- Expo TypeScript check
- API TypeScript check
- Expo and API ESLint on changed files
- Prettier and `git diff --check`
- sponsor parser tests (4 passing)
