### PR TITLE
Make Terms and Privacy reachable in production builds

### DIFF
--- a/apps/expo/src/app/(tabs)/feedback.tsx
+++ b/apps/expo/src/app/(tabs)/feedback.tsx
@@ -8,6 +8,7 @@ import {
   TouchableOpacity,
   View,
 } from "react-native";
+import { useRouter } from "expo-router";
 
 import type { IconName } from "~/components/ui";
 import { Text } from "~/components/Themed";
@@ -83,6 +84,7 @@ async function openFeedbackForm(url: string): Promise<boolean> {
 }
 
 export default function FeedbackScreen() {
+  const router = useRouter();
   const [cat, setCat] = useState<FeedbackCategory>("bug");
   const [text, setText] = useState("");
   const message = text.trim();
@@ -220,6 +222,16 @@ export default function FeedbackScreen() {
           onPress={emailDirect}
           style={{ alignSelf: "center" }}
         />
+
+        {/* The Settings tab is hidden in production, so this is the only way
+            to reach the legal copy in a release build. */}
+        <TouchableOpacity
+          onPress={() => router.push("/settings/terms")}
+          activeOpacity={0.7}
+          style={s.legalLink}
+        >
+          <Text style={s.legalLinkText}>Terms and Privacy Policy</Text>
+        </TouchableOpacity>
       </View>
     </TabScreen>
   );
@@ -227,6 +239,13 @@ export default function FeedbackScreen() {
 
 const s = StyleSheet.create({
   body: { paddingHorizontal: 20, paddingTop: 18 },
+  legalLink: { alignSelf: "center", marginTop: 26, paddingVertical: 8 },
+  legalLinkText: {
+    fontFamily: "AlbertSans-Medium",
+    fontSize: 12.5,
+    color: colors.textSecondary,
+    textDecorationLine: "underline",
+  },
   title: {
     fontFamily: "InriaSerif-Bold",
     fontSize: 19,

--- a/docs/legal/data-inventory.md
+++ b/docs/legal/data-inventory.md
@@ -60,8 +60,15 @@ Reachability (acceptance criterion — "reachable over public HTTPS"):
 
 - `https://billion-news.app/privacy` → 200, "Privacy Policy" ✓ (route live)
 - `https://billion-news.app/terms` → 200, "Terms of Service" ✓ (route live)
-- In-app: `Settings → Privacy → Read full Privacy Policy`, and `Settings → About Billion →
-Privacy policy / Terms of service` (`settings/terms`) ✓
+- In-app (**production**): `Feedback tab → Terms and Privacy Policy` → `settings/terms` ✓
+- In-app (dev only): `Settings → Privacy → Read full Privacy Policy`, and
+  `Settings → About Billion → Privacy policy / Terms of service`
+
+> ⚠️ **The Settings tab is hidden in release builds** (`(tabs)/_layout.tsx` sets
+> `href: __DEV__ ? undefined : null`, and `TabBar.tsx` skips it when `!__DEV__`). Settings was
+> the only route into the legal copy, so before the Feedback-tab link above, Terms and Privacy
+> were unreachable in production. Keep a legal entry point on a tab that ships, or this
+> acceptance criterion silently regresses.
 
 > ⚠️ **Redeploy required.** As of 2026-07-23 the live pages still serve the previous copy
 > ("Last updated April 5, 2026"). The revised text in this repo goes live only after
@@ -179,3 +186,11 @@ and `eas metadata:push`. Minimal shape:
 - **Stray `billion.app` references** in non-shipped code: scraper/measure-source `User-Agent`
   strings and a `civic@billion.app` address (`apps/scraper/...`, `packages/api/src/lib/measure-sources/*`,
   `candidate-sources/*`). Not user-visible, but they point at a domain we don't own.
+- **Two different contact addresses.** The legal copy tells users to email
+  `thatxliner@gmail.com`, but the production-visible Feedback tab uses
+  `billionnewsapp@gmail.com` (`(tabs)/feedback.tsx`). Pick one for the public-facing
+  privacy/support contact so the policy, the app, and the App Store Support URL agree.
+- **No acceptance gate.** There is no onboarding or first-launch flow, so users never
+  affirmatively accept the Terms. Not required by Apple for a no-account, read-only app, but a
+  first-launch notice ("By continuing you agree to…") linking both documents would materially
+  improve enforceability. Revisit before accounts, purchases, or EU availability.


### PR DESCRIPTION
Follow-up to #192. Closes the last open acceptance criterion on #127: "Terms and Privacy are reachable in-app."

## The problem

The Settings tab is hidden in release builds, in two places:

- `(tabs)/_layout.tsx` — `href: __DEV__ ? undefined : null`
- `TabBar.tsx` — `if (!__DEV__ && route.name === "settings") return null;`

Settings was the **only** route into the legal copy — every push to `/settings/terms` or `/settings/privacy` originates inside the Settings tree (`(tabs)/settings.tsx`, `settings/about.tsx`, `settings/privacy.tsx`). No other tab links to it. So in a production build, Terms and the Privacy Policy were unreachable, even though #192 rewrote them.

This is pre-existing (from `ca6b559`, "fix(expo): hide settings tab in production") — #192 just didn't catch it.

## The fix

Add a "Terms and Privacy Policy" link at the bottom of the **Feedback** tab, which does ship in production. `/settings/terms` lives in `app/settings/` — a root stack route, not inside the `(tabs)` group — so pushing to it works fine while the Settings tab stays hidden.

Deliberately **not** un-hiding Settings: it's hidden for good reason, since it still exposes login-only features (Edit Profile, Saved Articles, Blocked Content) that don't work in this no-account release.

The data inventory now records the hidden-tab constraint, so this doesn't silently regress.

## Two follow-ups found while checking (not fixed here)

- **Two contact addresses.** The legal copy points users at `thatxliner@gmail.com`, but the Feedback tab uses `billionnewsapp@gmail.com`. Worth picking one so the policy, the app, and the App Store Support URL agree.
- **No acceptance gate.** There's no onboarding or first-launch flow, so users never affirmatively accept the Terms. Not required by Apple for a no-account read-only app, but a first-launch "By continuing you agree to…" notice would materially improve enforceability. Happy to add it if wanted.

Both are logged in `docs/legal/data-inventory.md` §6.

## Verification

- `prettier --check` passes on both changed files with the repo config.
- Route target confirmed: `app/settings/terms.tsx` exists and renders both documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
