### PR TITLE
Add pull-to-refresh to Browse and Feed

### DIFF
--- a/apps/expo/src/app/(tabs)/feed.tsx
+++ b/apps/expo/src/app/(tabs)/feed.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -28,7 +28,7 @@ import {
   planes,
   resolveType,
 } from "~/styles";
-import { queryClient, trpc } from "~/utils/api";
+import { queryClient, trpc, trpcClient } from "~/utils/api";
 import { authClient } from "~/utils/auth";
 
 const { height: SCREEN_H, width: SCREEN_W } = Dimensions.get("window");
@@ -218,6 +218,8 @@ function FeedCard({
 export default function FeedScreen() {
   const router = useRouter();
   const insets = useSafeAreaInsets();
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const refreshInFlight = useRef(false);
 
   const {
     data,
@@ -244,6 +246,37 @@ export default function FeedScreen() {
 
   const loadMore = () => {
     if (hasNextPage && !isFetchingNextPage) void fetchNextPage();
+  };
+
+  const handleRefresh = async () => {
+    if (refreshInFlight.current) return;
+
+    refreshInFlight.current = true;
+    setIsRefreshing(true);
+
+    try {
+      const input = { limit: 10 };
+      const firstPage = await trpcClient.video.getInfinite.query({
+        ...input,
+        cursor: 0,
+      });
+      queryClient.setQueryData(trpc.video.getInfinite.infiniteQueryKey(input), {
+        pages: [firstPage],
+        pageParams: [0],
+      });
+    } catch {
+      Alert.alert(
+        "Unable to refresh",
+        "Your current feed is still available.",
+        [
+          { text: "Cancel", style: "cancel" },
+          { text: "Try Again", onPress: () => void handleRefresh() },
+        ],
+      );
+    } finally {
+      refreshInFlight.current = false;
+      setIsRefreshing(false);
+    }
   };
 
   if (isPending) {
@@ -290,7 +323,9 @@ export default function FeedScreen() {
         snapToInterval={SCREEN_H}
         snapToAlignment="start"
         decelerationRate="fast"
-        bounces={false}
+        alwaysBounceVertical
+        refreshing={isRefreshing}
+        onRefresh={() => void handleRefresh()}
         onEndReached={loadMore}
         onEndReachedThreshold={0.5}
         getItemLayout={(_d, index) => ({

--- a/apps/expo/src/app/(tabs)/index.tsx
+++ b/apps/expo/src/app/(tabs)/index.tsx
@@ -4,10 +4,11 @@ import {
   ActivityIndicator,
   Alert,
   FlatList,
+  RefreshControl,
   StyleSheet,
   View,
 } from "react-native";
-import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 
@@ -74,8 +75,6 @@ export default function BrowseScreen() {
   const election = voterInfoQuery.data?.election;
   const upcomingElection =
     election && isWithinDays(election.electionDay, 30) ? election : undefined;
-
-  const insets = useSafeAreaInsets();
 
   const {
     data,
@@ -170,18 +169,23 @@ export default function BrowseScreen() {
   };
 
   return (
-    <View style={s.screen}>
+    <SafeAreaView style={s.screen} edges={["top"]}>
       <FlatList
         data={items}
         keyExtractor={(item) => item.id}
         contentContainerStyle={{
-          paddingTop: insets.top + 4,
+          paddingTop: 4,
           paddingBottom: 120,
         }}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
-        refreshing={isRefreshing}
-        onRefresh={() => void handleRefresh()}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={() => void handleRefresh()}
+            tintColor={colors.white}
+          />
+        }
         ListHeaderComponent={
           <>
             <View style={s.headerPad}>
@@ -267,7 +271,7 @@ export default function BrowseScreen() {
           )
         }
       />
-    </View>
+    </SafeAreaView>
   );
 }
 

--- a/apps/expo/src/app/(tabs)/index.tsx
+++ b/apps/expo/src/app/(tabs)/index.tsx
@@ -1,6 +1,12 @@
 import type { Href } from "expo-router";
-import { useMemo, useState } from "react";
-import { ActivityIndicator, FlatList, StyleSheet, View } from "react-native";
+import { useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  FlatList,
+  StyleSheet,
+  View,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
@@ -15,7 +21,7 @@ import { posthog } from "~/config/posthog";
 import { useDebounced } from "~/hooks/useDebounce";
 import { useUserAddress } from "~/hooks/useUserAddress";
 import { colors, fontBody, fontDisplay, planes } from "~/styles";
-import { trpc } from "~/utils/api";
+import { queryClient, trpc, trpcClient } from "~/utils/api";
 import { toCardItem } from "~/utils/content";
 import { daysUntil, isWithinDays } from "~/utils/dates";
 
@@ -37,6 +43,8 @@ export default function BrowseScreen() {
   const router = useRouter();
   const [filter, setFilter] = useState<VideoPost["type"] | "all">("all");
   const [query, setQuery] = useState("");
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const refreshInFlight = useRef(false);
 
   const handleFilterChange = (f: VideoPost["type"] | "all") => {
     setFilter(f);
@@ -115,6 +123,52 @@ export default function BrowseScreen() {
     if (hasNextPage && !isFetchingNextPage) void fetchNextPage();
   };
 
+  const handleRefresh = async () => {
+    if (refreshInFlight.current) return;
+
+    refreshInFlight.current = true;
+    setIsRefreshing(true);
+
+    try {
+      if (isSearching) {
+        const input = {
+          query: debouncedQuery,
+          type: filter,
+        };
+        const refreshedItems = await trpcClient.content.search.query(input);
+        queryClient.setQueryData(
+          trpc.content.search.queryKey(input),
+          refreshedItems,
+        );
+      } else {
+        const input = { type: filter, limit: PAGE_SIZE };
+        const firstPage = await trpcClient.content.getByType.query({
+          ...input,
+          cursor: 0,
+        });
+        queryClient.setQueryData(
+          trpc.content.getByType.infiniteQueryKey(input),
+          {
+            pages: [firstPage],
+            pageParams: [0],
+          },
+        );
+      }
+    } catch {
+      Alert.alert(
+        "Unable to refresh",
+        "Your current results are still available.",
+        [
+          { text: "Cancel", style: "cancel" },
+          { text: "Try Again", onPress: () => void handleRefresh() },
+        ],
+      );
+    } finally {
+      refreshInFlight.current = false;
+      setIsRefreshing(false);
+    }
+  };
+
   return (
     <View style={s.screen}>
       <FlatList
@@ -126,6 +180,8 @@ export default function BrowseScreen() {
         }}
         showsVerticalScrollIndicator={false}
         keyboardShouldPersistTaps="handled"
+        refreshing={isRefreshing}
+        onRefresh={() => void handleRefresh()}
         ListHeaderComponent={
           <>
             <View style={s.headerPad}>

--- a/apps/expo/src/utils/api.tsx
+++ b/apps/expo/src/utils/api.tsx
@@ -19,31 +19,33 @@ export const queryClient = new QueryClient({
 /**
  * A set of typesafe hooks for consuming your API.
  */
-export const trpc = createTRPCOptionsProxy<AppRouter>({
-  client: createTRPCClient<AppRouter>({
-    links: [
-      loggerLink({
-        enabled: (opts) =>
-          process.env.NODE_ENV === "development" ||
-          (opts.direction === "down" && opts.result instanceof Error),
-        colorMode: "ansi",
-      }),
-      httpBatchLink({
-        transformer: superjson,
-        url: `${getBaseUrl()}/api/trpc`,
-        headers() {
-          const headers = new Map<string, string>();
-          headers.set("x-trpc-source", "expo-react");
+export const trpcClient = createTRPCClient<AppRouter>({
+  links: [
+    loggerLink({
+      enabled: (opts) =>
+        process.env.NODE_ENV === "development" ||
+        (opts.direction === "down" && opts.result instanceof Error),
+      colorMode: "ansi",
+    }),
+    httpBatchLink({
+      transformer: superjson,
+      url: `${getBaseUrl()}/api/trpc`,
+      headers() {
+        const headers = new Map<string, string>();
+        headers.set("x-trpc-source", "expo-react");
 
-          const cookies = authClient.getCookie();
-          if (cookies) {
-            headers.set("Cookie", cookies);
-          }
-          return headers;
-        },
-      }),
-    ],
-  }),
+        const cookies = authClient.getCookie();
+        if (cookies) {
+          headers.set("Cookie", cookies);
+        }
+        return headers;
+      },
+    }),
+  ],
+});
+
+export const trpc = createTRPCOptionsProxy<AppRouter>({
+  client: trpcClient,
   queryClient,
 });
 


### PR DESCRIPTION
## Summary

- add native pull-to-refresh to Browse and Feed
- refresh the active Browse filter or search query without clearing visible results
- atomically replace infinite-query data with a fresh first page so pagination resets cleanly
- prevent overlapping refreshes and offer an immediate retry after failures
- keep Feed pull gestures compatible with its paged list
- place the Browse list itself below the top safe area so the native iOS refresh indicator appears below the Dynamic Island

## Why

Users need to refresh production content without restarting the app. Previously, both lists relied only on initial loading and infinite-scroll pagination, so there was no explicit way to request current data.

Browse previously simulated its top safe area with content padding. That moved the list content but left the native refresh control attached to the full-screen scroll view behind the Dynamic Island. Wrapping the list in a top-edge `SafeAreaView` fixes the layout model without manually offsetting the spinner.

## Impact

Successful refreshes replace the list with current first-page results and subsequent scrolling continues from the new cursor. Failed refreshes leave the last successful content readable and show a recoverable error. The Browse refresh indicator now remains visible on modern iPhones.

## Validation

- `pnpm -F @acme/expo format`
- `pnpm -F @acme/expo lint`
- `pnpm -F @acme/expo typecheck`
- `git diff --check`
- manually confirmed Browse pull-to-refresh and spinner placement in the iOS Simulator

Closes #148