### PR TITLE
Fix broken db seed and silent test discovery in the scraper

### DIFF
--- a/apps/scraper/package.json
+++ b/apps/scraper/package.json
@@ -41,7 +41,7 @@
     "start:dev": "tsx src/entry.ts",
     "build": "pnpm run typecheck && vite build",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test src/**/*.test.ts",
+    "test": "tsx --test \"src/**/*.test.ts\"",
     "retroactive-lenses": "tsx src/retroactive-lenses-entry.ts",
     "reprocess-content": "tsx src/reprocess-content-entry.ts",
     "retroactive-videos": "tsx src/retroactive-videos-entry.ts",

--- a/packages/db/seed.ts
+++ b/packages/db/seed.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 
+import { clampBillDescription } from "./src/bill-description";
 import { db } from "./src/client";
 import { Bill, CourtCase, GovernmentContent, Video } from "./src/schema";
 
@@ -202,6 +203,12 @@ Housing advocates strongly support the bill but want even more aggressive zoning
   },
 ].map((b) => ({
   ...b,
+  // `bill.description` is capped at 100 characters by a check constraint, and
+  // every fixture above was written longer, so the very first insert aborted
+  // the whole seed. Clamp with the same helper the scraper and API use rather
+  // than hand-trimming the prose: the fixtures stay readable here, and what
+  // lands in the table matches what a real scraped row looks like.
+  description: clampBillDescription(b.description),
   contentHash: hash(b.title + b.fullText),
   versions: [],
 }));


### PR DESCRIPTION
Two independent bugs, both live on `main` today. Split out of #198 so they can land on their own.

## 1. `pnpm db:seed` fails outright

Every one of the five fixture bill descriptions runs 119–135 characters, and `bill.description` is capped at 100 by the `bill_description_max_100_chars` check constraint:

```
H.R. 1001   132 chars  OVER LIMIT
S. 502      135 chars  OVER LIMIT
H.R. 2200   119 chars  OVER LIMIT
S. 789      124 chars  OVER LIMIT
H.R. 3456   129 chars  OVER LIMIT
```

The bills insert is the first statement in `seed()`, so it aborts the whole run — **nothing** gets seeded. Not bills, not government content, not court cases, not the video feed rows.

This is on the contributor onboarding path. `pnpm onboard` asks *"Seed sample feed content for local development?"*, and everyone who says yes gets `Sample-data seed failed.` and an empty database.

**Fix:** clamp with `clampBillDescription` — the same helper the scraper and API already use — rather than hand-trimming the five strings. The fixtures stay readable as prose in the file, what lands in the table matches what a real scraped row looks like, and the invariant now holds by construction: you can't reintroduce the bug without deleting the clamp.

Result (truncates on word boundaries, as intended):

```
H.R. 1001 | 99 | A bill to authorize funding for the repair and modernization of roads, bridges, and public transit…
S. 502    | 98 | A bill to establish comprehensive federal data privacy protections for consumers and regulate the…
```

## 2. `pnpm test` in the scraper silently skips half the suite

The glob in `tsx --test src/**/*.test.ts` is unquoted, so the shell expands it before `tsx` ever sees it — and sh's `**` behaves like `*`, matching exactly one directory level:

```
$ sh -c 'echo src/**/*.test.ts'
src/utils/bill-description.test.ts src/utils/reprocessing-policy.test.ts
```

`src/env.test.ts` and `src/scraper-contracts.test.ts` were never collected, and anything nested deeper than `src/utils/` never would be. **2 of 4 files ran, and the suite reported green the whole time** — which is the dangerous part: a broken test in an uncollected file looks identical to a passing one.

**Fix:** quote the pattern so globbing is handled by Node's test runner, which walks recursively.

| | before | after |
| --- | --- | --- |
| files collected | 2 of 4 | 4 of 4 |
| tests discovered | 7 | 17 |

## Verification

Both reproduced on a clean checkout of `main` first, then re-run after the fix:

- Seed: applied migrations to a throwaway local Postgres, confirmed the constraint violation and zero rows inserted; after the fix, 5 bills / 4 gov content / 3 court cases / 12 videos insert cleanly. Inspected the clamped descriptions directly in the table.
- Tests: 7 → 17 discovered, all passing.
- Full monorepo typecheck, lint, and format pass.

## Note on #198

#198 currently carries both of these fixes too — it needed the seed working to verify its own changes. Once this merges, I can rebase #198 to drop them, or leave it and resolve the (identical-content) conflict at merge time. Happy to do whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)