### PR TITLE
fix(expo): stop render errors from killing the app

### DIFF
--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -31,12 +31,17 @@ import {
 import { QueryClientProvider } from "@tanstack/react-query";
 import { PostHogProvider } from "posthog-react-native";
 
+import { createRouteErrorBoundary } from "~/components/RouteErrorBoundary";
 import { posthog } from "~/config/posthog";
 import { useTheme } from "~/styles";
 import { queryClient } from "~/utils/api";
 import { authClient } from "~/utils/auth";
 
 import "../styles.css";
+
+// Last line of defence: catches render errors from any screen that doesn't
+// have its own boundary. Without one, React Native aborts the process.
+export const ErrorBoundary = createRouteErrorBoundary("root");
 
 // Keep splash screen visible while fonts load
 void SplashScreen.preventAutoHideAsync();

--- a/apps/expo/src/app/article-detail.tsx
+++ b/apps/expo/src/app/article-detail.tsx
@@ -16,6 +16,7 @@ import Markdown from "@ronradtke/react-native-markdown-display";
 import { useMutation, useQuery } from "@tanstack/react-query";
 
 import type { BillBriefData, BriefQuote } from "~/components/ui";
+import { createRouteErrorBoundary } from "~/components/RouteErrorBoundary";
 import { Text } from "~/components/Themed";
 import {
   Avatar,
@@ -48,6 +49,8 @@ import { queryClient, trpc } from "~/utils/api";
 import { authClient } from "~/utils/auth";
 import { formatDate } from "~/utils/dates";
 import { editorialVisualFor } from "~/utils/editorial-visuals";
+
+export const ErrorBoundary = createRouteErrorBoundary("article-detail");
 
 export default function ArticleDetailScreen() {
   const router = useRouter();
@@ -274,8 +277,13 @@ export default function ArticleDetailScreen() {
   const brief: BillBriefData | null =
     "brief" in content ? (content.brief as BillBriefData | null) : null;
 
-  const activeContent =
+  const rawContent =
     mode === "explainer" ? content.articleContent : content.originalContent;
+  // The types say this is a string, but the router has no `.output()` schema,
+  // so nothing enforces that at runtime. `.includes`/`.length` on a null would
+  // take the whole app down rather than render an empty article.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- guards an unvalidated API response
+  const activeContent = rawContent ?? "";
   const looksLikeMarkdown =
     /^#{1,6}\s/m.test(activeContent) ||
     /\[[^\]]+\]\((https?:\/\/|\/)/.test(activeContent) ||

--- a/apps/expo/src/components/RouteErrorBoundary.tsx
+++ b/apps/expo/src/components/RouteErrorBoundary.tsx
@@ -1,0 +1,80 @@
+/**
+ * Recovery UI for a route that threw while rendering.
+ *
+ * Without a boundary, React Native treats an uncaught render error as fatal:
+ * it goes to RCTFatal and the app is SIGABRT'd. That turned a single bad
+ * content row into a crash loop for a TestFlight user in 0.4.3. Routes that
+ * export this get a retry instead, and the error reaches PostHog either way.
+ */
+import type { ErrorBoundaryProps } from "expo-router";
+import { StyleSheet, View } from "react-native";
+import { useRouter } from "expo-router";
+
+import { Text } from "~/components/Themed";
+import { GhostButton, PrimaryButton } from "~/components/ui";
+import { posthog } from "~/config/posthog";
+import { colors, fontBody, fontDisplay, planes } from "~/styles";
+
+/**
+ * Build a route-level `ErrorBoundary` export.
+ *
+ * `routeName` is only used to tag the captured exception, so the same crash on
+ * two different screens doesn't collapse into one issue in PostHog.
+ */
+export function createRouteErrorBoundary(routeName: string) {
+  return function RouteErrorBoundary({ error, retry }: ErrorBoundaryProps) {
+    const router = useRouter();
+
+    // Render-phase capture is intentional: the boundary renders once per error,
+    // and deferring to an effect risks losing the report if the user leaves
+    // before it flushes.
+    posthog.captureException(error, { route: routeName });
+
+    return (
+      <View style={s.screen}>
+        <Text style={s.title}>Something went wrong</Text>
+        <Text style={s.body}>
+          This screen couldn&apos;t be displayed. The problem has been reported.
+        </Text>
+        <PrimaryButton
+          label="Try again"
+          onPress={() => void retry()}
+          style={s.action}
+        />
+        {router.canGoBack() && (
+          <GhostButton
+            label="Go back"
+            onPress={() => router.back()}
+            style={s.action}
+          />
+        )}
+      </View>
+    );
+  };
+}
+
+const s = StyleSheet.create({
+  screen: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 32,
+    backgroundColor: planes.navy,
+  },
+  title: {
+    fontFamily: fontDisplay.bold,
+    fontSize: 24,
+    color: colors.white,
+    textAlign: "center",
+  },
+  body: {
+    fontFamily: fontBody.regular,
+    fontSize: 14.5,
+    lineHeight: 21,
+    color: colors.textSecondary,
+    textAlign: "center",
+    marginTop: 10,
+    marginBottom: 24,
+  },
+  action: { width: 200, marginTop: 10 },
+});

--- a/apps/expo/src/config/posthog.ts
+++ b/apps/expo/src/config/posthog.ts
@@ -30,4 +30,12 @@ export const posthog = new PostHog(apiKey ?? "placeholder_key", {
   requestTimeout: 10000,
   fetchRetryCount: 3,
   fetchRetryDelay: 3000,
+  // Without this, a JS error that kills the app leaves no trace: the crash
+  // report only carries the ObjC abort path, not the JS message or stack.
+  errorTracking: {
+    autocapture: {
+      uncaughtExceptions: true,
+      unhandledRejections: true,
+    },
+  },
 });


### PR DESCRIPTION
## What happened

A TestFlight user on 0.4.3 (iPhone 8, iOS 16.7.16) hit a **crash loop** — three launches in 75 seconds. Reconstructed from their PostHog session (`distinct_id 019f972f-…`):

| Time (UTC) | |
|---|---|
| 02:51:35 | Install, first launch, screen `/` |
| 02:52:02–03.6 | `content_searched`: `Isr` → `Isra` → `Israe` → **`Israel`** |
| 02:52:14.8, 16.8, 17.7 | three taps |
| **02:52:19.32** | **crash** |
| 02:52:25 | relaunch → same `Israel` search → taps → **crash** → relaunch 02:52:49 |

No `$screen` for the destination and no `article_viewed`, so it died during `/article-detail`'s first render.

**Repro:** Browse → search "Israel" → tap *United States-Israel Agriculture Cooperation Improvement and Expansion Act* (H.R. 7587).

## Root cause

The crash log terminates via `RCTFatal ← -[RCTExceptionsManager reportFatal:] ← reportException:` with Hermes simultaneously inside `errorStackGetter` on the JS thread. That is React Native's uncaught-JavaScript-error path: `RCTFatal` raises an ObjC exception nothing catches → `std::terminate` → `abort()`.

The reporter's device is jailbroken (Dopamine, ElleKit, several TweakInject tweaks) and that was the initial suspicion — but **no tweak image appears in any frame** of the crashing stack or the JS stack, and a tweak fault would look like `EXC_BAD_ACCESS`, not a clean JS abort. The jailbreak is incidental.

What made it fatal rather than recoverable: **the app had no error boundary anywhere.** `git grep 'ErrorBoundary|componentDidCatch|getDerivedStateFromError'` over `apps/expo/src` and `packages/ui/src` returned nothing, at v0.4.3 and at HEAD. So any bad content row terminates the process instead of showing "couldn't load".

## Changes

- **`RouteErrorBoundary.tsx`** (new) — `createRouteErrorBoundary(routeName)` builds an expo-router `ErrorBoundary` export: themed recovery UI with retry + go-back, and reports to PostHog tagged by route so two screens don't collapse into one issue.
- **`_layout.tsx`** — root-level boundary as the catch-all.
- **`article-detail.tsx`** — its own boundary (the screen that crashed) so retry re-renders just that route.
- **`config/posthog.ts`** — enable `errorTracking.autocapture` for uncaught exceptions and unhandled rejections. There are currently **zero `$exception` events in the project** (queried Jul 1–28), which is why the actual JS error was never recorded.
- **`article-detail.tsx`** — default `activeContent` to `""`. Defensive, not a proven root cause: the types promise a string and the server does use `?? "No content available"`, but `_ContentDetailSchema` is never applied as a tRPC `.output()`, so nothing enforces it at runtime and `.includes`/`.length` on a null is an instant crash.

## Verification

`typecheck`, `lint` and `prettier --check` pass for `@acme/expo`. Typecheck passing is real signal on the `errorTracking` option — it's a typed field on `PostHogOptions`.

**Not runtime-verified** — I did not build and drive the app in a simulator, so the boundary catching a real throw is unexercised. Worth doing before release, e.g. by temporarily throwing in `ArticleDetailScreen`.

## Follow-ups not in this PR

- **Source maps** — stacks from autocapture will be unsymbolicated until `posthog-cli` upload is wired into the EAS build.
- **`imageUri` is a ~169 KB base64 data URI per item** (measured against prod). That's ~3.4 MB of JS strings per 20-item Browse page on a 2 GB iPhone 8. Not this crash — that would be a jetsam kill with a different signature — but it will bite.
- **Apply `_ContentDetailSchema` as a real `.output()`.** Deliberately skipped: zod strips unknown keys, and the schema is missing `sponsor`/`actions`/`status`/`lensData`/`brief`, so applying it as-is would silently drop those fields from the response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)