### PR TITLE
Stop losing bills and truncating the text we reason over

### DIFF
--- a/apps/scraper/src/main.ts
+++ b/apps/scraper/src/main.ts
@@ -35,6 +35,17 @@ const argv = await yargs(hideBin(process.argv))
     describe:
       "Maximum source records per scraper for this run; overrides the scraper-specific env value",
   })
+  .option("bill", {
+    alias: "b",
+    type: "string",
+    array: true,
+    describe:
+      'Fetch specific congress.gov bills by number (e.g. --bill "H.R. 7008"), ignoring the incremental update cursor. Repeatable. Requires the "congress" scraper',
+  })
+  .option("congress", {
+    type: "number",
+    describe: "Congress number for --bill (default: 119)",
+  })
   .check((args) => {
     const maxItems = args.maxItems;
     if (
@@ -45,6 +56,19 @@ const argv = await yargs(hideBin(process.argv))
     ) {
       throw new Error("--max-items must be a positive integer");
     }
+    const bills = args.bill;
+    if (bills?.length && args.scraper !== "congress") {
+      throw new Error('--bill requires the "congress" scraper');
+    }
+    if (args.congress !== undefined && !bills?.length) {
+      throw new Error("--congress only applies alongside --bill");
+    }
+    if (
+      args.congress !== undefined &&
+      (!Number.isInteger(args.congress) || args.congress <= 0)
+    ) {
+      throw new Error("--congress must be a positive integer");
+    }
     return true;
   })
   .help()
@@ -53,6 +77,8 @@ const argv = await yargs(hideBin(process.argv))
 const arg = argv.scraper as string;
 const concurrency = (argv as { concurrency: number }).concurrency;
 const maxItems = (argv as { maxItems?: number }).maxItems;
+const targets = (argv as { bill?: string[] }).bill;
+const congressNumber = (argv as { congress?: number }).congress;
 
 function logDatabaseTarget(): void {
   const target = databaseTarget(process.env.POSTGRES_URL!);
@@ -97,7 +123,7 @@ async function main() {
     }
     validateScraperEnv([scraper]);
     logDatabaseTarget();
-    await scraper.scrape({ maxItems });
+    await scraper.scrape({ maxItems, targets, congress: congressNumber });
     printMetricsSummary(scraper.name);
   }
 }

--- a/apps/scraper/src/retroactive-briefs.ts
+++ b/apps/scraper/src/retroactive-briefs.ts
@@ -27,6 +27,7 @@ interface BriefCandidate {
   billNumber: string;
   url: string;
   fullText: string;
+  summary: string | null;
   status: string | null;
   aiGeneratedArticle: string | null;
 }
@@ -40,6 +41,7 @@ async function findBills(limit: number): Promise<BriefCandidate[]> {
       billNumber: Bill.billNumber,
       url: Bill.url,
       fullText: Bill.fullText,
+      summary: Bill.summary,
       status: Bill.status,
       aiGeneratedArticle: Bill.aiGeneratedArticle,
     })
@@ -110,6 +112,7 @@ for (const candidate of candidates) {
       billNumber: candidate.billNumber,
       url: candidate.url,
       fullText: candidate.fullText,
+      officialSummary: candidate.summary,
       status: candidate.status,
       priorArticle: candidate.aiGeneratedArticle,
     });

--- a/apps/scraper/src/scrapers/congress.test.ts
+++ b/apps/scraper/src/scrapers/congress.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { parseBillIdentifier, parseBillUrl } from "./congress.js";
+import {
+  capToTsvectorLimit,
+  parseBillIdentifier,
+  parseBillUrl,
+} from "./congress.js";
 
 test("parseBillIdentifier accepts the forms people paste", () => {
   const expected = { billType: "hr", billNumber: "7008" };
@@ -42,4 +46,21 @@ test("parseBillIdentifier round-trips through parseBillUrl", () => {
     ),
     parsed,
   );
+});
+
+test("capToTsvectorLimit leaves normal bill text untouched", () => {
+  const text =
+    "SECTION 1. SHORT TITLE. This Act may be cited as the Example Act.";
+  assert.equal(capToTsvectorLimit(text, "H.R. 1"), text);
+});
+
+test("capToTsvectorLimit keeps oversized text under the tsvector byte ceiling", () => {
+  // Multibyte punctuation: a character-based slice would undercount bytes.
+  const huge = "section § one — text ".repeat(80_000);
+  assert.ok(Buffer.byteLength(huge, "utf8") > 1_048_575);
+
+  const capped = capToTsvectorLimit(huge, "H.R. 1");
+  assert.ok(Buffer.byteLength(capped, "utf8") <= 800_000);
+  assert.ok(capped.length > 0);
+  assert.doesNotMatch(capped, /\s$/u);
 });

--- a/apps/scraper/src/scrapers/congress.test.ts
+++ b/apps/scraper/src/scrapers/congress.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseBillIdentifier, parseBillUrl } from "./congress.js";
+
+test("parseBillIdentifier accepts the forms people paste", () => {
+  const expected = { billType: "hr", billNumber: "7008" };
+  assert.deepEqual(parseBillIdentifier("H.R. 7008"), expected);
+  assert.deepEqual(parseBillIdentifier("hr7008"), expected);
+  assert.deepEqual(parseBillIdentifier("HR 7008"), expected);
+  assert.deepEqual(parseBillIdentifier("  h.r.7008  "), expected);
+});
+
+test("parseBillIdentifier handles multi-part resolution types", () => {
+  assert.deepEqual(parseBillIdentifier("H.Con.Res. 113"), {
+    billType: "hconres",
+    billNumber: "113",
+  });
+  assert.deepEqual(parseBillIdentifier("S.J.Res. 5"), {
+    billType: "sjres",
+    billNumber: "5",
+  });
+  assert.deepEqual(parseBillIdentifier("S. 1"), {
+    billType: "s",
+    billNumber: "1",
+  });
+});
+
+test("parseBillIdentifier rejects unknown types and malformed input", () => {
+  assert.equal(parseBillIdentifier("H.X.Res. 12"), undefined);
+  assert.equal(parseBillIdentifier("7008"), undefined);
+  assert.equal(parseBillIdentifier("H.R."), undefined);
+  assert.equal(parseBillIdentifier("H.R. 70 08"), undefined);
+  assert.equal(parseBillIdentifier(""), undefined);
+});
+
+test("parseBillIdentifier round-trips through parseBillUrl", () => {
+  const parsed = parseBillIdentifier("H.R. 7008")!;
+  assert.deepEqual(
+    parseBillUrl(
+      `https://www.congress.gov/bill/119th-congress/house-bill/${parsed.billNumber}`,
+    ),
+    parsed,
+  );
+});

--- a/apps/scraper/src/scrapers/congress.ts
+++ b/apps/scraper/src/scrapers/congress.ts
@@ -2,6 +2,7 @@ import { eq, max } from "@acme/db";
 import { db } from "@acme/db/client";
 import { Bill } from "@acme/db/schema";
 
+import type { NewItemLimiter } from "../utils/new-item-limit.js";
 import type { Scraper } from "../utils/types.js";
 import { getItemLimit } from "../utils/concurrency.js";
 import { setExpectedTotal } from "../utils/db/metrics.js";
@@ -18,6 +19,8 @@ interface CongressScraperConfig {
   maxBills?: number;
   congress?: number;
   chamber?: "House" | "Senate";
+  /** Bill identifiers to fetch directly instead of walking the update feed. */
+  bills?: string[];
 }
 
 interface ApiBillListItem {
@@ -154,6 +157,29 @@ export function parseBillUrl(
   return { billType, billNumber: number };
 }
 
+const apiBillTypes = new Set(Object.values(urlSlugToApiType));
+
+/**
+ * Parse a human-written bill identifier into the congress.gov API's
+ * {billType, billNumber}. Punctuation and spacing within the type are ignored,
+ * so the forms people actually paste all work: "H.R. 7008", "hr7008",
+ * "H.Con.Res. 113". The number itself must be contiguous — otherwise a typo
+ * like "H.R. 70 08" would silently resolve to a different real bill.
+ */
+export function parseBillIdentifier(
+  input: string,
+): { billType: string; billNumber: string } | undefined {
+  const match = /^([a-z][a-z.\s]*?)[.\s]*(\d+)$/i.exec(input.trim());
+  if (!match) return undefined;
+  const billType = match[1]!.replace(/[.\s]/g, "").toLowerCase();
+  if (!apiBillTypes.has(billType)) return undefined;
+  return { billType, billNumber: match[2]! };
+}
+
+function chamberForBillType(billType: string): "House" | "Senate" {
+  return billType.startsWith("h") ? "House" : "Senate";
+}
+
 function stripHtml(html: string): string {
   return html
     .replace(/<[^>]+>/g, " ")
@@ -246,8 +272,142 @@ async function fetchActions(
   }
 }
 
+/**
+ * Fetch one bill's detail/summary/text/actions and upsert it. Shared by the
+ * incremental feed walk and the targeted `--bill` path.
+ */
+async function processBill(
+  congress: number,
+  billType: string,
+  billNumber: string,
+  fallbackChamber: "House" | "Senate",
+  newItemLimiter: NewItemLimiter,
+): Promise<void> {
+  const detailData = await congressFetch<ApiBillDetail>(
+    `/bill/${congress}/${billType}/${billNumber}`,
+  );
+  const detail = detailData.bill;
+
+  const formattedBillNumber = formatBillNumber(detail.type, detail.number);
+  const title = (detail.title ?? "Unknown").slice(0, 250);
+
+  const primarySponsor = detail.sponsors?.[0];
+  const sponsor = primarySponsor
+    ? `${primarySponsor.firstName} ${primarySponsor.lastName} (${primarySponsor.party}-${primarySponsor.state})`.slice(
+        0,
+        250,
+      )
+    : undefined;
+
+  const status = (detail.latestAction?.text ?? "Unknown").slice(0, 250);
+  const introducedDate = detail.introducedDate
+    ? new Date(detail.introducedDate)
+    : undefined;
+  const chamberValue = (detail.originChamber ?? fallbackChamber) as
+    | "House"
+    | "Senate";
+  const billUrl = `https://www.congress.gov/bill/${congress}${ordinalSuffix(congress)}-congress/${billTypeToUrlSlug(detail.type)}/${billNumber}`;
+
+  const summary = await fetchSummary(congress, billType, billNumber);
+  const fullText = await fetchFullText(congress, billType, billNumber);
+  const actions = await fetchActions(congress, billType, billNumber);
+
+  await upsertContent(
+    {
+      type: "bill",
+      data: {
+        billNumber: formattedBillNumber,
+        title,
+        // Keep the official CRS summary as source material. The DB
+        // pipeline generates the compact, app-facing description.
+        description: undefined,
+        sponsor,
+        status,
+        introducedDate,
+        congress,
+        chamber: chamberValue,
+        summary,
+        fullText,
+        actions,
+        url: billUrl,
+        sourceWebsite: "congress.gov",
+      },
+    },
+    { newItemLimiter },
+  );
+
+  logger.success(`Processed: ${formattedBillNumber} — ${title}`);
+}
+
+/**
+ * Fetch specific bills by number, bypassing the incremental `fromDateTime`
+ * cursor. A normal run only sees bills updated since the last successful
+ * scrape and caps each window at `maxBills`, so anything that overflowed a
+ * busy window becomes unreachable once the cursor moves past it. This is how
+ * those gaps get backfilled.
+ */
+async function scrapeTargeted(identifiers: string[], congress: number) {
+  const targets = identifiers.map((identifier) => {
+    const parsed = parseBillIdentifier(identifier);
+    if (!parsed) {
+      throw new Error(
+        `Unrecognized bill identifier "${identifier}" (expected e.g. "H.R. 7008" or "S.J.Res. 5")`,
+      );
+    }
+    return parsed;
+  });
+
+  logger.info(
+    `Fetching ${targets.length} requested bill(s) from congress ${congress}...`,
+  );
+  setExpectedTotal(targets.length);
+
+  // Every bill here was explicitly asked for, so none should be downgraded to
+  // a raw-content save by the per-run new-item budget.
+  const newItemLimiter = createNewItemLimiter(targets.length);
+  const limit = getItemLimit();
+  const results = await Promise.allSettled(
+    targets.map(({ billType, billNumber }) =>
+      limit(() =>
+        processBill(
+          congress,
+          billType,
+          billNumber,
+          chamberForBillType(billType),
+          newItemLimiter,
+        ),
+      ),
+    ),
+  );
+
+  // Unlike the feed walk, a targeted run has no later run to retry it — fail
+  // loudly so the caller knows the bill still isn't in the database.
+  const failures = results.flatMap((result, i) =>
+    result.status === "rejected"
+      ? [{ target: targets[i]!, reason: result.reason as unknown }]
+      : [],
+  );
+  for (const { target, reason } of failures) {
+    logger.error(
+      `Error processing bill ${target.billType}${target.billNumber}`,
+      reason,
+    );
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `Failed to process ${failures.length} of ${targets.length} requested bill(s)`,
+    );
+  }
+
+  logger.success("Completed");
+}
+
 async function scrape(config: CongressScraperConfig = {}) {
   const { maxBills = 100, congress = 119, chamber = "House" } = config;
+
+  if (config.bills?.length) {
+    return scrapeTargeted(config.bills, congress);
+  }
 
   logger.info(`Starting (congress=${congress}, chamber=${chamber})...`);
 
@@ -310,66 +470,13 @@ async function scrape(config: CongressScraperConfig = {}) {
     bills.map((item) =>
       limit(async () => {
         try {
-          const billType = item.type.toLowerCase();
-          const billNumber = item.number;
-
-          const detailData = await congressFetch<ApiBillDetail>(
-            `/bill/${congress}/${billType}/${billNumber}`,
+          await processBill(
+            congress,
+            item.type.toLowerCase(),
+            item.number,
+            chamber,
+            newItemLimiter,
           );
-          const detail = detailData.bill;
-
-          const formattedBillNumber = formatBillNumber(
-            detail.type,
-            detail.number,
-          );
-          const title = (detail.title ?? "Unknown").slice(0, 250);
-
-          const primarySponsor = detail.sponsors?.[0];
-          const sponsor = primarySponsor
-            ? `${primarySponsor.firstName} ${primarySponsor.lastName} (${primarySponsor.party}-${primarySponsor.state})`.slice(
-                0,
-                250,
-              )
-            : undefined;
-
-          const status = (detail.latestAction?.text ?? "Unknown").slice(0, 250);
-          const introducedDate = detail.introducedDate
-            ? new Date(detail.introducedDate)
-            : undefined;
-          const chamberValue = (detail.originChamber ?? chamber) as
-            | "House"
-            | "Senate";
-          const billUrl = `https://www.congress.gov/bill/${congress}${ordinalSuffix(congress)}-congress/${billTypeToUrlSlug(detail.type)}/${billNumber}`;
-
-          const summary = await fetchSummary(congress, billType, billNumber);
-          const fullText = await fetchFullText(congress, billType, billNumber);
-          const actions = await fetchActions(congress, billType, billNumber);
-
-          await upsertContent(
-            {
-              type: "bill",
-              data: {
-                billNumber: formattedBillNumber,
-                title,
-                // Keep the official CRS summary as source material. The DB
-                // pipeline generates the compact, app-facing description.
-                description: undefined,
-                sponsor,
-                status,
-                introducedDate,
-                congress,
-                chamber: chamberValue,
-                summary,
-                fullText,
-                actions,
-                url: billUrl,
-                sourceWebsite: "congress.gov",
-              },
-            },
-            { newItemLimiter },
-          );
-
-          logger.success(`Processed: ${formattedBillNumber} — ${title}`);
         } catch (error) {
           logger.error(
             `Error processing bill ${item.type}${item.number}`,
@@ -389,5 +496,7 @@ export const congress: Scraper = {
     scrape({
       maxBills:
         (options?.maxItems ?? Number(process.env.CONGRESS_MAX_ITEMS)) || 100,
+      bills: options?.targets,
+      ...(options?.congress ? { congress: options.congress } : {}),
     }),
 };

--- a/apps/scraper/src/scrapers/congress.ts
+++ b/apps/scraper/src/scrapers/congress.ts
@@ -208,6 +208,40 @@ export async function fetchSummary(
   }
 }
 
+/**
+ * Postgres rejects `to_tsvector` input over 1,048,575 bytes, and
+ * `Bill.searchVector` is a generated column over `full_text` — so an oversized
+ * bill fails its INSERT outright rather than degrading. `processBill` catches
+ * and logs that error, which would make the bill vanish silently, exactly the
+ * failure mode we just removed. Keep a wide margin under the ceiling.
+ *
+ * This is ~125x the old 1,000-word cap, so it only bites genuinely enormous
+ * bills (omnibus/appropriations). Unlike the old cap it is loud, and the
+ * section-by-section pipeline in issue #216 is the real answer for those.
+ */
+const MAX_FULL_TEXT_BYTES = 800_000;
+
+export function capToTsvectorLimit(text: string, label: string): string {
+  if (Buffer.byteLength(text, "utf8") <= MAX_FULL_TEXT_BYTES) return text;
+
+  // Byte budget, not characters: bill text carries multibyte punctuation
+  // (section signs, em dashes, curly quotes) that a char-based slice ignores.
+  let end = text.length;
+  while (
+    end > 0 &&
+    Buffer.byteLength(text.slice(0, end), "utf8") > MAX_FULL_TEXT_BYTES
+  ) {
+    end = Math.floor(end * 0.98);
+  }
+  const clipped = text.slice(0, end);
+  const lastSpace = clipped.lastIndexOf(" ");
+  const result = lastSpace > 0 ? clipped.slice(0, lastSpace) : clipped;
+  logger.warn(
+    `${label}: full text is ${Buffer.byteLength(text, "utf8")} bytes, capped to ${Buffer.byteLength(result, "utf8")} to stay under the tsvector limit`,
+  );
+  return result;
+}
+
 export async function fetchFullText(
   congress: number,
   billType: string,
@@ -229,12 +263,14 @@ export async function fetchFullText(
       const rawText = await res.text();
       if (!rawText) continue;
 
-      let text = stripHtml(rawText);
-      const words = text.split(/\s+/);
-      if (words.length > 1000) {
-        text = words.slice(0, 1000).join(" ");
-      }
-      return text.trim() || undefined;
+      // Store the bill as published. An earlier 1,000-word cap silently cut
+      // most bills off mid-section — H.R. 7008 lost its entire penalties
+      // section, and the brief generator then reported that the bill
+      // specified no penalties. Downstream consumers window this text to fit
+      // their own context budget (see SOURCE_WINDOW in ai/bill-brief.ts);
+      // truncating at ingest time only destroys information for all of them.
+      const text = stripHtml(rawText).trim();
+      return capToTsvectorLimit(text, billNumber) || undefined;
     }
   } catch {
     // Full text is optional

--- a/apps/scraper/src/utils/ai/bill-brief.ts
+++ b/apps/scraper/src/utils/ai/bill-brief.ts
@@ -17,6 +17,7 @@
  *      Quotes are exempt: a source is allowed to be partisan, we are not.
  */
 import { APICallError, generateText, Output, RetryError } from "ai";
+import { z } from "zod";
 
 import type {
   BillBrief,
@@ -33,7 +34,6 @@ import {
   BriefQuoteSchema,
   BriefVisualSchema,
 } from "@acme/validators";
-import { z } from "zod";
 
 import type { DualLensSource } from "./text-generation.js";
 import { trackLLMUsage } from "../costs.js";
@@ -547,6 +547,7 @@ function buildBriefPrompt(args: {
   url: string;
   legalStatus: BriefLegalStatus;
   sourceText: string;
+  officialSummary?: string | null;
   priorArticle?: string | null;
   readingResearch?: string;
   readingSources?: DualLensSource[];
@@ -560,6 +561,7 @@ function buildBriefPrompt(args: {
     url,
     legalStatus,
     sourceText,
+    officialSummary,
     priorArticle,
     readingResearch,
     readingSources,
@@ -622,6 +624,7 @@ Rules that decide whether this brief ships:
 
 Field notes:
 - "hook" is rendered under the heading "What this means for you" and replaces a grid of disconnected fact tiles. Write one coherent paragraph of 2–3 short sentences. First explain the most consequential practical changes; then state the most important limitation, condition, or uncertainty. Connect the ideas naturally instead of listing figures. Preserve legal status ("would" for proposals), and do not imply every reader is personally affected. Wrap two or three short, concrete phrases in **double asterisks** so a scanner can retain the key changes. Never bold a whole sentence, generic transition, verdict, or loaded language.
+- Surprise belongs in the "hook". A reader who knows only the bill's title and short description should not be able to predict it. Two things are almost always more useful than restating the title: (a) **provisions unrelated to the bill's stated subject** — unrelated policy riding along in the same text is one of the most consequential things a reader can learn, and a title will never reveal it; and (b) **the gap between what the title promises and what the text does** — a bill named for banning something that restricts only one narrow form of it, grandfathers everything existing, or omits an asset class the reader would assume is covered. When either is present, it belongs in the hook ahead of a fuller recitation of the main provisions. Only describe what the source actually supports; do not manufacture a twist for a bill that genuinely has none, and keep the framing neutral — state the mismatch, let the reader judge it.
 - "changes" must contrast current law ("before") with the proposal ("after"). If the source does not establish current law, say that in "before" instead of guessing. Evaluate every change independently for a direct supporting quote; when the official text contains one, include it so every supported card has its own route back to the text. Never invent or stretch a quote merely to make the cards look consistent.
 - Each affected-group "takeaway" is the card's always-visible summary. Write one complete standalone sentence that names the group or a clear pronoun and states what would happen. For example: "States would get a **longer window to plan multi-year projects**." Do not return fragments such as "a longer funding horizon" or "depends on final rules." Put qualifications and mechanism detail in "effect".
 - "visual" is optional curated artwork. Use "infrastructure-repair" only for physical road or bridge work, "public-transit" only for rail or bus expansion, "data-privacy" only for company collection or use of personal data, and "data-control" only for a person's right to access or delete personal data. Evaluate each change independently and use different relevant visuals across cards when available; never repeat or force an image merely for visual parity. If none applies, omit the property; providers that cannot omit optional JSON fields may return null.
@@ -652,6 +655,11 @@ ${
         .join("\n")}\n`
     : '\nNo verified outside sources were found. Omit "whyNotBefore" and return an empty reading list.\n'
 }
+${
+  officialSummary
+    ? `\nOfficial CRS summary of the whole bill (nonpartisan, written by the Congressional Research Service). The official text below may be windowed and end mid-section, so treat this summary as authoritative for the bill's overall scope — including provisions the excerpt cuts off, such as penalties and effective dates. Do not report something as unspecified when this summary specifies it. Never quote from this summary: every "quote" must come verbatim from the official text below.\n${officialSummary.slice(0, 6000)}\n`
+    : ""
+}
 Official text:
 ${sourceText.slice(0, SOURCE_WINDOW)}
 ---
@@ -671,6 +679,7 @@ export async function generateBillBrief(args: {
   billNumber: string;
   url: string;
   fullText: string;
+  officialSummary?: string | null;
   status?: string | null;
   priorArticle?: string | null;
 }): Promise<Omit<BillBriefRecord, "generatedAt" | "modelVersion"> | null> {
@@ -700,6 +709,7 @@ export async function generateBillBrief(args: {
           url: args.url,
           legalStatus,
           sourceText: args.fullText,
+          officialSummary: args.officialSummary,
           priorArticle: args.priorArticle,
           readingResearch: readingResearch.notes,
           readingSources: readingResearch.sources,

--- a/apps/scraper/src/utils/db/operations.ts
+++ b/apps/scraper/src/utils/db/operations.ts
@@ -183,9 +183,9 @@ export async function upsertContent(
     );
   }
 
-  // New items beyond the run's daily budget skip AI enrichment. Bills that
-  // need a generated description are deferred before insertion; other content
-  // can persist raw and look like "needs backfill" work next run.
+  // New items beyond the run's daily budget skip AI enrichment but are still
+  // persisted with their raw content, so they surface as "needs backfill" work
+  // for the retroactive scripts rather than being lost.
   const budgetExhausted =
     progressKind === "new" &&
     options?.newItemLimiter !== undefined &&
@@ -202,21 +202,33 @@ export async function upsertContent(
   // A generated bill description is part of the bill's minimum usable record,
   // not an optional derived asset. Generate it before the insert so provider
   // failure cannot leave a new, summarizable bill permanently blank.
+  //
+  // Past the budget we persist the bill anyway rather than skipping the insert.
+  // The scraper's incremental cursor advances past everything it fetched, so a
+  // skipped bill is never offered again — it is lost, not deferred. A raw row
+  // still renders (the content API coalesces description -> summary) and
+  // `backfill-bill-descriptions` fills in the real description later.
   let preGeneratedDescription: string | undefined;
   if (!existing && input.type === "bill" && !sourceDescription) {
-    if (budgetExhausted || !hasSummarySource) {
+    if (!hasSummarySource) {
       logger.warn(
         `${label}: deferring insert until a summary can be generated`,
       );
       return undefined;
     }
-    const summarySource = input.data.summary || input.data.fullText || "";
-    logger.start(`Generating required AI summary for ${label}`);
-    preGeneratedDescription = await generateAISummary(title, summarySource);
-    if (!preGeneratedDescription.trim()) {
-      throw new Error(`AI returned an empty required summary for ${label}`);
+    if (budgetExhausted) {
+      logger.info(
+        `${label}: past new-item budget, persisting raw for a later backfill`,
+      );
+    } else {
+      const summarySource = input.data.summary || input.data.fullText || "";
+      logger.start(`Generating required AI summary for ${label}`);
+      preGeneratedDescription = await generateAISummary(title, summarySource);
+      if (!preGeneratedDescription.trim()) {
+        throw new Error(`AI returned an empty required summary for ${label}`);
+      }
+      shouldGenerateSummary = false;
     }
-    shouldGenerateSummary = false;
   }
 
   if (progressKind === "new") incrementNewEntries();
@@ -422,8 +434,11 @@ export async function upsertContent(
       logger.success(`${label} enriched with AI content`);
     }
 
-    // Generate and cache dual-lens perspectives
-    if (hasUsableText && result?.id) {
+    // Generate and cache dual-lens perspectives. Past-budget items are skipped
+    // along with every other derived asset: the lens runs an agentic research
+    // loop, and it is the budget's whole purpose to not pay for that on a bill
+    // we are only persisting raw. `retroactive-lenses` backfills them.
+    if (hasUsableText && result?.id && !budgetExhausted) {
       await upsertContentLens(
         result.id,
         input.type,
@@ -438,7 +453,13 @@ export async function upsertContent(
     // Generate and cache the structured brief. Bills only for now — the brief
     // schema is written around legislative mechanics (before/after provisions,
     // sponsor-vs-text framing) and needs separate design work per content type.
-    if (hasUsableText && result?.id && input.type === "bill") {
+    // Past-budget items defer to `retroactive-briefs`, as with the lens above.
+    if (
+      hasUsableText &&
+      result?.id &&
+      input.type === "bill" &&
+      !budgetExhausted
+    ) {
       await upsertBillBrief({
         contentId: result.id,
         contentHash: newContentHash,
@@ -446,6 +467,7 @@ export async function upsertContent(
         billNumber: input.data.billNumber,
         url,
         fullText: fullText!,
+        officialSummary: input.data.summary,
         status: input.data.status,
         priorArticle: aiGeneratedArticle,
       });
@@ -597,6 +619,7 @@ export async function upsertBillBrief(args: {
   billNumber: string;
   url: string;
   fullText: string;
+  officialSummary?: string | null;
   status?: string | null;
   priorArticle?: string | null;
 }): Promise<boolean> {
@@ -628,6 +651,7 @@ export async function upsertBillBrief(args: {
     billNumber: args.billNumber,
     url: args.url,
     fullText: args.fullText,
+    officialSummary: args.officialSummary,
     status: args.status,
     priorArticle: args.priorArticle,
   });

--- a/apps/scraper/src/utils/new-item-limit.ts
+++ b/apps/scraper/src/utils/new-item-limit.ts
@@ -1,8 +1,10 @@
 /**
  * Caps how many brand-new items a single scraper run will fully process
- * (AI summary/article/image generation). Items beyond the cap are still
- * saved with their raw content, so they roll over as "backfill" work that
- * a later run will pick up under next day's budget.
+ * (AI summary/article/image generation). Items beyond the cap are still saved
+ * with their raw content — the scraper's incremental cursor advances past
+ * everything it fetched, so an item that is not persisted here is lost rather
+ * than deferred. They roll over as "backfill" work for the retroactive
+ * scripts (`backfill-bill-descriptions`, `retroactive-briefs`, ...).
  */
 
 export interface NewItemLimiter {

--- a/apps/scraper/src/utils/types.ts
+++ b/apps/scraper/src/utils/types.ts
@@ -59,4 +59,12 @@ export interface Scraper {
 
 export interface ScraperRunOptions {
   maxItems?: number;
+  /**
+   * Source-specific record identifiers to fetch directly, bypassing whatever
+   * incremental cursor the scraper normally uses. Scrapers without a targeted
+   * mode ignore this.
+   */
+  targets?: string[];
+  /** Congress number for targeted congress.gov runs (e.g. 119). */
+  congress?: number;
 }


### PR DESCRIPTION
Started as "add H.R. 7008 to the database" and turned into three data-loss bugs in the bill pipeline.

## 1. New bills past the per-run budget were discarded, not deferred

`upsertContent` returned before the insert when a bill needed a generated description and the run's new-item budget was spent — reasoning that a description is part of a bill's minimum usable record. But the incremental cursor is `max(Bill.updatedAt)`, a **wall-clock write time** compared against congress.gov's `updateDate`, so it advances past everything the run fetched. A bill skipped that way is never offered again. It was lost, not deferred, and `new-item-limit.ts` promised the opposite in a comment.

Prod dates the regression to `5a02089` (2026-07-21) precisely:

| Day | New bills inserted |
|---|---|
| 07-09 | 104 |
| 07-12 | 59 |
| 07-19 | 86 |
| **07-21** | **← `5a02089` lands** |
| 07-24 | 9 |
| 07-26 | 5 |
| 07-27 | 2 |
| 07-28 | 1 |

Hard ceiling at the 10/run cap from that date on. Since 07-21, **1,742 House bills were updated upstream and 17 landed.** H.R. 7008 was one of the casualties.

Past-budget bills now persist raw. They stay visible because the content API coalesces `description -> summary` (`content.ts:33`), and `backfill-bill-descriptions` fills in the real description later.

While fixing this I found the dual lens and structured brief were gated only on `hasUsableText` — they were protected from the budget purely by the early return this PR removes. Left alone, this change would have routed ~90 bills/run into two LLM pipelines each, including the lens's agentic research loop. Both are now gated on the budget, matching what video generation already did.

## 2. Bill full text was truncated to 1,000 words at ingest

H.R. 7008's stored text was exactly 1,000 words, severed mid-sentence at `"on behalf, or for the"` — the entire penalties section gone. The brief then told readers the bill **"does not specify penalties"**, in the hook, the most prominent line in the UI. The CRS summary in the same database row spells them out: greater of $2,000 or 10% of transaction value, plus net gain, not payable from campaign funds.

The cap also quietly broke quote verification, which checks against this same truncated text — legitimate quotes from later sections were dropped as unverified (`dropped 4 unverified quote(s)` on H.R. 7008).

Text is now stored as published, capped only by a byte ceiling. That ceiling is load-bearing: `to_tsvector` rejects input over 1,048,575 bytes and `Bill.searchVector` is a generated column over `full_text`, so an oversized bill would fail its INSERT outright and vanish through the same catch-and-log path this PR is trying to close. Verified against Postgres directly:

```
ERROR:  string is too long for tsvector (3377790 bytes, max 1048575 bytes)
```

The new cap is ~125x the old one, byte-aware (bill text carries multibyte punctuation), and logs when it bites.

## 3. The brief generator never saw the CRS summary

It received only `fullText`, so anything past its window was simply unknown to it. The summary is now passed as authoritative, explicitly **non-quotable** context — quotes are still verified against the official text alone, so this can't introduce ungrounded quotes.

## Also

The hook now surfaces provisions unrelated to the bill's stated subject, and gaps between what a title promises and what the text does. The dual lens had already found the SAVE Act voter-ID provisions riding along inside H.R. 7008 — exactly what a reader can't get from the title, and exactly what never reached the top line.

Earlier commit in this branch adds `--bill` for targeted backfills, which is how H.R. 7008 got into prod and how any single bill can be regenerated for testing.

## Testing

- 36/36 unit tests, typecheck and prettier clean
- `--bill "H.R. 7008"` run against prod on big-mac: bill landed complete (summary, full text, article, 20 actions, lens, brief, header art)
- tsvector ceiling confirmed against a live Postgres
- Budget behavior exercised against the local DB with a reduced cap

## Not fixed here

**The cursor itself.** Bills beyond the 100-bill fetch window are still skipped permanently. The real fix is a persisted cursor holding the upstream `updateDate` of the newest processed bill instead of `now()`, walking the feed oldest-first so the window and the budget are the same number. That needs a schema change and belongs in its own PR.

**The ~1,000-bill backlog** dropped between 07-21 and now still needs draining.

Long-bill handling is tracked in #216 (section-by-section analysis pass feeding a separate writing pass).
