### PR TITLE
Split bill briefs into analysis and writing passes

### DIFF
--- a/apps/scraper/src/retroactive-briefs.ts
+++ b/apps/scraper/src/retroactive-briefs.ts
@@ -2,17 +2,17 @@
  * Backfill structured briefs for bills that predate the brief pipeline, or
  * whose brief is stale relative to the bill's current contentHash.
  *
- * Mirrors `retroactive-lenses.ts`. Bills already carry a vetted long-form
- * article, so the backfill hands that to the generator as prior analysis —
- * the restructuring pass is cheaper and more consistent than re-reading the
- * statute cold, and quotes are still verified against the official text.
+ * The analysis pass is cached independently from the reader-facing brief, so
+ * a brief-schema update can reuse an unchanged bill's section notes. Quotes
+ * are still verified against the complete official text.
  */
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { and, desc, eq, isNotNull, isNull, ne, or } from "@acme/db";
+import { and, desc, eq, isNotNull, isNull, ne, or, sql } from "@acme/db";
 import { db } from "@acme/db/client";
 import { Bill, ContentBrief } from "@acme/db/schema";
+import { BILL_BRIEF_VERSION } from "@acme/validators";
 
 import { AIRateLimitError } from "./utils/ai/text-generation.js";
 import { upsertBillBrief } from "./utils/db/operations.js";
@@ -28,6 +28,7 @@ interface BriefCandidate {
   url: string;
   fullText: string;
   status: string | null;
+  summary: string | null;
   aiGeneratedArticle: string | null;
 }
 
@@ -41,6 +42,7 @@ async function findBills(limit: number): Promise<BriefCandidate[]> {
       url: Bill.url,
       fullText: Bill.fullText,
       status: Bill.status,
+      summary: Bill.summary,
       aiGeneratedArticle: Bill.aiGeneratedArticle,
     })
     .from(Bill)
@@ -57,6 +59,7 @@ async function findBills(limit: number): Promise<BriefCandidate[]> {
         or(
           isNull(ContentBrief.id),
           ne(ContentBrief.contentHash, Bill.contentHash),
+          sql`${ContentBrief.brief}->>'version' IS DISTINCT FROM ${String(BILL_BRIEF_VERSION)}`,
         ),
       ),
     )
@@ -111,6 +114,7 @@ for (const candidate of candidates) {
       url: candidate.url,
       fullText: candidate.fullText,
       status: candidate.status,
+      summary: candidate.summary,
       priorArticle: candidate.aiGeneratedArticle,
     });
     if (generated) processed++;

--- a/apps/scraper/src/scrapers/congress.test.ts
+++ b/apps/scraper/src/scrapers/congress.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { extractFormattedBillText } from "./congress.js";
+
+void test("formatted bill text is normalized without a word-count cap", () => {
+  const words = Array.from({ length: 1_250 }, (_, index) => `word${index + 1}`);
+  const normalized = extractFormattedBillText(
+    `<html><body><p>${words.join(" ")}</p></body></html>`,
+  );
+
+  assert.ok(normalized);
+  assert.equal(normalized.split(/\s+/).length, 1_250);
+  assert.match(normalized, /word1250$/);
+});
+
+void test("empty formatted bill text stays optional", () => {
+  assert.equal(
+    extractFormattedBillText("<html><body> </body></html>"),
+    undefined,
+  );
+});

--- a/apps/scraper/src/scrapers/congress.ts
+++ b/apps/scraper/src/scrapers/congress.ts
@@ -165,6 +165,11 @@ function stripHtml(html: string): string {
     .trim();
 }
 
+/** Convert Congress.gov formatted HTML to complete normalized source text. */
+export function extractFormattedBillText(rawText: string): string | undefined {
+  return stripHtml(rawText).trim() || undefined;
+}
+
 export async function fetchSummary(
   congress: number,
   billType: string,
@@ -203,12 +208,7 @@ export async function fetchFullText(
       const rawText = await res.text();
       if (!rawText) continue;
 
-      let text = stripHtml(rawText);
-      const words = text.split(/\s+/);
-      if (words.length > 1000) {
-        text = words.slice(0, 1000).join(" ");
-      }
-      return text.trim() || undefined;
+      return extractFormattedBillText(rawText);
     }
   } catch {
     // Full text is optional

--- a/apps/scraper/src/utils/ai/bill-analysis.test.ts
+++ b/apps/scraper/src/utils/ai/bill-analysis.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BillAnalysis } from "@acme/validators";
+
+import {
+  assertCompleteSectionCoverage,
+  BILL_SECTION_CHUNK_LIMIT,
+  formatBillAnalysis,
+  splitBillIntoSections,
+} from "./bill-analysis.js";
+
+void test("section inventory retains the preamble and every legislative section", () => {
+  const source = [
+    "119th CONGRESS 1st Session H. R. 7008 A BILL",
+    "SECTION 1. SHORT TITLE. This Act may be cited as the Example Act.",
+    "SEC. 2. REQUIREMENT. A covered person shall file a report.",
+    "SEC. 3. PENALTIES. A covered person who violates section 2 shall pay the greater of $2,000 or 10 percent of the transaction value.",
+  ].join(" ");
+
+  const sections = splitBillIntoSections(source);
+
+  assert.deepEqual(
+    sections.map((section) => section.locator),
+    [
+      "Preamble",
+      "SECTION 1. SHORT TITLE.",
+      "SEC. 2. REQUIREMENT.",
+      "SEC. 3. PENALTIES.",
+    ],
+  );
+  assert.equal(sections.map((section) => section.text).join(""), source);
+  assertCompleteSectionCoverage(sections, source.length);
+  assert.match(sections.at(-1)!.text, /greater of \$2,000 or 10 percent/);
+});
+
+void test("oversized sections use bounded overlapping parts without coverage gaps", () => {
+  const repeatedProvision =
+    " The Administrator shall publish a quarterly report for every covered project.";
+  const source = `SEC. 1. REPORTING.${repeatedProvision.repeat(500)}`;
+  const sections = splitBillIntoSections(source);
+
+  assert.ok(sections.length > 1);
+  assert.ok(
+    sections.every(
+      (section) => section.text.length <= BILL_SECTION_CHUNK_LIMIT,
+    ),
+  );
+  assert.equal(sections[0]!.start, 0);
+  assert.equal(sections.at(-1)!.end, source.length);
+  for (let index = 1; index < sections.length; index++) {
+    assert.ok(sections[index]!.start < sections[index - 1]!.end);
+  }
+  assertCompleteSectionCoverage(sections, source.length);
+});
+
+void test("analysis formatting preserves late-section penalties and exact quotes", () => {
+  const penalty =
+    "the greater of $2,000 or 10 percent of the transaction value";
+  const analysis: BillAnalysis = {
+    sourceLength: 42_000,
+    sourceHash: "a".repeat(64),
+    sectionCount: 2,
+    analyzedSectionIds: ["section-001", "section-002"],
+    sections: [
+      {
+        sectionId: "section-001",
+        locator: "SEC. 1. DEFINITIONS.",
+        summary: "Defines the people and transactions covered by the bill.",
+        substantive: true,
+        findings: [],
+      },
+      {
+        sectionId: "section-002",
+        locator: "SEC. 9. PENALTIES.",
+        summary: "Creates a monetary penalty for violations.",
+        substantive: true,
+        findings: [
+          {
+            category: "penalty",
+            statement:
+              "A violator must pay a monetary penalty based on a fixed minimum or a share of the transaction.",
+            actors: ["violator"],
+            affectedParties: ["covered person"],
+            crossReferences: [],
+            quote: { text: penalty, locator: "Sec. 9(a)" },
+          },
+        ],
+      },
+    ],
+  };
+
+  const formatted = formatBillAnalysis(analysis);
+  assert.match(formatted, /SEC\. 9\. PENALTIES/);
+  assert.match(formatted, /\[penalty\]/);
+  assert.match(formatted, /greater of \$2,000 or 10 percent/);
+});

--- a/apps/scraper/src/utils/ai/bill-analysis.ts
+++ b/apps/scraper/src/utils/ai/bill-analysis.ts
@@ -1,0 +1,367 @@
+import { createHash } from "node:crypto";
+import { APICallError, generateText, Output, RetryError } from "ai";
+import pLimit from "p-limit";
+import { z } from "zod";
+
+import type { BillAnalysis, BillSectionNotes } from "@acme/validators";
+import {
+  BillAnalysisFindingSchema,
+  BillAnalysisSchema,
+  BillSectionNotesSchema,
+} from "@acme/validators";
+
+import { trackLLMUsage } from "../costs.js";
+import { createLogger } from "../log.js";
+import { getStructuredLlm } from "./provider.js";
+import {
+  AIRateLimitError,
+  rateLimitHit,
+  setRateLimitHit,
+} from "./text-generation.js";
+
+const logger = createLogger("bill-analysis");
+
+/**
+ * Each analysis call sees at most one legislative section. Exceptionally long
+ * sections are split into overlapping parts so a pathological section cannot
+ * recreate the old whole-document context-window failure.
+ */
+export const BILL_SECTION_CHUNK_LIMIT = 14_000;
+const BILL_SECTION_CHUNK_OVERLAP = 600;
+const MAX_ANALYSIS_ATTEMPTS = 2;
+
+export interface BillSourceSection {
+  id: string;
+  locator: string;
+  start: number;
+  end: number;
+  text: string;
+}
+
+interface SectionBoundary {
+  start: number;
+  locator: string;
+}
+
+const SECTION_MARKER = /\b(?:SEC\.|SECTION)\s+\d+[A-Z0-9-]*\./g;
+const SECTION_LOCATOR =
+  /^((?:SEC\.|SECTION)\s+\d+[A-Z0-9-]*\.(?:\s+[A-Z][A-Z0-9 ,;:'()/–—-]{2,120}\.)?)/;
+
+function sectionLocator(sourceText: string, start: number): string {
+  return (
+    SECTION_LOCATOR.exec(sourceText.slice(start, start + 300))?.[1]?.trim() ??
+    /\b(?:SEC\.|SECTION)\s+\d+[A-Z0-9-]*\./.exec(
+      sourceText.slice(start, start + 80),
+    )?.[0] ??
+    "Untitled section"
+  );
+}
+
+function findSectionBoundaries(sourceText: string): SectionBoundary[] {
+  const boundaries: SectionBoundary[] = [];
+  SECTION_MARKER.lastIndex = 0;
+  for (const match of sourceText.matchAll(SECTION_MARKER)) {
+    if (match.index === undefined) continue;
+    boundaries.push({
+      start: match.index,
+      locator: sectionLocator(sourceText, match.index),
+    });
+  }
+  return boundaries;
+}
+
+function splitRange(
+  sourceText: string,
+  start: number,
+  end: number,
+): { start: number; end: number }[] {
+  const ranges: { start: number; end: number }[] = [];
+  let cursor = start;
+
+  while (cursor < end) {
+    const hardEnd = Math.min(cursor + BILL_SECTION_CHUNK_LIMIT, end);
+    let chunkEnd = hardEnd;
+    if (hardEnd < end) {
+      const minimumEnd = cursor + Math.floor(BILL_SECTION_CHUNK_LIMIT * 0.7);
+      const whitespace = sourceText.lastIndexOf(" ", hardEnd);
+      if (whitespace >= minimumEnd) chunkEnd = whitespace;
+    }
+    ranges.push({ start: cursor, end: chunkEnd });
+    if (chunkEnd >= end) break;
+    cursor = Math.max(cursor + 1, chunkEnd - BILL_SECTION_CHUNK_OVERLAP);
+  }
+
+  return ranges;
+}
+
+/**
+ * Inventory the whole source using the bill's own SEC./SECTION markers. The
+ * preamble is retained as its own unit, and markerless or oversized documents
+ * fall back to bounded overlapping parts. Every source character is covered.
+ */
+export function splitBillIntoSections(sourceText: string): BillSourceSection[] {
+  if (!sourceText.length) return [];
+
+  const markers = findSectionBoundaries(sourceText);
+  let boundaries: SectionBoundary[];
+  if (markers.length === 0) {
+    boundaries = [{ start: 0, locator: "Full text" }];
+  } else {
+    const first = markers[0]!;
+    const prefix = sourceText.slice(0, first.start);
+    boundaries =
+      first.start === 0
+        ? markers
+        : prefix.trim()
+          ? [{ start: 0, locator: "Preamble" }, ...markers]
+          : [{ ...first, start: 0 }, ...markers.slice(1)];
+  }
+  const sections: BillSourceSection[] = [];
+
+  boundaries.forEach((boundary, sectionIndex) => {
+    const logicalEnd = boundaries[sectionIndex + 1]?.start ?? sourceText.length;
+    const parts = splitRange(sourceText, boundary.start, logicalEnd);
+    parts.forEach((part, partIndex) => {
+      const baseId = `section-${String(sectionIndex + 1).padStart(3, "0")}`;
+      const partSuffix = parts.length > 1 ? `.part-${partIndex + 1}` : "";
+      const partLabel =
+        parts.length > 1
+          ? `${boundary.locator} (part ${partIndex + 1} of ${parts.length})`
+          : boundary.locator;
+      sections.push({
+        id: `${baseId}${partSuffix}`,
+        locator: partLabel,
+        start: part.start,
+        end: part.end,
+        text: sourceText.slice(part.start, part.end),
+      });
+    });
+  });
+
+  assertCompleteSectionCoverage(sections, sourceText.length);
+  return sections;
+}
+
+/** Throw if a splitter regression omits any portion of the source. */
+export function assertCompleteSectionCoverage(
+  sections: readonly BillSourceSection[],
+  sourceLength: number,
+): void {
+  if (sourceLength === 0 && sections.length === 0) return;
+  if (sections.length === 0 || sections[0]!.start !== 0) {
+    throw new Error("Bill section inventory does not start at source offset 0");
+  }
+
+  let coveredThrough = 0;
+  for (const section of sections) {
+    if (section.start > coveredThrough) {
+      throw new Error(
+        `Bill section inventory has a gap before source offset ${section.start}`,
+      );
+    }
+    if (section.end <= section.start) {
+      throw new Error(`Bill section ${section.id} is empty`);
+    }
+    coveredThrough = Math.max(coveredThrough, section.end);
+  }
+  if (coveredThrough !== sourceLength) {
+    throw new Error(
+      `Bill section inventory ends at ${coveredThrough}, expected ${sourceLength}`,
+    );
+  }
+}
+
+const GeneratedAnalysisQuoteSchema = z.object({
+  text: z.string().trim().min(20).max(1600),
+  locator: z.string().trim().max(160).nullish(),
+});
+const GeneratedAnalysisFindingSchema = BillAnalysisFindingSchema.extend({
+  quote: GeneratedAnalysisQuoteSchema.nullish(),
+});
+const GeneratedSectionNotesSchema = BillSectionNotesSchema.omit({
+  sectionId: true,
+  locator: true,
+}).extend({
+  findings: z.array(GeneratedAnalysisFindingSchema).max(30),
+});
+
+function withoutNulls(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withoutNulls);
+  if (!value || typeof value !== "object") return value;
+  return Object.fromEntries(
+    Object.entries(value)
+      .filter(([, child]) => child !== null)
+      .map(([key, child]) => [key, withoutNulls(child)]),
+  );
+}
+
+function isRateLimitError(error: unknown): boolean {
+  if (error instanceof APICallError) return error.statusCode === 429;
+  if (error instanceof RetryError) return isRateLimitError(error.lastError);
+  if (!(error instanceof Error)) return false;
+  const message = error.message.toLowerCase();
+  return (
+    message.includes("429") ||
+    message.includes("rate limit") ||
+    message.includes("resource_exhausted") ||
+    message.includes("quota")
+  );
+}
+
+function buildSectionAnalysisPrompt(args: {
+  billNumber: string;
+  section: BillSourceSection;
+}): string {
+  return `You are performing the reading pass for a legislative brief. Analyze exactly one source section and return structured notes, not reader-facing prose.
+
+The later writing pass will never see the raw bill text. Your notes must therefore preserve every material mechanism needed to explain the bill accurately.
+
+Use a facet-based inventory:
+- changes to law, authority, eligibility, duties, rights, funding, deadlines, effective dates, implementation, and oversight
+- every penalty, enforcement mechanism, exemption, exception, condition, definition, and cross-reference
+- the actor taking an action and each party directly affected
+- uncertainties that are genuinely left open by this section
+
+Rules:
+- Be exhaustive within this section, even when a provision seems secondary.
+- Give each distinct mechanism its own finding. Do not collapse a penalty, exemption, or deadline into a general summary.
+- A finding must be self-contained and say who does what, to whom, under what condition, and when the text supplies those details.
+- Copy a supporting quote exactly when it would let the writer substantiate a concrete mechanism, number, date, penalty, exemption, or definition. Never paraphrase inside "quote.text".
+- Use the most specific subsection label available in "quote.locator".
+- Record cross-references; do not guess what referenced law currently says.
+- Do not treat findings, purpose clauses, the bill title, or sponsor language as proof of real-world effects.
+- Set "substantive" to false only for a table of contents or boilerplate with no operative or interpretive content. An amendment, definition, effective date, or severability clause is substantive.
+- Do not claim that something is absent from the entire bill. You can only say it is not specified in this section.
+
+Bill: ${args.billNumber}
+Inventory unit: ${args.section.id}
+Locator: ${args.section.locator}
+Source offsets: ${args.section.start}-${args.section.end}
+
+<section>
+${args.section.text}
+</section>
+
+Return the structured notes now.`;
+}
+
+async function analyzeSection(
+  billNumber: string,
+  section: BillSourceSection,
+): Promise<BillSectionNotes> {
+  for (let attempt = 1; attempt <= MAX_ANALYSIS_ATTEMPTS; attempt++) {
+    try {
+      const { output, usage } = await generateText({
+        model: getStructuredLlm(),
+        output: Output.object({ schema: GeneratedSectionNotesSchema }),
+        prompt: buildSectionAnalysisPrompt({ billNumber, section }),
+      });
+      trackLLMUsage(usage.inputTokens, usage.outputTokens);
+      const generated = GeneratedSectionNotesSchema.parse(withoutNulls(output));
+      return BillSectionNotesSchema.parse({
+        ...generated,
+        sectionId: section.id,
+        locator: section.locator,
+      });
+    } catch (error) {
+      if (isRateLimitError(error)) {
+        setRateLimitHit(true);
+        throw new AIRateLimitError();
+      }
+      if (attempt === MAX_ANALYSIS_ATTEMPTS) throw error;
+      logger.warn(
+        `Analysis failed for ${billNumber} ${section.id}; retrying`,
+        error,
+      );
+    }
+  }
+  throw new Error(
+    `Analysis exhausted attempts for ${billNumber} ${section.id}`,
+  );
+}
+
+/**
+ * Read every inventoried source section and return coverage-checked notes.
+ * Any failed section fails the pass: the writer never receives partial notes
+ * and therefore cannot mistake an unvisited section for evidence of absence.
+ */
+export async function analyzeBill(args: {
+  billNumber: string;
+  fullText: string;
+}): Promise<BillAnalysis> {
+  if (rateLimitHit) throw new AIRateLimitError();
+
+  const sourceSections = splitBillIntoSections(args.fullText);
+  if (sourceSections.length === 0) {
+    throw new Error(`Cannot analyze empty bill text for ${args.billNumber}`);
+  }
+
+  const configuredConcurrency = Number(
+    process.env.BILL_ANALYSIS_CONCURRENCY ?? 3,
+  );
+  const concurrency = Number.isFinite(configuredConcurrency)
+    ? Math.min(8, Math.max(1, Math.floor(configuredConcurrency)))
+    : 3;
+  const limit = pLimit(concurrency);
+  const sections = await Promise.all(
+    sourceSections.map((section) =>
+      limit(() => analyzeSection(args.billNumber, section)),
+    ),
+  );
+  const analyzedSectionIds = sections.map((section) => section.sectionId);
+  const expectedSectionIds = sourceSections.map((section) => section.id);
+  if (
+    analyzedSectionIds.length !== expectedSectionIds.length ||
+    analyzedSectionIds.some((id, index) => id !== expectedSectionIds[index])
+  ) {
+    throw new Error(`Incomplete bill analysis coverage for ${args.billNumber}`);
+  }
+
+  const analysis = BillAnalysisSchema.parse({
+    sourceLength: args.fullText.length,
+    sourceHash: createHash("sha256").update(args.fullText).digest("hex"),
+    sectionCount: sourceSections.length,
+    analyzedSectionIds,
+    sections,
+  });
+  logger.success(
+    `Analyzed ${args.billNumber}: ${analysis.sectionCount} section unit(s), ${analysis.sections.reduce((sum, section) => sum + section.findings.length, 0)} finding(s)`,
+  );
+  return analysis;
+}
+
+/** Compact, lossless-enough serialization for the writing pass. */
+export function formatBillAnalysis(analysis: BillAnalysis): string {
+  return analysis.sections
+    .map((section) => {
+      const findings =
+        section.findings.length > 0
+          ? section.findings
+              .map((finding, index) => {
+                const metadata = [
+                  finding.actors.length
+                    ? `actors: ${finding.actors.join("; ")}`
+                    : "",
+                  finding.affectedParties.length
+                    ? `affected: ${finding.affectedParties.join("; ")}`
+                    : "",
+                  finding.crossReferences.length
+                    ? `cross-references: ${finding.crossReferences.join("; ")}`
+                    : "",
+                ]
+                  .filter(Boolean)
+                  .join(" | ");
+                const quote = finding.quote
+                  ? `\n   exact quote${finding.quote.locator ? ` (${finding.quote.locator})` : ""}: ${JSON.stringify(finding.quote.text)}`
+                  : "";
+                return `${index + 1}. [${finding.category}] ${finding.statement}${metadata ? `\n   ${metadata}` : ""}${quote}`;
+              })
+              .join("\n")
+          : "No material findings recorded.";
+      return `## ${section.sectionId} — ${section.locator}
+Substantive: ${section.substantive ? "yes" : "no"}
+Summary: ${section.summary}
+${findings}`;
+    })
+    .join("\n\n");
+}

--- a/apps/scraper/src/utils/ai/bill-brief.test.ts
+++ b/apps/scraper/src/utils/ai/bill-brief.test.ts
@@ -82,6 +82,7 @@ void test("older brief records stay renderable but are not current cache hits", 
   };
   const v5 = { ...brief(), ...metadata, version: 5 };
   const v6 = { ...brief(), ...metadata, version: 6 };
+  const v7 = { ...brief(), ...metadata, version: 7 };
 
   assert.equal(isUsableBillBrief(v5), true);
   assert.equal(isCurrentBillBrief(v5), false);
@@ -89,6 +90,9 @@ void test("older brief records stay renderable but are not current cache hits", 
   assert.equal(isUsableBillBrief(v6), true);
   assert.equal(isCurrentBillBrief(v6), false);
   assert.equal(parseBillBriefRecord(v6)?.version, BILL_BRIEF_VERSION);
+  assert.equal(isUsableBillBrief(v7), true);
+  assert.equal(isCurrentBillBrief(v7), false);
+  assert.equal(parseBillBriefRecord(v7)?.version, BILL_BRIEF_VERSION);
 
   const current = {
     ...v5,

--- a/apps/scraper/src/utils/ai/bill-brief.ts
+++ b/apps/scraper/src/utils/ai/bill-brief.ts
@@ -2,23 +2,25 @@
  * Bill Brief generation — turns a bill into the structured document defined in
  * `@acme/validators`, replacing the markdown wall of text as the primary read.
  *
- * The pipeline is deliberately three steps, only one of which costs a token:
+ * The pipeline separates reading from writing:
  *
- *   1. Structure (LLM). One schema-validated call grounded in the official text
- *      plus, when we have it, the existing long-form article — that article has
- *      already done the careful nonpartisan analysis, so this pass is mostly a
- *      restructuring job rather than a fresh reading.
- *   2. Verify quotes (deterministic). Every quote is checked against the full
+ *   1. Analyze (LLM). Every legislative section becomes structured, exhaustive
+ *      notes. No source section is silently clipped by a flat context window.
+ *   2. Write (LLM). One schema-validated call turns the accumulated notes into
+ *      the reader-facing brief without seeing raw bill text.
+ *   3. Verify quotes (deterministic). Every quote is checked against the full
  *      source text. Unverified quotes are dropped, not shipped — a brief may
  *      say less than the model wrote, but it never attributes words to a bill
  *      that the bill does not contain.
- *   3. Lint framing (deterministic). Loaded political phrasing in the model's
+ *   4. Lint framing (deterministic). Loaded political phrasing in the model's
  *      own prose triggers one regeneration with the offending phrases named.
  *      Quotes are exempt: a source is allowed to be partisan, we are not.
  */
 import { APICallError, generateText, Output, RetryError } from "ai";
+import { z } from "zod";
 
 import type {
+  BillAnalysis,
   BillBrief,
   BillBriefRecord,
   BriefLegalStatus,
@@ -33,11 +35,11 @@ import {
   BriefQuoteSchema,
   BriefVisualSchema,
 } from "@acme/validators";
-import { z } from "zod";
 
 import type { DualLensSource } from "./text-generation.js";
 import { trackLLMUsage } from "../costs.js";
 import { createLogger } from "../log.js";
+import { analyzeBill, formatBillAnalysis } from "./bill-analysis.js";
 import { getStructuredLlm } from "./provider.js";
 import {
   AIRateLimitError,
@@ -47,15 +49,6 @@ import {
 } from "./text-generation.js";
 
 const logger = createLogger("ai-brief");
-
-/**
- * How much of the bill the model reads. Bills routinely run past a provider's
- * context window; verification still runs against the *whole* text, so a quote
- * pulled from anywhere in the document validates even though the model only
- * saw the opening. Larger than the 3–4k windows used elsewhere because a brief
- * has to find concrete provisions, not just a gist.
- */
-const SOURCE_WINDOW = 24_000;
 
 /** Attempts at structuring before giving up (each is one LLM call). */
 const MAX_ATTEMPTS = 2;
@@ -114,7 +107,7 @@ function isRateLimitError(error: unknown): boolean {
 }
 
 /* ------------------------------------------------------------------ *
- * Step 2 — quote verification
+ * Step 3 — quote verification
  * ------------------------------------------------------------------ */
 
 /**
@@ -263,7 +256,7 @@ export function verifyBriefContext(
 }
 
 /* ------------------------------------------------------------------ *
- * Step 3 — framing lint
+ * Step 4 — framing lint
  * ------------------------------------------------------------------ */
 
 /**
@@ -522,7 +515,7 @@ export function findMissingEmphasis(brief: BillBrief): string[] {
 }
 
 /* ------------------------------------------------------------------ *
- * Step 1 — structuring
+ * Step 2 — writing
  * ------------------------------------------------------------------ */
 
 /**
@@ -546,7 +539,8 @@ function buildBriefPrompt(args: {
   billNumber: string;
   url: string;
   legalStatus: BriefLegalStatus;
-  sourceText: string;
+  analysis: BillAnalysis;
+  crsSummary?: string | null;
   priorArticle?: string | null;
   readingResearch?: string;
   readingSources?: DualLensSource[];
@@ -559,7 +553,8 @@ function buildBriefPrompt(args: {
     billNumber,
     url,
     legalStatus,
-    sourceText,
+    analysis,
+    crsSummary,
     priorArticle,
     readingResearch,
     readingSources,
@@ -599,7 +594,7 @@ function buildBriefPrompt(args: {
 
 ${tense}
 
-Your job is to explain the policy, not to promote or attack it. Treat the title, acronym, findings, purpose clauses, and sponsor statements as claims about intent — not proof of results. Base every factual statement on the supplied source text.
+Your job is to explain the policy, not to promote or attack it. Treat the title, acronym, findings, purpose clauses, and sponsor statements as claims about intent — not proof of results. Base every factual statement on the complete section analysis or the authoritative CRS summary below.
 
 Before filling in the fields, silently identify:
 1. The concrete mechanisms: what authority, rule, funding, eligibility, deadline, review, oversight, enforcement, or safeguard is added, removed, weakened, expanded, or transferred.
@@ -610,7 +605,7 @@ Before filling in the fields, silently identify:
 Rules that decide whether this brief ships:
 
 - **Mechanism over marketing.** Removing or waiving rules, reviews, reporting, or oversight is deregulation or reduced oversight. Say that. Do not hide it behind "cuts red tape", "modernizes", "streamlines", or "speeds up". Equally, do not attach a hostile label the text does not support.
-- **Quotes are verbatim.** Every "quote" field must be an exact, unedited span copied character-for-character from the source text below. Do not paraphrase, splice, trim mid-word, or fix grammar. Quotes that do not appear in the source are removed automatically, so a paraphrase in quotation marks just loses you a citation.
+- **Quotes are verbatim.** Every "quote" field must be copied character-for-character from an "exact quote" in the section notes below. The CRS summary and outside research are never quote sources. Do not paraphrase, splice, trim mid-word, or fix grammar. Quotes that do not appear in the original bill are removed automatically.
 - **No invented figures.** A number, date, or dollar amount goes in "facts" only if the source states it. Fewer facts is correct; a plausible-looking invented figure is not.
 - **No manufactured symmetry.** If the text supports one consequence more strongly than another, say so. Use "mixed" or "unclear" for an affected group rather than balancing the list for its own sake.
 - **Use only the allowed change kinds.** Every change "kind" must be exactly one of: "creates", "repeals", "expands", "restricts", "requires", "waives", "funds", or "transfers". Map synonyms such as "sets" or "establishes" to "creates", and "restructures" to the closest allowed mechanism.
@@ -622,7 +617,7 @@ Rules that decide whether this brief ships:
 
 Field notes:
 - "hook" is rendered under the heading "What this means for you" and replaces a grid of disconnected fact tiles. Write one coherent paragraph of 2–3 short sentences. First explain the most consequential practical changes; then state the most important limitation, condition, or uncertainty. Connect the ideas naturally instead of listing figures. Preserve legal status ("would" for proposals), and do not imply every reader is personally affected. Wrap two or three short, concrete phrases in **double asterisks** so a scanner can retain the key changes. Never bold a whole sentence, generic transition, verdict, or loaded language.
-- "changes" must contrast current law ("before") with the proposal ("after"). If the source does not establish current law, say that in "before" instead of guessing. Evaluate every change independently for a direct supporting quote; when the official text contains one, include it so every supported card has its own route back to the text. Never invent or stretch a quote merely to make the cards look consistent.
+- "changes" must contrast current law ("before") with the proposal ("after"). If the notes and CRS summary do not establish current law, say that in "before" instead of guessing. Evaluate every change independently for a direct supporting quote; when its analysis finding carries one, include it so every supported card has its own route back to the text. Never invent or stretch a quote merely to make the cards look consistent.
 - Each affected-group "takeaway" is the card's always-visible summary. Write one complete standalone sentence that names the group or a clear pronoun and states what would happen. For example: "States would get a **longer window to plan multi-year projects**." Do not return fragments such as "a longer funding horizon" or "depends on final rules." Put qualifications and mechanism detail in "effect".
 - "visual" is optional curated artwork. Use "infrastructure-repair" only for physical road or bridge work, "public-transit" only for rail or bus expansion, "data-privacy" only for company collection or use of personal data, and "data-control" only for a person's right to access or delete personal data. Evaluate each change independently and use different relevant visuals across cards when available; never repeat or force an image merely for visual parity. If none applies, omit the property; providers that cannot omit optional JSON fields may return null.
 - "unknowns" is required. Name what the text leaves open — undefined terms, delegated decisions, unfunded pieces, effects the source does not establish. Bold the exact unresolved choice or consequence, not a generic phrase such as "the text does not say."
@@ -636,8 +631,13 @@ Bill: ${billNumber} — ${title}
 Status: ${legalStatus === "enacted" ? "enacted" : "proposed, not yet law"}
 Source URL: ${url}
 ${
+  crsSummary
+    ? `\nAuthoritative Congressional Research Service summary (context only; never quote this as bill text):\n${crsSummary}\n`
+    : "\nNo CRS summary was available. Do not fill gaps with assumptions.\n"
+}
+${
   priorArticle
-    ? `\nPrior nonpartisan analysis of this bill (already vetted for framing — reuse its judgments, but pull all quotes from the official text below):\n${priorArticle.slice(0, 6000)}\n`
+    ? `\nPrior nonpartisan analysis of this bill (secondary context only; resolve conflicts in favor of the section notes and CRS summary, and never quote this as bill text):\n${priorArticle.slice(0, 6000)}\n`
     : ""
 }
 ${
@@ -652,8 +652,11 @@ ${
         .join("\n")}\n`
     : '\nNo verified outside sources were found. Omit "whyNotBefore" and return an empty reading list.\n'
 }
-Official text:
-${sourceText.slice(0, SOURCE_WINDOW)}
+Complete section inventory: ${analysis.sectionCount} of ${analysis.sectionCount} source units analyzed; ${analysis.sourceLength} source characters covered.
+Only make a bill-wide absence claim after checking every section below. A section-level note that something is unspecified is not by itself proof that the entire bill omits it.
+
+Structured section notes:
+${formatBillAnalysis(analysis)}
 ---
 
 Produce the structured brief now.`;
@@ -672,16 +675,33 @@ export async function generateBillBrief(args: {
   url: string;
   fullText: string;
   status?: string | null;
+  summary?: string | null;
   priorArticle?: string | null;
+  analysis?: BillAnalysis;
 }): Promise<Omit<BillBriefRecord, "generatedAt" | "modelVersion"> | null> {
   if (rateLimitHit) throw new AIRateLimitError();
 
   const legalStatus = deriveLegalStatus(args.status);
-  const readingResearch = await researchBillContext(
-    args.title,
-    args.billNumber,
-    args.fullText,
-  );
+  let analysis: BillAnalysis;
+  let readingResearch: Awaited<ReturnType<typeof researchBillContext>>;
+  try {
+    [analysis, readingResearch] = await Promise.all([
+      args.analysis
+        ? Promise.resolve(args.analysis)
+        : analyzeBill({
+            billNumber: args.billNumber,
+            fullText: args.fullText,
+          }),
+      researchBillContext(args.title, args.billNumber, args.fullText),
+    ]);
+  } catch (error) {
+    if (error instanceof AIRateLimitError || isRateLimitError(error)) {
+      setRateLimitHit(true);
+      throw new AIRateLimitError();
+    }
+    logger.warn(`Bill analysis failed for ${args.billNumber}`, error);
+    return null;
+  }
   let loadedPhrases: string[] | undefined;
   let jargonPhrases: string[] | undefined;
   let missingEmphasis: string[] | undefined;
@@ -699,7 +719,8 @@ export async function generateBillBrief(args: {
           billNumber: args.billNumber,
           url: args.url,
           legalStatus,
-          sourceText: args.fullText,
+          analysis,
+          crsSummary: args.summary,
           priorArticle: args.priorArticle,
           readingResearch: readingResearch.notes,
           readingSources: readingResearch.sources,

--- a/apps/scraper/src/utils/db/operations.ts
+++ b/apps/scraper/src/utils/db/operations.ts
@@ -1,13 +1,19 @@
+import type { BillAnalysis } from "@acme/validators";
 import { and, eq } from "@acme/db";
 import { db } from "@acme/db/client";
 import {
   Bill,
+  BillAnalysis as BillAnalysisCache,
   ContentBrief,
   ContentLens,
   CourtCase,
   GovernmentContent,
 } from "@acme/db/schema";
-import { isCurrentBillBrief } from "@acme/validators";
+import {
+  BILL_ANALYSIS_VERSION,
+  BillAnalysisRecordSchema,
+  isCurrentBillBrief,
+} from "@acme/validators";
 
 import type { NewItemLimiter } from "../new-item-limit.js";
 import type {
@@ -15,6 +21,7 @@ import type {
   CourtCaseData,
   GovernmentContentData,
 } from "../types.js";
+import { analyzeBill } from "../ai/bill-analysis.js";
 import { generateBillBrief } from "../ai/bill-brief.js";
 import { generateImageSearchKeywords } from "../ai/image-keywords.js";
 import { getTextModelVersion } from "../ai/provider.js";
@@ -447,6 +454,7 @@ export async function upsertContent(
         url,
         fullText: fullText!,
         status: input.data.status,
+        summary: input.data.summary,
         priorArticle: aiGeneratedArticle,
       });
     }
@@ -598,6 +606,7 @@ export async function upsertBillBrief(args: {
   url: string;
   fullText: string;
   status?: string | null;
+  summary?: string | null;
   priorArticle?: string | null;
 }): Promise<boolean> {
   const [existing] = await db
@@ -623,13 +632,25 @@ export async function upsertBillBrief(args: {
     return true;
   }
 
+  const analysis = await getOrCreateBillAnalysis({
+    contentId: args.contentId,
+    contentHash: args.contentHash,
+    billNumber: args.billNumber,
+    fullText: args.fullText,
+  });
+  if (!analysis) {
+    logger.warn(`Section analysis returned null for ${args.billNumber}`);
+    return false;
+  }
   const generated = await generateBillBrief({
     title: args.title,
     billNumber: args.billNumber,
     url: args.url,
     fullText: args.fullText,
     status: args.status,
+    summary: args.summary,
     priorArticle: args.priorArticle,
+    analysis,
   });
   if (!generated) {
     logger.warn(`Brief generation returned null for ${args.billNumber}`);
@@ -663,4 +684,73 @@ export async function upsertBillBrief(args: {
 
   logger.success(`Cached brief for ${args.billNumber}`);
   return true;
+}
+
+async function getOrCreateBillAnalysis(args: {
+  contentId: string;
+  contentHash: string;
+  billNumber: string;
+  fullText: string;
+}): Promise<BillAnalysis | null> {
+  const [existing] = await db
+    .select({
+      contentHash: BillAnalysisCache.contentHash,
+      analysis: BillAnalysisCache.analysis,
+      analysisVersion: BillAnalysisCache.analysisVersion,
+    })
+    .from(BillAnalysisCache)
+    .where(eq(BillAnalysisCache.contentId, args.contentId))
+    .limit(1);
+  const parsed = BillAnalysisRecordSchema.safeParse(existing?.analysis);
+
+  if (
+    !forceAIRegeneration &&
+    existing?.contentHash === args.contentHash &&
+    existing.analysisVersion === BILL_ANALYSIS_VERSION &&
+    parsed.success
+  ) {
+    logger.debug(`Section analysis already cached for ${args.billNumber}`);
+    return parsed.data;
+  }
+
+  let analysis: BillAnalysis;
+  try {
+    analysis = await analyzeBill({
+      billNumber: args.billNumber,
+      fullText: args.fullText,
+    });
+  } catch (error) {
+    if (error instanceof AIRateLimitError) throw error;
+    logger.warn(`Section analysis failed for ${args.billNumber}`, error);
+    return null;
+  }
+  const modelVersion = getTextModelVersion();
+  const record = BillAnalysisRecordSchema.parse({
+    ...analysis,
+    version: BILL_ANALYSIS_VERSION,
+    generatedAt: new Date().toISOString(),
+    modelVersion,
+  });
+  await db
+    .insert(BillAnalysisCache)
+    .values({
+      contentId: args.contentId,
+      contentHash: args.contentHash,
+      analysis: record,
+      analysisVersion: BILL_ANALYSIS_VERSION,
+      modelVersion,
+    })
+    .onConflictDoUpdate({
+      target: BillAnalysisCache.contentId,
+      set: {
+        contentHash: args.contentHash,
+        analysis: record,
+        analysisVersion: BILL_ANALYSIS_VERSION,
+        modelVersion,
+        updatedAt: new Date(),
+      },
+    });
+
+  logger.success(`Cached section analysis for ${args.billNumber}`);
+  return record;
 }

--- a/packages/db/drizzle/0005_mushy_blink.sql
+++ b/packages/db/drizzle/0005_mushy_blink.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "bill_analysis" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"content_id" uuid NOT NULL,
+	"content_hash" varchar(64) NOT NULL,
+	"analysis" jsonb NOT NULL,
+	"analysis_version" integer NOT NULL,
+	"model_version" varchar(50) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone,
+	CONSTRAINT "bill_analysis_contentId_unique" UNIQUE("content_id")
+);
+--> statement-breakpoint
+CREATE INDEX "bill_analysis_content_id_idx" ON "bill_analysis" USING btree ("content_id");

--- a/packages/db/drizzle/meta/0005_snapshot.json
+++ b/packages/db/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,2953 @@
+{
+  "id": "f4ee9c00-7ee1-4364-88d6-3667c485deb2",
+  "prevId": "ce10bc7e-4908-4e07-afe0-370189f10ef7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bill": {
+      "name": "bill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bill_number": {
+          "name": "bill_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sponsor": {
+          "name": "sponsor",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "introduced_date": {
+          "name": "introduced_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "congress": {
+          "name": "congress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chamber": {
+          "name": "chamber",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_website": {
+          "name": "source_website",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(bill_number, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(sponsor, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(description, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(full_text, '')), 'C')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "bill_search_vector_idx": {
+          "name": "bill_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bill_number_trgm_idx": {
+          "name": "bill_number_trgm_idx",
+          "columns": [
+            {
+              "expression": "bill_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bill_billNumber_sourceWebsite_unique": {
+          "name": "bill_billNumber_sourceWebsite_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bill_number",
+            "source_website"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bill_description_max_100_chars": {
+          "name": "bill_description_max_100_chars",
+          "value": "\"bill\".\"description\" is null or char_length(\"bill\".\"description\") <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bill_analysis": {
+      "name": "bill_analysis",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis": {
+          "name": "analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_version": {
+          "name": "analysis_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bill_analysis_content_id_idx": {
+          "name": "bill_analysis_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bill_analysis_contentId_unique": {
+          "name": "bill_analysis_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_content": {
+      "name": "blocked_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocked_content_user_id_idx": {
+          "name": "blocked_content_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocked_content_userId_name_type_unique": {
+          "name": "blocked_content_userId_name_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name",
+            "type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate": {
+      "name": "candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "party": {
+          "name": "party",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_url": {
+          "name": "candidate_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incumbent": {
+          "name": "incumbent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "biography": {
+          "name": "biography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_contest_id_idx": {
+          "name": "candidate_contest_id_idx",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.civic_api_cache": {
+      "name": "civic_api_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address_hash": {
+          "name": "address_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "response_data": {
+          "name": "response_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "civic_cache_expires_idx": {
+          "name": "civic_cache_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "civic_api_cache_addressHash_endpoint_params_unique": {
+          "name": "civic_api_cache_addressHash_endpoint_params_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "address_hash",
+            "endpoint",
+            "params"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_brief": {
+      "name": "content_brief",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "content_brief_content_id_idx": {
+          "name": "content_brief_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_brief_contentType_contentId_unique": {
+          "name": "content_brief_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "content_type",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_lens": {
+      "name": "content_lens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lens_data": {
+          "name": "lens_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "content_lens_content_id_idx": {
+          "name": "content_lens_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_lens_contentType_contentId_unique": {
+          "name": "content_lens_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "content_type",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest": {
+      "name": "contest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "election_id": {
+          "name": "election_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "office": {
+          "name": "office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_name": {
+          "name": "district_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_scope": {
+          "name": "district_scope",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_elected": {
+          "name": "number_elected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referendum_title": {
+          "name": "referendum_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_subtitle": {
+          "name": "referendum_subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_text": {
+          "name": "referendum_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_pro_statement": {
+          "name": "referendum_pro_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_con_statement": {
+          "name": "referendum_con_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_url": {
+          "name": "referendum_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_description": {
+          "name": "role_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_is_ai_generated": {
+          "name": "summary_is_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fiscal_impact": {
+          "name": "fiscal_impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citations": {
+          "name": "citations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contest_election_id_idx": {
+          "name": "contest_election_id_idx",
+          "columns": [
+            {
+              "expression": "election_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.court_case": {
+      "name": "court_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court": {
+          "name": "court",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_date": {
+          "name": "filed_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(case_number, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(description, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(full_text, '')), 'C')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "court_case_search_vector_idx": {
+          "name": "court_case_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "court_case_number_trgm_idx": {
+          "name": "court_case_number_trgm_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "court_case_caseNumber_court_unique": {
+          "name": "court_case_caseNumber_court_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "case_number",
+            "court"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.election": {
+      "name": "election",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_type": {
+          "name": "election_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ocd_division_id": {
+          "name": "ocd_division_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadlines": {
+          "name": "deadlines",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "election_externalId_source_unique": {
+          "name": "election_externalId_source_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "external_id",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.government_content": {
+      "name": "government_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whitehouse.gov'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(description, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(full_text, '')), 'C')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "government_content_search_vector_idx": {
+          "name": "government_content_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "government_content_url_unique": {
+          "name": "government_content_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_agenda_item": {
+      "name": "legistar_agenda_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_item_id": {
+          "name": "event_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda_sequence": {
+          "name": "agenda_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_number": {
+          "name": "agenda_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed_flag_name": {
+          "name": "passed_flag_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tally": {
+          "name": "tally",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mover_name": {
+          "name": "mover_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seconder_name": {
+          "name": "seconder_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_file": {
+          "name": "matter_file",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_name": {
+          "name": "matter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_type": {
+          "name": "matter_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_status": {
+          "name": "matter_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "agenda_note": {
+          "name": "agenda_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_note": {
+          "name": "minutes_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_agenda_item_event_idx": {
+          "name": "legistar_agenda_item_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_agenda_item_jurisdiction_eventItemId_unique": {
+          "name": "legistar_agenda_item_jurisdiction_eventItemId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jurisdiction",
+            "event_item_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_body": {
+      "name": "legistar_body",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_guid": {
+          "name": "body_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_flag": {
+          "name": "active_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "number_of_members": {
+          "name": "number_of_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_body_jurisdiction_bodyId_unique": {
+          "name": "legistar_body_jurisdiction_bodyId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jurisdiction",
+            "body_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_matter": {
+      "name": "legistar_matter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matter_guid": {
+          "name": "matter_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_file": {
+          "name": "matter_file",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_name": {
+          "name": "body_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_date": {
+          "name": "intro_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_date": {
+          "name": "agenda_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed_date": {
+          "name": "passed_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enactment_date": {
+          "name": "enactment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enactment_number": {
+          "name": "enactment_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester": {
+          "name": "requester",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_matter_file_idx": {
+          "name": "legistar_matter_file_idx",
+          "columns": [
+            {
+              "expression": "matter_file",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_matter_jurisdiction_matterId_unique": {
+          "name": "legistar_matter_jurisdiction_matterId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jurisdiction",
+            "matter_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_meeting": {
+      "name": "legistar_meeting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_guid": {
+          "name": "event_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_name": {
+          "name": "body_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_file": {
+          "name": "agenda_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_file": {
+          "name": "minutes_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_path": {
+          "name": "video_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_status_name": {
+          "name": "agenda_status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_status_name": {
+          "name": "minutes_status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_site_url": {
+          "name": "in_site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_meeting_date_idx": {
+          "name": "legistar_meeting_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_meeting_jurisdiction_eventId_unique": {
+          "name": "legistar_meeting_jurisdiction_eventId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jurisdiction",
+            "event_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_vote": {
+      "name": "legistar_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_id": {
+          "name": "vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_item_id": {
+          "name": "event_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_name": {
+          "name": "person_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_name": {
+          "name": "value_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legistar_vote_event_item_idx": {
+          "name": "legistar_vote_event_item_idx",
+          "columns": [
+            {
+              "expression": "event_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legistar_vote_person_idx": {
+          "name": "legistar_vote_person_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_vote_jurisdiction_voteId_unique": {
+          "name": "legistar_vote_jurisdiction_voteId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "jurisdiction",
+            "vote_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polling_location": {
+      "name": "polling_location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "election_id": {
+          "name": "election_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line2": {
+          "name": "address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours": {
+          "name": "hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_services": {
+          "name": "voter_services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "polling_location_election_id_idx": {
+          "name": "polling_location_election_id_idx",
+          "columns": [
+            {
+              "expression": "election_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_description": {
+      "name": "role_description",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'seed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "role_description_role_level_unique": {
+          "name": "role_description_role_level_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "role",
+            "level"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_article": {
+      "name": "saved_article",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_article_user_id_idx": {
+          "name": "saved_article_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "saved_article_userId_contentId_unique": {
+          "name": "saved_article_userId_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "content_types": {
+          "name": "content_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preference_userId_unique": {
+          "name": "user_preference_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "personalize": {
+          "name": "personalize",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "analytics": {
+          "name": "analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "crash": {
+          "name": "crash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "offline": {
+          "name": "offline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_userId_unique": {
+          "name": "user_settings_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video": {
+      "name": "video",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_data": {
+          "name": "image_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_mime_type": {
+          "name": "image_mime_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_width": {
+          "name": "image_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_height": {
+          "name": "image_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement_metrics": {
+          "name": "engagement_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"likes\":0,\"comments\":0,\"shares\":0}'::jsonb"
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "video_content_id_idx": {
+          "name": "video_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "video_created_at_idx": {
+          "name": "video_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "video_contentType_contentId_unique": {
+          "name": "video_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "content_type",
+            "content_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1785197666763,
       "tag": "0004_glorious_skrulls",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1785213786839,
+      "tag": "0005_mushy_blink",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -4,7 +4,7 @@ import { check, customType, index, pgTable, unique } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod/v4";
 
-import type { BillBriefRecord } from "@acme/validators";
+import type { BillAnalysisRecord, BillBriefRecord } from "@acme/validators";
 
 // Custom bytea type for binary data storage
 const bytea = customType<{ data: Buffer; notNull: false; default: false }>({
@@ -747,6 +747,31 @@ export const ContentBrief = pgTable(
   (table) => ({
     uniqueContentBrief: unique().on(table.contentType, table.contentId),
     contentIdIndex: index("content_brief_content_id_idx").on(table.contentId),
+  }),
+);
+
+/**
+ * Exhaustive section notes for bill text. These are deliberately cached apart
+ * from the reader-facing brief: changing tone or presentation can regenerate
+ * the writing pass without paying to re-read an unchanged bill.
+ */
+export const BillAnalysis = pgTable(
+  "bill_analysis",
+  (t) => ({
+    id: t.uuid().notNull().primaryKey().defaultRandom(),
+    contentId: t.uuid().notNull(),
+    contentHash: t.varchar({ length: 64 }).notNull(),
+    analysis: t.jsonb().$type<BillAnalysisRecord>().notNull(),
+    analysisVersion: t.integer().notNull(),
+    modelVersion: t.varchar({ length: 50 }).notNull(),
+    createdAt: t.timestamp().defaultNow().notNull(),
+    updatedAt: t
+      .timestamp({ mode: "date", withTimezone: true })
+      .$onUpdateFn(() => sql`now()`),
+  }),
+  (table) => ({
+    uniqueBillAnalysis: unique().on(table.contentId),
+    contentIdIndex: index("bill_analysis_content_id_idx").on(table.contentId),
   }),
 );
 

--- a/packages/validators/src/bill-analysis.ts
+++ b/packages/validators/src/bill-analysis.ts
@@ -1,0 +1,115 @@
+import { z } from "zod";
+
+/**
+ * Bump when the section-note contract changes. Analysis is cached separately
+ * from the reader-facing brief so editorial rewrites can reuse the expensive
+ * read-through while a changed note schema forces a fresh analysis.
+ */
+export const BILL_ANALYSIS_VERSION = 1;
+
+export const BillAnalysisFindingCategorySchema = z.enum([
+  "change",
+  "authority",
+  "affected-party",
+  "funding",
+  "deadline",
+  "effective-date",
+  "enforcement",
+  "penalty",
+  "exemption",
+  "definition",
+  "cross-reference",
+  "implementation",
+  "oversight",
+  "uncertainty",
+]);
+export type BillAnalysisFindingCategory = z.infer<
+  typeof BillAnalysisFindingCategorySchema
+>;
+
+export const BillAnalysisQuoteSchema = z.object({
+  text: z
+    .string()
+    .trim()
+    .min(20)
+    .max(1600)
+    .describe(
+      "An exact, unedited span from this source section that supports the finding.",
+    ),
+  locator: z
+    .string()
+    .trim()
+    .max(160)
+    .optional()
+    .describe("The most specific subsection or paragraph label available."),
+});
+export type BillAnalysisQuote = z.infer<typeof BillAnalysisQuoteSchema>;
+
+export const BillAnalysisFindingSchema = z.object({
+  category: BillAnalysisFindingCategorySchema,
+  statement: z
+    .string()
+    .trim()
+    .min(10)
+    .max(600)
+    .describe(
+      "A precise, self-contained note describing the mechanism, condition, or unresolved point.",
+    ),
+  actors: z
+    .array(z.string().trim().min(1).max(120))
+    .max(8)
+    .describe(
+      "People, agencies, courts, governments, or organizations acting.",
+    ),
+  affectedParties: z
+    .array(z.string().trim().min(1).max(140))
+    .max(8)
+    .describe("People or institutions directly affected by the provision."),
+  crossReferences: z
+    .array(z.string().trim().min(1).max(180))
+    .max(8)
+    .describe("Other statutes, sections, rules, or definitions referenced."),
+  quote: BillAnalysisQuoteSchema.optional(),
+});
+export type BillAnalysisFinding = z.infer<typeof BillAnalysisFindingSchema>;
+
+export const BillSectionNotesSchema = z.object({
+  sectionId: z.string().trim().min(1).max(120),
+  locator: z.string().trim().min(1).max(180),
+  summary: z
+    .string()
+    .trim()
+    .min(10)
+    .max(900)
+    .describe(
+      "A compact inventory of what this section does, without editorial framing.",
+    ),
+  substantive: z
+    .boolean()
+    .describe(
+      "False only for tables of contents, boilerplate, or other text with no operative or interpretive content.",
+    ),
+  findings: z
+    .array(BillAnalysisFindingSchema)
+    .max(30)
+    .describe(
+      "Specific and exhaustive notes for every material mechanism in the section.",
+    ),
+});
+export type BillSectionNotes = z.infer<typeof BillSectionNotesSchema>;
+
+export const BillAnalysisSchema = z.object({
+  sourceLength: z.number().int().nonnegative(),
+  sourceHash: z.string().length(64),
+  sectionCount: z.number().int().positive(),
+  analyzedSectionIds: z.array(z.string().trim().min(1).max(120)).min(1),
+  sections: z.array(BillSectionNotesSchema).min(1),
+});
+export type BillAnalysis = z.infer<typeof BillAnalysisSchema>;
+
+export const BillAnalysisRecordSchema = BillAnalysisSchema.extend({
+  version: z.literal(BILL_ANALYSIS_VERSION),
+  generatedAt: z.string(),
+  modelVersion: z.string(),
+});
+export type BillAnalysisRecord = z.infer<typeof BillAnalysisRecordSchema>;

--- a/packages/validators/src/bill-brief.ts
+++ b/packages/validators/src/bill-brief.ts
@@ -32,7 +32,7 @@
 import { z } from "zod";
 
 /** Bump when the shape or generation contract requires cached rows to refresh. */
-export const BILL_BRIEF_VERSION = 7;
+export const BILL_BRIEF_VERSION = 8;
 
 /**
  * What a provision mechanically does. Deliberately descriptive: a reader can
@@ -404,6 +404,12 @@ const BillBriefV6RecordSchema = BillBriefSchema.extend({
   ...BriefRecordMetadataSchema,
 });
 
+/** The last flat-source-window brief, before section-by-section analysis. */
+const BillBriefV7RecordSchema = BillBriefSchema.extend({
+  version: z.literal(7),
+  ...BriefRecordMetadataSchema,
+});
+
 /** The immediately preceding rich-brief shape, before cited history was added. */
 const BillBriefV5RecordSchema = BillBriefSchema.extend({
   version: z.literal(5),
@@ -443,8 +449,8 @@ const BillBriefV1RecordSchema = z.object({
 });
 
 function conciseTakeaway(effect: string): string {
-  const firstSentence = effect.match(/^.*?[.!?](?:\s|$)/)?.[0]?.trim();
-  const candidate = firstSentence || effect;
+  const firstSentence = /^.*?[.!?](?:\s|$)/.exec(effect)?.[0]?.trim();
+  const candidate = firstSentence ?? effect;
   if (candidate.length <= 140) return candidate;
   return `${candidate.slice(0, 136).replace(/\s+\S*$/, "")}…`;
 }
@@ -457,6 +463,11 @@ function conciseTakeaway(effect: string): string {
 export function parseBillBriefRecord(value: unknown): BillBriefRecord | null {
   const current = BillBriefRecordSchema.safeParse(value);
   if (current.success) return current.data;
+
+  const v7 = BillBriefV7RecordSchema.safeParse(value);
+  if (v7.success) {
+    return { ...v7.data, version: BILL_BRIEF_VERSION };
+  }
 
   const v6 = BillBriefV6RecordSchema.safeParse(value);
   if (v6.success) {

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 
 export * from "./bill-brief";
+export * from "./bill-analysis";
 
 export const unused = z.string().describe(
   `This lib is currently not used as we use drizzle-zod for simple schemas


### PR DESCRIPTION
Closes #216.

## What changed

- removes the 1,000-word Congress.gov ingest cap so complete bill text is stored
- inventories every bill section and analyzes each section independently into typed, facet-based notes covering mechanisms, actors, affected parties, dates, funding, penalties, exemptions, definitions, cross-references, oversight, and uncertainties
- bounds exceptionally long sections with overlapping chunks and asserts complete source-offset coverage before writing
- makes the reader-facing brief consume only the complete section notes, authoritative non-quotable CRS context, and verified outside research—never a flat raw-text slice
- persists analysis separately in `bill_analysis`, versioned independently from the brief, so editorial reruns can reuse an unchanged bill's read-through
- bumps the brief contract to v8 while keeping v7 records renderable and makes the backfill select stale schema versions
- keeps deterministic full-text quote verification as the final provenance check

## Why

The previous `slice(0, 24_000)` made later provisions invisible and allowed missing context to be reported as a bill-wide absence. The new pipeline fails closed if any source unit is unvisited, while the writing pass receives an explicit complete inventory.

The note strategy follows hierarchical long-document summarization research: preserve discourse structure, make a local facet inventory first, then synthesize from that content plan. For the current plain-text storage format, `SEC.`/`SECTION` markers provide the primary structure; markerless text and oversized sections use a bounded overlap fallback without dropping characters.

## Validation

- `pnpm --filter @acme/scraper test` — 35 passing
- `pnpm typecheck` — 16 tasks passing
- `pnpm lint` — 13 tasks passing
- `pnpm --filter @acme/scraper build`
- `pnpm --filter @acme/validators build`
- `pnpm --filter @acme/db build`
- `POSTGRES_URL=postgresql://... pnpm --filter @acme/db db-check`
- live H.R. 7008 reported-text check: 1,646 words retained, penalty text covered, maximum analysis unit 7,739 characters