### PR TITLE
Store the operative bill text, not the introduced draft

### DIFF
--- a/apps/scraper/src/scrapers/congress.test.ts
+++ b/apps/scraper/src/scrapers/congress.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   capToTsvectorLimit,
+  orderTextVersionsNewestFirst,
   parseBillIdentifier,
   parseBillUrl,
 } from "./congress.js";
@@ -63,4 +64,43 @@ test("capToTsvectorLimit keeps oversized text under the tsvector byte ceiling", 
   assert.ok(Buffer.byteLength(capped, "utf8") <= 800_000);
   assert.ok(capped.length > 0);
   assert.doesNotMatch(capped, /\s$/u);
+});
+
+const textVersion = (type: string, date: string | null) => ({
+  type,
+  date,
+  formats: [{ type: "Formatted Text", url: `https://example.test/${type}` }],
+});
+
+test("orderTextVersionsNewestFirst picks the operative text, not the introduced draft", () => {
+  // The real H.R. 7008 payload order: congress.gov returns newest-first, and a
+  // plain reverse() picked "Introduced in House" — missing the photo-ID
+  // provisions added by the substitute the House actually passed.
+  const versions = [
+    textVersion("Engrossed in House", "2026-07-22T04:00:00Z"),
+    textVersion("Reported in House", "2026-02-03T05:00:00Z"),
+    textVersion("Introduced in House", "2026-01-12T05:00:00Z"),
+  ];
+
+  assert.equal(
+    orderTextVersionsNewestFirst(versions)[0]!.type,
+    "Engrossed in House",
+  );
+  // Same answer regardless of the order the API hands us.
+  assert.equal(
+    orderTextVersionsNewestFirst([...versions].reverse())[0]!.type,
+    "Engrossed in House",
+  );
+});
+
+test("orderTextVersionsNewestFirst sorts undated versions last", () => {
+  const ordered = orderTextVersionsNewestFirst([
+    textVersion("Undated", null),
+    textVersion("Introduced in House", "2026-01-12T05:00:00Z"),
+    textVersion("Engrossed in House", "2026-07-22T04:00:00Z"),
+  ]);
+  assert.deepEqual(
+    ordered.map((v) => v.type),
+    ["Engrossed in House", "Introduced in House", "Undated"],
+  );
 });

--- a/apps/scraper/src/scrapers/congress.ts
+++ b/apps/scraper/src/scrapers/congress.ts
@@ -242,6 +242,34 @@ export function capToTsvectorLimit(text: string, label: string): string {
   return result;
 }
 
+/**
+ * Order text versions newest-first so we store the *operative* text.
+ *
+ * This used to be `[...textVersions].reverse()`, which assumes the API returns
+ * oldest-first. It returns newest-first, so the reverse picked the version a
+ * bill was introduced as — for every bill, forever. H.R. 7008 passed the House
+ * with a substitute that added SEC. 3, "Requiring Voters To Provide Photo
+ * Identification"; we stored the January introduced draft, which contains none
+ * of it, and the app told readers the bill was only about stock trading.
+ *
+ * Sort explicitly rather than trusting either order. Versions without a date
+ * sort last: an undated version is not evidence of being current.
+ */
+export function orderTextVersionsNewestFirst(
+  versions: readonly ApiTextVersion[],
+): ApiTextVersion[] {
+  return [...versions].sort((a, b) => {
+    const aTime = a.date ? Date.parse(a.date) : NaN;
+    const bTime = b.date ? Date.parse(b.date) : NaN;
+    const aValid = !Number.isNaN(aTime);
+    const bValid = !Number.isNaN(bTime);
+    if (aValid && bValid) return bTime - aTime;
+    if (aValid) return -1;
+    if (bValid) return 1;
+    return 0;
+  });
+}
+
 export async function fetchFullText(
   congress: number,
   billType: string,
@@ -253,7 +281,7 @@ export async function fetchFullText(
     );
     if (!data.textVersions?.length) return undefined;
 
-    for (const version of [...data.textVersions].reverse()) {
+    for (const version of orderTextVersionsNewestFirst(data.textVersions)) {
       const txtFormat = version.formats.find(
         (f) => f.type === "Formatted Text",
       );


### PR DESCRIPTION
`fetchFullText` iterated `[...textVersions].reverse()`, assuming congress.gov returns text versions oldest-first. **It returns newest-first**, so the reverse selected the version each bill was *introduced* as. Every bill amended after introduction is represented in our database by a superseded draft.

## What this cost us

H.R. 7008 passed the House on 2026-07-22 with a substitute (H.AMDT. 267) adding **SEC. 3, "Requiring Voters To Provide Photo Identification"** — amending the Help America Vote Act so an election official "may not provide a ballot for an election for Federal office" without photo ID.

| version | chars | |
|---|---|---|
| Engrossed in House (passed 07-22) | 14,747 | the operative text |
| Introduced in House (01-12) | 9,315 | **what we stored** |
| Stored before the truncation fix | 6,383 | 43% of the operative bill |

The app described a congressional stock-trading bill and never mentioned the election provisions the House actually voted on — 13 occurrences of "photo identification" that were simply not in our copy.

The dual lens *did* surface it, but only by researching outside reporting (a member's floor vote explainer). That finding was then lost when the lens regenerated, because the text needed to ground the claim was never in our copy of the bill. Chasing "why did the lens lose this?" is what surfaced the bug.

## Fix

Sort by date explicitly rather than trusting either array order. Undated versions sort last — an undated version is not evidence of being current. Tests cover the real H.R. 7008 payload order and assert the same answer regardless of the order the API hands us.

## Follow-ups not in this PR

- **Existing rows are stale.** Every bill needs re-scraping to pick up its operative text. The `--bill` flag handles individual bills; the backlog needs a plan.
- Bills are only re-fetched when the feed surfaces them, so a bill that passed after we last saw it keeps its introduced text indefinitely.

Related: #216, and the truncation/budget fixes in #217.