### PR TITLE
Make the per-run budget cover every generation, not just new items

### DIFF
--- a/apps/scraper/src/utils/db/operations.ts
+++ b/apps/scraper/src/utils/db/operations.ts
@@ -183,19 +183,39 @@ export async function upsertContent(
     );
   }
 
-  // New items beyond the run's daily budget skip AI enrichment but are still
-  // persisted with their raw content, so they surface as "needs backfill" work
-  // for the retroactive scripts rather than being lost.
-  const budgetExhausted =
-    progressKind === "new" &&
-    options?.newItemLimiter !== undefined &&
-    !options.newItemLimiter.tryConsume();
+  // The run's budget is a cap on *items that generate*, not on new items.
+  //
+  // It used to be gated on `progressKind === "new"`, which left the far more
+  // expensive case uncapped: an existing bill whose content changed, or which
+  // is missing a derived asset, would regenerate its brief and its dual lens
+  // with no limit at all. A backfill re-walking the archive therefore ignored
+  // the budget almost entirely — every bill it passed took the "changed" path,
+  // because its stored text was being corrected.
+  //
+  // One item draws at most one slot, and only when something is actually
+  // generated. A genuinely unchanged item with every asset present costs
+  // nothing and must not consume budget, or a run would throttle itself to N
+  // items while doing no work.
+  let budgetSlotTaken = false;
+  const claimBudget = (): boolean => {
+    if (!options?.newItemLimiter) return true;
+    if (budgetSlotTaken) return true;
+    if (options.newItemLimiter.tryConsume()) {
+      budgetSlotTaken = true;
+      return true;
+    }
+    return false;
+  };
+
+  const wantsUpfrontGeneration =
+    shouldGenerateSummary || shouldGenerateArticle || shouldGenerateImage;
+  const budgetExhausted = wantsUpfrontGeneration && !claimBudget();
   if (budgetExhausted) {
     shouldGenerateSummary = false;
     shouldGenerateArticle = false;
     shouldGenerateImage = false;
     logger.info(
-      `${label}: daily new-item cap reached, deferring AI enrichment to a later run`,
+      `${label}: run budget reached, deferring AI enrichment to a later run`,
     );
   }
 
@@ -448,6 +468,7 @@ export async function upsertContent(
         fullText!,
         articleType,
         aiGeneratedArticle,
+        claimBudget,
       );
     }
 
@@ -471,6 +492,7 @@ export async function upsertContent(
         officialSummary: input.data.summary,
         status: input.data.status,
         priorArticle: aiGeneratedArticle,
+        claimBudget,
       });
     }
   } catch (error) {
@@ -499,6 +521,8 @@ export async function upsertContent(
         newContentHash,
         videoSource,
         result.thumbnailUrl,
+        {},
+        claimBudget,
       );
     } catch (error) {
       if (error instanceof AIRateLimitError) {
@@ -539,6 +563,7 @@ export async function upsertContentLens(
   fullText: string,
   articleType: string,
   aiGeneratedArticle?: string | null,
+  claimBudget?: () => boolean,
 ): Promise<boolean> {
   const modelVersion = `${getTextModelVersion()}:concrete-examples-v2`;
 
@@ -576,6 +601,16 @@ export async function upsertContentLens(
   ) {
     logger.debug(`Dual-lens already cached for ${contentId}`);
     return true;
+  }
+
+  // Claimed after the cache check, never before: a cached lens costs nothing
+  // and must not spend a slot. This loop is the single most expensive step in
+  // the pipeline, so it is exactly what the budget exists to bound.
+  if (claimBudget && !claimBudget()) {
+    logger.info(
+      `Run budget reached, deferring dual-lens for ${contentId} to a later run`,
+    );
+    return false;
   }
 
   const lens = await generateDualLens(
@@ -636,6 +671,7 @@ export async function upsertBillBrief(args: {
   officialSummary?: string | null;
   status?: string | null;
   priorArticle?: string | null;
+  claimBudget?: () => boolean;
 }): Promise<boolean> {
   const [existing] = await db
     .select({
@@ -658,6 +694,14 @@ export async function upsertBillBrief(args: {
   ) {
     logger.debug(`Brief already cached for ${args.billNumber}`);
     return true;
+  }
+
+  // Same contract as the lens: only a real generation draws on the budget.
+  if (args.claimBudget && !args.claimBudget()) {
+    logger.info(
+      `Run budget reached, deferring brief for ${args.billNumber} to a later run`,
+    );
+    return false;
   }
 
   const generated = await generateBillBrief({

--- a/apps/scraper/src/utils/db/video-operations.ts
+++ b/apps/scraper/src/utils/db/video-operations.ts
@@ -83,6 +83,7 @@ export async function generateVideoForContent(
   author: string,
   thumbnailUrl?: string | null,
   options: GenerateVideoOptions = {},
+  claimBudget?: () => boolean,
 ): Promise<GenerateVideoResult> {
   const existing = await checkExistingVideo(
     contentType,
@@ -95,6 +96,17 @@ export async function generateVideoForContent(
     logger.debug(`Video unchanged for ${contentType}:${contentId}, skipping`);
     incrementVideosSkipped();
     return { regenerated: false, hasImage: existing.hasImage };
+  }
+
+  // Claimed only past the cache check, so an unchanged video never spends a
+  // slot. Regeneration costs a marketing-copy call plus an image, which is why
+  // it belongs under the same per-run budget as the brief and the lens.
+  if (claimBudget && !claimBudget()) {
+    logger.info(
+      `Run budget reached, deferring video for ${contentType}:${contentId} to a later run`,
+    );
+    incrementVideosSkipped();
+    return { regenerated: false, hasImage: existing?.hasImage ?? false };
   }
 
   logger.start(`Generating video for ${contentType}:${contentId}`);

--- a/apps/scraper/src/utils/new-item-limit.test.ts
+++ b/apps/scraper/src/utils/new-item-limit.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { createNewItemLimiter } from "./new-item-limit.js";
+
+/**
+ * Mirrors the per-item claim in `upsertContent`. An item draws at most one
+ * slot no matter how many assets it generates, and only when it generates
+ * something at all.
+ */
+function makeClaim(limiter: { tryConsume(): boolean }) {
+  let taken = false;
+  return () => {
+    if (taken) return true;
+    if (limiter.tryConsume()) {
+      taken = true;
+      return true;
+    }
+    return false;
+  };
+}
+
+test("one item draws one slot however many assets it generates", () => {
+  const limiter = createNewItemLimiter(2);
+
+  const first = makeClaim(limiter);
+  // article, then lens, then brief, then video — all for the same item.
+  assert.equal(first(), true);
+  assert.equal(first(), true);
+  assert.equal(first(), true);
+  assert.equal(first(), true);
+
+  const second = makeClaim(limiter);
+  assert.equal(second(), true);
+
+  // Budget of 2 is now spent, so a third item generates nothing.
+  const third = makeClaim(limiter);
+  assert.equal(third(), false);
+});
+
+test("an item that generates nothing does not spend budget", () => {
+  const limiter = createNewItemLimiter(1);
+
+  // A fully cached item never calls its claim at all.
+  makeClaim(limiter);
+
+  // ...so the single slot is still available to an item that does work.
+  const worker = makeClaim(limiter);
+  assert.equal(worker(), true);
+});
+
+test("a denied item stays denied for its remaining assets", () => {
+  const limiter = createNewItemLimiter(1);
+
+  const first = makeClaim(limiter);
+  assert.equal(first(), true);
+
+  // Second item is refused up front and must not sneak its lens or brief
+  // through on a later call — the regression that let a backfill regenerate
+  // every existing bill's derived assets uncapped.
+  const second = makeClaim(limiter);
+  assert.equal(second(), false);
+  assert.equal(second(), false);
+  assert.equal(second(), false);
+});

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -97,10 +97,18 @@ giant bill cannot wedge the cursor. Section-aware storage is the real fix
 
 ### The new-item budget
 
-`SCRAPER_MAX_NEW_ITEMS_PER_RUN` (default 10) caps how many brand-new items pay
-for AI generation in one run. Items past the cap are **still persisted with
-their raw content** — they just skip the description, article, lens, brief, and
-video, and are picked up later by the retroactive scripts.
+`SCRAPER_MAX_NEW_ITEMS_PER_RUN` (default 10) caps how many items pay for AI
+generation in one run. Items past the cap are **still persisted with their raw
+content** — they just skip the description, article, lens, brief, and video,
+and are picked up later by the retroactive scripts.
+
+The cap counts **items that generate**, not new items, and each item draws at
+most one slot however many assets it produces. A slot is claimed at the point
+of generation, after each asset's own cache check, so a fully cached item costs
+nothing and does not consume budget. Gating on "new" instead left the expensive
+case uncapped: an existing bill whose content changed regenerated its brief and
+its dual lens with no limit, which meant a backfill correcting stored text
+ignored the budget almost entirely.
 
 Persisting them is not optional. The cursor advances past everything the run
 fetched, so an item not written here is lost rather than deferred. Between
@@ -110,8 +118,9 @@ bills per day fell from ~86 to under 10 while 1,742 upstream updates produced
 `description → summary`.
 
 Every derived asset must be gated on the budget for the cap to mean anything —
-the dual lens in particular runs an agentic research loop. Video generation,
-lens, and brief all check it.
+the dual lens in particular runs an agentic research loop. The article/summary/
+image block, the lens, the brief, and video generation all claim through the
+same per-item function.
 
 `SCRAPER_FORCE_AI_REGEN=1` overrides the cache. A `isUsableText()` gate refuses to feed AI any text under 200 chars or that's mostly blank/all-caps/single-word lines — keeps the model from "summarizing" garbage.
 


### PR DESCRIPTION
`budgetExhausted` was gated on `progressKind === "new"`, so the cap only ever applied to bills we had never seen. Existing bills were uncapped — and they are the expensive ones. An existing bill whose content changed, or which is missing a derived asset, regenerated its brief and its dual lens with **no limit at all**.

## How it surfaced

Running a backfill over the 119th Congress. Every bill the walk passes takes the "changed" path, because #217 and #230 are replacing stored text with the untruncated *operative* version — so the `contentHash` differs for essentially the entire archive.

| | count |
|---|---|
| bills | 765 |
| missing brief | 750 |
| missing lens | 599 |

A job configured with `SCRAPER_MAX_NEW_ITEMS_PER_RUN=1` would have generated ~750 briefs and ~600 agentic research loops. The cap said 1. Estimated $40–60 and 50+ hours against a job whose entire purpose was cheap coverage.

I stopped the backfill rather than let it run; the cursor is durable so nothing was lost.

## The fix

The budget now counts **items that generate**. Two properties matter:

- **One item draws at most one slot**, however many assets it produces. Otherwise a single bill could eat an entire run's budget across article + lens + brief + video.
- **A slot is claimed at the point of generation, after each asset's own cache check.** Claiming earlier would be worse than useless — a run would throttle itself to N items while doing no work, because a fully cached item would still spend a slot.

The lens, the brief, and video generation each take a `claimBudget` callback and check it after their cache lookup. The summary/article/image block claims up front, since its need is already known by then.

## Tests

Three properties, each of which was wrong at some point today:

- one item spends one slot across many assets
- an item that generates nothing spends nothing
- an item refused up front cannot sneak a later asset through

42/42 passing, typecheck and prettier clean.

## After this lands

Re-run the backfill for coverage (cheap, bounded), then drain enrichment separately via `retroactive-briefs` and `retroactive-lenses` at a chosen rate. That was the intent of the original job and is what this makes actually true.