### PR TITLE
Store complete bill source versions and parse sections

### DIFF
--- a/apps/scraper/src/fixtures/bills/omnibus.xml
+++ b/apps/scraper/src/fixtures/bills/omnibus.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bill xmlns="http://xml.house.gov/schemas/uslm/1.0">
+  <legis-body>
+    <division>
+      <num>DIVISION A</num>
+      <heading>GENERAL PROVISIONS</heading>
+      <title>
+        <num>TITLE II</num>
+        <heading>PROGRAM ADMINISTRATION</heading>
+        <subtitle>
+          <num>Subtitle B</num>
+          <heading>Reporting and Enforcement</heading>
+          <section id="H8800-219">
+            <num>SEC. 219.</num>
+            <heading>REPORTING REQUIREMENTS.</heading>
+            <subsection>
+              <num>(a)</num>
+              <heading>Report.</heading>
+              <text>The Secretary shall submit a report under section 101.</text>
+            </subsection>
+            <subsection>
+              <num>(b)</num>
+              <heading>Amendment.</heading>
+              <text>Section 552 of title 5, United States Code, is amended to read as follows:</text>
+              <quoted-block>
+                <section id="quoted-552">
+                  <num>“§ 552.</num>
+                  <heading>Public information</heading>
+                  <subsection><num>“(a)</num><text>Each agency shall make the records available verbatim.</text></subsection>
+                </section>
+              </quoted-block>
+            </subsection>
+          </section>
+        </subtitle>
+      </title>
+    </division>
+    <division>
+      <num>DIVISION B</num>
+      <heading>EFFECTIVE DATES</heading>
+      <section id="H8800-1001">
+        <num>SEC. 1001.</num>
+        <heading>EFFECTIVE DATE.</heading>
+        <text>Except as provided in section 219, this division takes effect on enactment.</text>
+      </section>
+    </division>
+  </legis-body>
+</bill>

--- a/apps/scraper/src/fixtures/bills/simple.xml
+++ b/apps/scraper/src/fixtures/bills/simple.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bill xmlns="http://xml.house.gov/schemas/uslm/1.0">
+  <legis-body>
+    <section id="H1234ABC">
+      <num>SECTION 1.</num>
+      <heading>SHORT TITLE.</heading>
+      <text>This Act may be cited as the “Example Act”.</text>
+    </section>
+    <section id="H1234DEF">
+      <num>SEC. 2.</num>
+      <heading>EFFECTIVE DATE.</heading>
+      <text>This Act takes effect 30 days after enactment.</text>
+    </section>
+  </legis-body>
+</bill>

--- a/apps/scraper/src/scrapers/congress.test.ts
+++ b/apps/scraper/src/scrapers/congress.test.ts
@@ -3,8 +3,6 @@ import test from "node:test";
 
 import {
   advancesCursor,
-  assertWithinTsvectorLimit,
-  BillTextTooLargeError,
   cursorHighWaterMark,
   orderTextVersionsNewestFirst,
   parseBillIdentifier,
@@ -70,27 +68,6 @@ test("parseBillIdentifier round-trips through parseBillUrl", () => {
       `https://www.congress.gov/bill/119th-congress/house-bill/${parsed.billNumber}`,
     ),
     parsed,
-  );
-});
-
-test("assertWithinTsvectorLimit leaves normal bill text untouched", () => {
-  const text =
-    "SECTION 1. SHORT TITLE. This Act may be cited as the Example Act.";
-  assert.equal(assertWithinTsvectorLimit(text, "H.R. 1"), text);
-});
-
-test("assertWithinTsvectorLimit refuses oversized text instead of truncating", () => {
-  // Multibyte punctuation: a character count would undercount the byte size.
-  const huge = "section § one — text ".repeat(80_000);
-  assert.ok(Buffer.byteLength(huge, "utf8") > 1_048_575);
-
-  // A truncated bill reads as complete and misinforms; an absent one does not.
-  assert.throws(
-    () => assertWithinTsvectorLimit(huge, "H.R. 1"),
-    (error: unknown) =>
-      error instanceof BillTextTooLargeError &&
-      error.label === "H.R. 1" &&
-      error.bytes === Buffer.byteLength(huge, "utf8"),
   );
 });
 

--- a/apps/scraper/src/scrapers/congress.ts
+++ b/apps/scraper/src/scrapers/congress.ts
@@ -3,6 +3,7 @@ import { db } from "@acme/db/client";
 import { ScraperCursor } from "@acme/db/schema";
 
 import type { UpsertOutcome } from "../utils/db/operations.js";
+import type { BillSourceVersionInput } from "../utils/bill-sections.js";
 import type { NewItemLimiter } from "../utils/new-item-limit.js";
 import type { Scraper } from "../utils/types.js";
 import { getItemLimit } from "../utils/concurrency.js";
@@ -15,6 +16,7 @@ import {
   retryQueueDepth,
 } from "../utils/db/retry-queue.js";
 import { fetchWithRetry } from "../utils/fetch.js";
+import { createContentHash } from "../utils/hash.js";
 import { createLogger } from "../utils/log.js";
 import { createNewItemLimiter } from "../utils/new-item-limit.js";
 import { congressConfig } from "./congress.config.js";
@@ -240,42 +242,6 @@ export async function fetchSummary(
 }
 
 /**
- * Postgres rejects `to_tsvector` input over 1,048,575 bytes and
- * `Bill.searchVector` is a generated column over `full_text`, so an oversized
- * bill cannot be stored whole. Keep a wide margin under that ceiling.
- *
- * We refuse the bill rather than truncating it. A truncated bill is not a
- * smaller bill, it is a *wrong* one: H.R. 7008's brief told readers the bill
- * specified no penalties because the penalties were past the cut. An absent
- * bill is visibly absent; a truncated one reads as complete and misinforms.
- * Section-aware storage (#191) is what actually fixes these.
- */
-const MAX_FULL_TEXT_BYTES = 800_000;
-
-export class BillTextTooLargeError extends Error {
-  constructor(
-    readonly label: string,
-    readonly bytes: number,
-  ) {
-    super(
-      `${label}: full text is ${bytes} bytes, over the ${MAX_FULL_TEXT_BYTES}-byte storage ceiling — refusing to store a truncated bill`,
-    );
-    this.name = "BillTextTooLargeError";
-  }
-}
-
-/** Throws `BillTextTooLargeError` rather than returning a shortened string. */
-export function assertWithinTsvectorLimit(text: string, label: string): string {
-  // Byte length, not character count: bill text carries multibyte punctuation
-  // (section signs, em dashes, curly quotes) that a char count undercounts.
-  const bytes = Buffer.byteLength(text, "utf8");
-  if (bytes > MAX_FULL_TEXT_BYTES) {
-    throw new BillTextTooLargeError(label, bytes);
-  }
-  return text;
-}
-
-/**
  * Order text versions newest-first so we store the *operative* text.
  *
  * This used to be `[...textVersions].reverse()`, which assumes the API returns
@@ -303,43 +269,93 @@ export function orderTextVersionsNewestFirst(
   });
 }
 
+function versionCode(version: ApiTextVersion, sourceUrl: string): string {
+  const fileCode = /\d+([a-z]+)\.(?:xml|htm(?:l)?)$/i.exec(
+    new URL(sourceUrl).pathname,
+  )?.[1];
+  return (fileCode || version.type).toLowerCase().replace(/[^a-z0-9]+/g, "-");
+}
+
+async function fetchBillText(
+  congress: number,
+  billType: string,
+  billNumber: string,
+): Promise<{
+  fullText?: string;
+  sourceVersions: BillSourceVersionInput[];
+}> {
+  const data = await congressFetch<{ textVersions: ApiTextVersion[] }>(
+    `/bill/${congress}/${billType.toLowerCase()}/${billNumber}/text`,
+  );
+  const sourceVersions: BillSourceVersionInput[] = [];
+  const xmlFailures: Error[] = [];
+  let fullText: string | undefined;
+
+  for (const version of orderTextVersionsNewestFirst(data.textVersions ?? [])) {
+    const xmlFormat = version.formats.find(
+      (format) => format.type.toLowerCase() === "formatted xml",
+    );
+    if (xmlFormat) {
+      try {
+        const response = await fetchWithRetry(xmlFormat.url);
+        const rawXml = await response.text();
+        if (rawXml) {
+          sourceVersions.push({
+            versionCode: versionCode(version, xmlFormat.url),
+            versionType: version.type,
+            officialDate: version.date ? new Date(version.date) : undefined,
+            sourceUrl: xmlFormat.url,
+            rawXml,
+            sourceHash: createContentHash(rawXml),
+          });
+          fullText ??= stripHtml(rawXml).trim() || undefined;
+          continue;
+        }
+      } catch (error) {
+        xmlFailures.push(
+          error instanceof Error ? error : new Error(String(error)),
+        );
+        logger.warn(
+          `Could not fetch ${version.type} XML for ${billType}${billNumber}: ${error instanceof Error ? error.message : error}`,
+        );
+      }
+    }
+
+    // Some historical versions only advertise Formatted Text. Preserve the
+    // latest bill-level text for existing downstream consumers, while source
+    // version storage remains restricted to complete official XML.
+    if (!fullText) {
+      const textFormat = version.formats.find(
+        (format) => format.type.toLowerCase() === "formatted text",
+      );
+      if (textFormat) {
+        try {
+          const response = await fetchWithRetry(textFormat.url);
+          const rawText = await response.text();
+          fullText = stripHtml(rawText).trim() || undefined;
+        } catch {}
+      }
+    }
+  }
+
+  if (xmlFailures.length > 0) {
+    throw new AggregateError(
+      xmlFailures,
+      `Failed to retain ${xmlFailures.length} official XML version(s) for ${billType}${billNumber}`,
+    );
+  }
+
+  return { fullText, sourceVersions };
+}
+
 export async function fetchFullText(
   congress: number,
   billType: string,
   billNumber: string,
 ): Promise<string | undefined> {
   try {
-    const data = await congressFetch<{ textVersions: ApiTextVersion[] }>(
-      `/bill/${congress}/${billType.toLowerCase()}/${billNumber}/text`,
-    );
-    if (!data.textVersions?.length) return undefined;
-
-    for (const version of orderTextVersionsNewestFirst(data.textVersions)) {
-      const txtFormat = version.formats.find(
-        (f) => f.type === "Formatted Text",
-      );
-      if (!txtFormat) continue;
-
-      const res = await fetchWithRetry(txtFormat.url);
-      const rawText = await res.text();
-      if (!rawText) continue;
-
-      // Store the bill as published. An earlier 1,000-word cap silently cut
-      // most bills off mid-section — H.R. 7008 lost its entire penalties
-      // section, and the brief generator then reported that the bill
-      // specified no penalties. Downstream consumers window this text to fit
-      // their own context budget (see SOURCE_WINDOW in ai/bill-brief.ts);
-      // truncating at ingest time only destroys information for all of them.
-      const text = stripHtml(rawText).trim();
-      return assertWithinTsvectorLimit(text, billNumber) || undefined;
-    }
-  } catch (error) {
-    // Full text is otherwise optional — a fetch failure degrades to a bill
-    // without text. Oversize is different: it means we *have* the text and
-    // cannot store it faithfully, and swallowing it here would save the bill
-    // textless, which is the silent-wrongness this check exists to prevent.
-    if (error instanceof BillTextTooLargeError) throw error;
-  }
+    return (await fetchBillText(congress, billType, billNumber)).fullText;
+  } catch {}
   return undefined;
 }
 
@@ -455,7 +471,11 @@ async function processBill(
     : undefined;
 
   const summary = await fetchSummary(congress, billType, billNumber);
-  const fullText = await fetchFullText(congress, billType, billNumber);
+  const { fullText, sourceVersions } = await fetchBillText(
+    congress,
+    billType,
+    billNumber,
+  );
   const actions = await fetchActions(congress, billType, billNumber);
 
   const outcome = await upsertContent(
@@ -480,7 +500,7 @@ async function processBill(
         sourceUpdatedAt,
       },
     },
-    { newItemLimiter },
+    { newItemLimiter, billSourceVersions: sourceVersions },
   );
 
   if (outcome.status === "written") {
@@ -804,14 +824,6 @@ async function scrape(config: CongressScraperConfig = {}) {
       }
       return queue(outcome.reason);
     } catch (error) {
-      if (error instanceof BillTextTooLargeError) {
-        // A deliberate refusal, not a failure to retry: the bill will be exactly
-        // as oversized next run, so queueing it would just burn an attempt a day
-        // forever. Move past it and rely on the log.
-        logger.warn(`Skipping ${item.type}${item.number}: ${error.message}`);
-        await clearRetry(scraperKey, itemKey);
-        return { ok: true, sourceUpdatedAt: feedUpdatedAt };
-      }
       logger.error(`Error processing bill ${item.type}${item.number}`, error);
       return queue(error instanceof Error ? error.message : String(error));
     }

--- a/apps/scraper/src/scrapers/congress.ts
+++ b/apps/scraper/src/scrapers/congress.ts
@@ -655,10 +655,6 @@ async function scrapeRecent(
             newItemLimiter,
           );
         } catch (error) {
-          if (error instanceof BillTextTooLargeError) {
-            logger.warn(`Skipping ${item.type}${item.number}: ${error.message}`);
-            return;
-          }
           failures += 1;
           logger.error(
             `Error processing bill ${item.type}${item.number}`,

--- a/apps/scraper/src/scrapers/congress.ts
+++ b/apps/scraper/src/scrapers/congress.ts
@@ -877,11 +877,6 @@ async function scrape(config: CongressScraperConfig = {}) {
               await recordRetry(scraperKey, itemKey, outcome.reason);
             }
           } catch (error) {
-            if (error instanceof BillTextTooLargeError) {
-              logger.warn(`Skipping ${itemKey}: ${error.message}`);
-              await clearRetry(scraperKey, itemKey);
-              return;
-            }
             logger.error(`Retry failed for ${itemKey}`, error);
             await recordRetry(
               scraperKey,

--- a/apps/scraper/src/utils/bill-sections.test.ts
+++ b/apps/scraper/src/utils/bill-sections.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { MAX_SECTION_BYTES, parseBillSections } from "./bill-sections.js";
+
+const fixture = (name: string) =>
+  readFile(new URL(`../fixtures/bills/${name}.xml`, import.meta.url), "utf8");
+
+test("simple bill fixture produces stable addressable sections", async () => {
+  const xml = await fixture("simple");
+  const first = parseBillSections(xml);
+  const second = parseBillSections(xml);
+
+  assert.deepEqual(second, first);
+  assert.deepEqual(
+    first.map((section) => section.structuralPath),
+    ["section-1", "section-2"],
+  );
+  assert.equal(first[0]?.xmlId, "H1234ABC");
+  assert.ok(first[0]?.sourceStartOffset !== undefined);
+  assert.ok(first[0]?.sourceEndOffset !== undefined);
+  assert.match(first[1]?.sectionHash ?? "", /^[a-f0-9]{64}$/);
+});
+
+test("omnibus fixture retains hierarchy, policy details, and quoted amendments", async () => {
+  const sections = parseBillSections(await fixture("omnibus"));
+
+  assert.deepEqual(
+    sections.map((section) => section.structuralPath),
+    ["division-a/title-ii/subtitle-b/section-219", "division-b/section-1001"],
+  );
+  assert.match(
+    sections[0]?.text ?? "",
+    /Each agency shall make the records available verbatim/,
+  );
+  assert.match(sections[0]?.text ?? "", /shall submit a report/);
+  assert.match(sections[1]?.text ?? "", /takes effect on enactment/);
+  assert.ok(
+    sections[0]?.crossReferences.some(
+      (reference) => reference.toLowerCase() === "section 101",
+    ),
+  );
+});
+
+test("multi-megabyte omnibus sections split at subsection boundaries", async () => {
+  const base = await fixture("omnibus");
+  const payload = "appropriations and reporting requirement ".repeat(18_000);
+  const subsections = Array.from(
+    { length: 8 },
+    (_, index) =>
+      `<subsection id="large-${index}"><num>(${index + 1})</num><text>${payload}</text></subsection>`,
+  ).join("");
+  const xml = base.replace(
+    "</legis-body>",
+    `<section id="H8800-LARGE"><num>SEC. 9000.</num><heading>OMNIBUS APPROPRIATIONS.</heading>${subsections}</section></legis-body>`,
+  );
+
+  assert.ok(Buffer.byteLength(xml, "utf8") > 4_000_000);
+  const sections = parseBillSections(xml);
+  const chunks = sections.filter((section) =>
+    section.structuralPath.startsWith("section-9000/part-"),
+  );
+  assert.ok(chunks.length > 1);
+  assert.ok(
+    chunks.every(
+      (section) =>
+        Buffer.byteLength(section.text, "utf8") <= MAX_SECTION_BYTES * 2,
+    ),
+  );
+  assert.ok(chunks.every((section) => section.sectionHash.length === 64));
+});

--- a/apps/scraper/src/utils/bill-sections.ts
+++ b/apps/scraper/src/utils/bill-sections.ts
@@ -1,0 +1,234 @@
+import { createHash } from "node:crypto";
+import { load } from "cheerio";
+
+export const MAX_SECTION_BYTES = 500_000;
+
+export interface ParsedBillSection {
+  structuralPath: string;
+  displayedNumber?: string;
+  heading?: string;
+  order: number;
+  text: string;
+  sectionHash: string;
+  tokenCount: number;
+  sourceStartOffset?: number;
+  sourceEndOffset?: number;
+  xmlId?: string;
+  crossReferences: string[];
+}
+
+export interface BillSourceVersionInput {
+  versionCode: string;
+  versionType: string;
+  officialDate?: Date;
+  sourceUrl: string;
+  rawXml: string;
+  sourceHash: string;
+}
+
+function normalizedText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function slug(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/§/g, " section ")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 100);
+}
+
+function structuralPart(tag: string, number: string, fallback: number): string {
+  const cleaned = number
+    .replace(
+      /^(sec(?:tion)?\.?|title|subtitle|division|part|subpart|chapter|subchapter)\s+/i,
+      "",
+    )
+    .replace(/[.:]+$/g, "")
+    .trim();
+  return `${tag}-${slug(cleaned) || fallback}`;
+}
+
+function tokenCount(text: string): number {
+  return text.match(/\S+/g)?.length ?? 0;
+}
+
+function sectionHash(text: string): string {
+  return createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+function splitAtWordBoundaries(text: string, maxBytes: number): string[] {
+  const chunks: string[] = [];
+  let current = "";
+  let currentBytes = 0;
+  for (const word of text.split(/\s+/)) {
+    const wordBytes = Buffer.byteLength(word, "utf8");
+    const candidateBytes = currentBytes + (current ? 1 : 0) + wordBytes;
+    if (current && candidateBytes > maxBytes) {
+      chunks.push(current);
+      current = word;
+      currentBytes = wordBytes;
+    } else {
+      current = current ? `${current} ${word}` : word;
+      currentBytes = candidateBytes;
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+/** Internal and statutory references useful for later provision linking. */
+export function extractCrossReferences(text: string): string[] {
+  const references = new Set<string>();
+  const patterns = [
+    /\bsections?\s+\d+[a-z0-9().-]*/gi,
+    /\b\d+\s+U\.?\s*S\.?\s*C\.?\s*§?\s*\d+[a-z0-9().-]*/gi,
+    /\bPublic Law \d+-\d+\b/gi,
+    /\b(?:title|subtitle|chapter|part)\s+[IVXLCDM0-9A-Z-]+\b/gi,
+  ];
+  for (const pattern of patterns) {
+    for (const match of text.matchAll(pattern)) {
+      references.add(normalizedText(match[0]!).replace(/[.,;:]+$/g, ""));
+    }
+  }
+  return [...references].sort((a, b) => a.localeCompare(b));
+}
+
+function sourceOffsets(
+  rawXml: string,
+  xmlId: string | undefined,
+  serialized: string,
+): { sourceStartOffset?: number; sourceEndOffset?: number } {
+  let start = rawXml.indexOf(serialized);
+  if (start < 0 && xmlId) {
+    const idAt = rawXml.search(
+      new RegExp(
+        `\\b(?:id|identifier)=(["'])${xmlId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\1`,
+      ),
+    );
+    if (idAt >= 0) start = rawXml.lastIndexOf("<section", idAt);
+  }
+  if (start < 0) return {};
+
+  const tags = /<\/?section\b[^>]*>/gi;
+  tags.lastIndex = start;
+  let depth = 0;
+  for (let match = tags.exec(rawXml); match; match = tags.exec(rawXml)) {
+    depth += match[0].startsWith("</") ? -1 : 1;
+    if (depth === 0) {
+      return {
+        sourceStartOffset: start,
+        sourceEndOffset: match.index + match[0].length,
+      };
+    }
+  }
+  return { sourceStartOffset: start };
+}
+
+/**
+ * Parse USLM-style formatted XML into stable, searchable units.
+ *
+ * Top-level <section> elements are ordinary units. Nested sections in quoted
+ * amendments remain part of their containing section, preserving the enacted
+ * language without duplicating it as if it were a provision of this bill.
+ * Very large sections are grouped at subsection/paragraph boundaries.
+ */
+export function parseBillSections(rawXml: string): ParsedBillSection[] {
+  const $ = load(rawXml, { xml: true });
+  const parsed: ParsedBillSection[] = [];
+  const usedPaths = new Map<string, number>();
+
+  $("section").each((sectionIndex, element) => {
+    if ($(element).parents("section").length > 0) return;
+
+    const section = $(element);
+    const displayedNumber = normalizedText(
+      section.children("num").first().text(),
+    );
+    const heading = normalizedText(section.children("heading").first().text());
+    const ancestors = section
+      .parents("title, subtitle, division, part, subpart, chapter, subchapter")
+      .toArray()
+      .reverse()
+      .map((ancestor, index) => {
+        const node = $(ancestor);
+        const tag = ancestor.tagName.toLowerCase();
+        return structuralPart(
+          tag,
+          normalizedText(node.children("num").first().text()),
+          index + 1,
+        );
+      });
+    const basePart = structuralPart(
+      "section",
+      displayedNumber,
+      sectionIndex + 1,
+    );
+    const basePath = [...ancestors, basePart].join("/");
+    const occurrence = (usedPaths.get(basePath) ?? 0) + 1;
+    usedPaths.set(basePath, occurrence);
+    const uniqueBasePath =
+      occurrence === 1 ? basePath : `${basePath}-${occurrence}`;
+
+    const wholeText = normalizedText(section.text());
+    const xmlId = section.attr("id") ?? section.attr("identifier");
+    const serialized = $.xml(element);
+    const offsets = sourceOffsets(rawXml, xmlId, serialized);
+
+    const boundaryChildren = section.children(
+      "subsection, paragraph, subparagraph, clause",
+    );
+    const chunks: string[] = [];
+    if (
+      Buffer.byteLength(wholeText, "utf8") > MAX_SECTION_BYTES &&
+      boundaryChildren.length > 1
+    ) {
+      const prefix = normalizedText(`${displayedNumber} ${heading}`);
+      let current = prefix;
+      boundaryChildren.each((_, child) => {
+        const childText = normalizedText($(child).text());
+        const childChunks = splitAtWordBoundaries(
+          childText,
+          MAX_SECTION_BYTES - Buffer.byteLength(prefix, "utf8") - 1,
+        );
+        for (const childChunk of childChunks) {
+          if (
+            current !== prefix &&
+            Buffer.byteLength(`${current} ${childChunk}`, "utf8") >
+              MAX_SECTION_BYTES
+          ) {
+            chunks.push(current);
+            current = prefix;
+          }
+          current = normalizedText(`${current} ${childChunk}`);
+        }
+      });
+      if (current !== prefix) chunks.push(current);
+    } else {
+      chunks.push(wholeText);
+    }
+
+    chunks.forEach((text, chunkIndex) => {
+      if (!text) return;
+      const structuralPath =
+        chunks.length === 1
+          ? uniqueBasePath
+          : `${uniqueBasePath}/part-${String(chunkIndex + 1).padStart(3, "0")}`;
+      parsed.push({
+        structuralPath,
+        displayedNumber: displayedNumber || undefined,
+        heading: heading || undefined,
+        order: parsed.length,
+        text,
+        sectionHash: sectionHash(text),
+        tokenCount: tokenCount(text),
+        ...offsets,
+        xmlId,
+        crossReferences: extractCrossReferences(text),
+      });
+    });
+  });
+
+  return parsed;
+}

--- a/apps/scraper/src/utils/db/bill-source-operations.ts
+++ b/apps/scraper/src/utils/db/bill-source-operations.ts
@@ -1,0 +1,88 @@
+import { and, eq } from "@acme/db";
+import { db } from "@acme/db/client";
+import { BillSection, BillSourceVersion } from "@acme/db/schema";
+
+import type { BillSourceVersionInput } from "../bill-sections.js";
+import { parseBillSections } from "../bill-sections.js";
+
+/**
+ * Retain immutable official versions and parse each source hash once.
+ * Re-fetching byte-identical XML is a database no-op.
+ */
+export async function persistBillSourceVersions(
+  billId: string,
+  versions: readonly BillSourceVersionInput[],
+): Promise<void> {
+  for (const version of versions) {
+    const [inserted] = await db
+      .insert(BillSourceVersion)
+      .values({ billId, ...version })
+      .onConflictDoNothing({
+        target: [
+          BillSourceVersion.billId,
+          BillSourceVersion.versionCode,
+          BillSourceVersion.sourceHash,
+        ],
+      })
+      .returning({
+        id: BillSourceVersion.id,
+        parseStatus: BillSourceVersion.parseStatus,
+      });
+
+    const sourceVersion =
+      inserted ??
+      (
+        await db
+          .select({
+            id: BillSourceVersion.id,
+            parseStatus: BillSourceVersion.parseStatus,
+          })
+          .from(BillSourceVersion)
+          .where(
+            and(
+              eq(BillSourceVersion.billId, billId),
+              eq(BillSourceVersion.versionCode, version.versionCode),
+              eq(BillSourceVersion.sourceHash, version.sourceHash),
+            ),
+          )
+          .limit(1)
+      )[0];
+
+    if (!sourceVersion || sourceVersion.parseStatus === "parsed") continue;
+
+    try {
+      const sections = parseBillSections(version.rawXml);
+      await db.transaction(async (tx) => {
+        await tx
+          .delete(BillSection)
+          .where(eq(BillSection.sourceVersionId, sourceVersion.id));
+        if (sections.length > 0) {
+          await tx.insert(BillSection).values(
+            sections.map((section) => ({
+              sourceVersionId: sourceVersion.id,
+              ...section,
+            })),
+          );
+        }
+        await tx
+          .update(BillSourceVersion)
+          .set({
+            parseStatus: "parsed",
+            parseError: null,
+            updatedAt: new Date(),
+          })
+          .where(eq(BillSourceVersion.id, sourceVersion.id));
+      });
+    } catch (error) {
+      await db
+        .update(BillSourceVersion)
+        .set({
+          parseStatus: "failed",
+          parseError: error instanceof Error ? error.message : String(error),
+          updatedAt: new Date(),
+        })
+        .where(eq(BillSourceVersion.id, sourceVersion.id));
+      throw error;
+    }
+  }
+}

--- a/apps/scraper/src/utils/db/operations.ts
+++ b/apps/scraper/src/utils/db/operations.ts
@@ -12,6 +12,7 @@ import {
 } from "@acme/db/schema";
 import { isCurrentBillBrief } from "@acme/validators";
 
+import type { BillSourceVersionInput } from "../bill-sections.js";
 import type { NewItemLimiter } from "../new-item-limit.js";
 import type {
   BillData,
@@ -36,6 +37,7 @@ import { createContentHash } from "../hash.js";
 import { createLogger } from "../log.js";
 import { tickProgress } from "../progress.js";
 import { isUsableSourceText } from "../reprocessing-policy.js";
+import { persistBillSourceVersions } from "./bill-source-operations.js";
 import {
   checkExistingBill,
   checkExistingCourtCase,
@@ -152,7 +154,10 @@ function getUpdateTable(input: ContentData) {
 
 export async function upsertContent(
   input: ContentData,
-  options?: { newItemLimiter?: NewItemLimiter },
+  options?: {
+    newItemLimiter?: NewItemLimiter;
+    billSourceVersions?: readonly BillSourceVersionInput[];
+  },
 ): Promise<UpsertOutcome> {
   const newContentHash = createContentHash(hashFields(input));
   const existing = await checkExisting(input);
@@ -327,6 +332,7 @@ export async function upsertContent(
       description: preGeneratedDescription,
       label,
       claimBudget,
+      billSourceVersions: options?.billSourceVersions,
     });
 
     if (assembled.status !== "ready") {
@@ -432,6 +438,10 @@ export async function upsertContent(
       })
       .returning();
     result = row;
+  }
+
+  if (input.type === "bill" && result && options?.billSourceVersions?.length) {
+    await persistBillSourceVersions(result.id, options.billSourceVersions);
   }
 
   logger.debug(`${label} upserted (raw)`);
@@ -871,6 +881,7 @@ async function assembleNewBill(args: {
   description?: string;
   label: string;
   claimBudget: () => boolean;
+  billSourceVersions?: readonly BillSourceVersionInput[];
 }): Promise<AssembleResult> {
   const { data, contentHash, label } = args;
   const description = args.description ?? data.description;
@@ -947,6 +958,10 @@ async function assembleNewBill(args: {
     await persistVideoRecord(tx, "bill", billId, video);
     await persistBillBrief(tx, billId, contentHash, brief);
   });
+
+  if (args.billSourceVersions?.length) {
+    await persistBillSourceVersions(billId, args.billSourceVersions);
+  }
 
   incrementVideosGenerated();
   logger.success(`${label} stored complete (brief + header art)`);

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -117,16 +117,12 @@ opposite and stored every bill's introduced draft. H.R. 7008 passed the House
 with a substitute adding a photo-ID voting section, and none of it was in our
 copy.
 
-Text is stored **whole or not at all**. `Bill.searchVector` is a generated
-column running `to_tsvector` over `full_text`, and Postgres rejects input over
-1,048,575 bytes, so an enormous bill cannot be stored complete. Rather than
-truncate, `fetchFullText` raises `BillTextTooLargeError` and the bill is
-skipped: a truncated bill is not a smaller bill, it is a wrong one that reads
-as complete. An earlier 1,000-word cap cut H.R. 7008 mid-section and the
-generated brief then told readers the bill specified no penalties. The walk
-treats the refusal as a deliberate skip rather than a retryable failure so one
-giant bill cannot wedge the cursor. Section-aware storage is the real fix
-(issue #191).
+Every advertised **Formatted XML** version is retained byte-for-byte in
+`bill_source_version` and parsed into stable `bill_section` rows. Bill metadata
+keeps its own generated search vector, while complete legislative text is
+indexed per section. This avoids PostgreSQL's 1,048,575-byte `to_tsvector`
+input ceiling without truncating or refusing an omnibus bill. Re-fetching an
+identical `(bill, version code, source hash)` is a no-op.
 
 ## Upsert + Change Detection
 

--- a/packages/api/src/router/content.ts
+++ b/packages/api/src/router/content.ts
@@ -6,6 +6,8 @@ import { clampBillDescription } from "@acme/db/bill-description";
 import { db } from "@acme/db/client";
 import {
   Bill,
+  BillSection,
+  BillSourceVersion,
   ContentBrief,
   ContentLens,
   CourtCase,
@@ -422,10 +424,9 @@ export const contentRouter = {
     }),
 
   // Full-text search across bills, government content, and court cases.
-  // Matches against the generated `search_vector` tsvector column (title,
-  // summary/description, full text) and, for bill/case numbers, a pg_trgm
-  // trigram similarity match so loose codes like "hr1234" still find
-  // "H.R. 1234".
+  // Bill metadata and independently indexed source sections are searched
+  // together. Per-section vectors avoid PostgreSQL's input ceiling for giant
+  // omnibus bills and make provisions within them discoverable.
   search: publicProcedure
     .input(
       z.object({
@@ -441,12 +442,30 @@ export const contentRouter = {
       const type = input.type ?? "all";
       const tsQuery = sql`websearch_to_tsquery('english', ${query})`;
 
+      const billSectionRank = sql<number>`coalesce((
+        select max(ts_rank_cd(${BillSection.searchVector}, ${tsQuery}))
+        from ${BillSection}
+        inner join ${BillSourceVersion}
+          on ${BillSourceVersion.id} = ${BillSection.sourceVersionId}
+        where ${BillSourceVersion.billId} = ${Bill.id}
+          and ${BillSection.searchVector} @@ ${tsQuery}
+      ), 0)`;
       const billRank = sql<number>`greatest(
         ts_rank_cd(${Bill.searchVector}, ${tsQuery}),
+        ${billSectionRank},
         similarity(${Bill.billNumber}, ${query})
       )`;
       const billMatch = sql`(
-        ${Bill.searchVector} @@ ${tsQuery} or ${Bill.billNumber} % ${query}
+        ${Bill.searchVector} @@ ${tsQuery}
+        or ${Bill.billNumber} % ${query}
+        or exists (
+          select 1
+          from ${BillSection}
+          inner join ${BillSourceVersion}
+            on ${BillSourceVersion.id} = ${BillSection.sourceVersionId}
+          where ${BillSourceVersion.billId} = ${Bill.id}
+            and ${BillSection.searchVector} @@ ${tsQuery}
+        )
       )`;
 
       const govRank = sql<number>`ts_rank_cd(${GovernmentContent.searchVector}, ${tsQuery})`;

--- a/packages/db/drizzle/0009_flashy_steel_serpent.sql
+++ b/packages/db/drizzle/0009_flashy_steel_serpent.sql
@@ -1,0 +1,50 @@
+CREATE TABLE "bill_section" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"source_version_id" uuid NOT NULL,
+	"parent_section_id" uuid,
+	"structural_path" text NOT NULL,
+	"displayed_number" text,
+	"heading" text,
+	"order" integer NOT NULL,
+	"text" text NOT NULL,
+	"section_hash" varchar(64) NOT NULL,
+	"token_count" integer NOT NULL,
+	"source_start_offset" integer,
+	"source_end_offset" integer,
+	"xml_id" text,
+	"cross_references" jsonb DEFAULT '[]'::jsonb NOT NULL,
+	"search_vector" "tsvector" GENERATED ALWAYS AS (to_tsvector('english', coalesce(heading, '') || ' ' || coalesce(text, ''))) STORED,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "bill_section_sourceVersionId_structuralPath_unique" UNIQUE("source_version_id","structural_path")
+);
+--> statement-breakpoint
+CREATE TABLE "bill_source_version" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"bill_id" uuid NOT NULL,
+	"version_code" varchar(50) NOT NULL,
+	"version_type" text NOT NULL,
+	"official_date" timestamp with time zone,
+	"source_url" text NOT NULL,
+	"raw_xml" text NOT NULL,
+	"source_hash" varchar(64) NOT NULL,
+	"parse_status" varchar(20) DEFAULT 'pending' NOT NULL,
+	"parse_error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone,
+	CONSTRAINT "bill_source_version_billId_versionCode_sourceHash_unique" UNIQUE("bill_id","version_code","source_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "bill" drop column "search_vector";--> statement-breakpoint
+ALTER TABLE "bill" ADD COLUMN "search_vector" "tsvector" GENERATED ALWAYS AS ((
+        setweight(to_tsvector('english', coalesce(bill_number, '')), 'A') ||
+        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+        setweight(to_tsvector('english', coalesce(sponsor, '')), 'B') ||
+        setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(description, '')), 'B')
+      )) STORED;--> statement-breakpoint
+ALTER TABLE "bill_section" ADD CONSTRAINT "bill_section_source_version_id_bill_source_version_id_fk" FOREIGN KEY ("source_version_id") REFERENCES "public"."bill_source_version"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "bill_section" ADD CONSTRAINT "bill_section_parent_section_id_bill_section_id_fk" FOREIGN KEY ("parent_section_id") REFERENCES "public"."bill_section"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "bill_source_version" ADD CONSTRAINT "bill_source_version_bill_id_bill_id_fk" FOREIGN KEY ("bill_id") REFERENCES "public"."bill"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "bill_section_source_version_idx" ON "bill_section" USING btree ("source_version_id");--> statement-breakpoint
+CREATE INDEX "bill_section_parent_idx" ON "bill_section" USING btree ("parent_section_id");--> statement-breakpoint
+CREATE INDEX "bill_section_search_vector_idx" ON "bill_section" USING gin ("search_vector");--> statement-breakpoint
+CREATE INDEX "bill_source_version_bill_idx" ON "bill_source_version" USING btree ("bill_id");

--- a/packages/db/drizzle/meta/0009_snapshot.json
+++ b/packages/db/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,3231 @@
+{
+  "id": "f212562b-8399-426d-9f53-3f3df17c8385",
+  "prevId": "88cdf022-a9d5-4220-8a3b-c11460654689",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bill": {
+      "name": "bill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bill_number": {
+          "name": "bill_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sponsor": {
+          "name": "sponsor",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "introduced_date": {
+          "name": "introduced_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "congress": {
+          "name": "congress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chamber": {
+          "name": "chamber",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_website": {
+          "name": "source_website",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(bill_number, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(sponsor, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(description, '')), 'B')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "bill_search_vector_idx": {
+          "name": "bill_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bill_number_trgm_idx": {
+          "name": "bill_number_trgm_idx",
+          "columns": [
+            {
+              "expression": "bill_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bill_billNumber_sourceWebsite_unique": {
+          "name": "bill_billNumber_sourceWebsite_unique",
+          "nullsNotDistinct": false,
+          "columns": ["bill_number", "source_website"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bill_description_max_100_chars": {
+          "name": "bill_description_max_100_chars",
+          "value": "\"bill\".\"description\" is null or char_length(\"bill\".\"description\") <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bill_section": {
+      "name": "bill_section",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_version_id": {
+          "name": "source_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_section_id": {
+          "name": "parent_section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structural_path": {
+          "name": "structural_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayed_number": {
+          "name": "displayed_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_hash": {
+          "name": "section_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_start_offset": {
+          "name": "source_start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_end_offset": {
+          "name": "source_end_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xml_id": {
+          "name": "xml_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cross_references": {
+          "name": "cross_references",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(heading, '') || ' ' || coalesce(text, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bill_section_source_version_idx": {
+          "name": "bill_section_source_version_idx",
+          "columns": [
+            {
+              "expression": "source_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bill_section_parent_idx": {
+          "name": "bill_section_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bill_section_search_vector_idx": {
+          "name": "bill_section_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bill_section_source_version_id_bill_source_version_id_fk": {
+          "name": "bill_section_source_version_id_bill_source_version_id_fk",
+          "tableFrom": "bill_section",
+          "tableTo": "bill_source_version",
+          "columnsFrom": ["source_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bill_section_parent_section_id_bill_section_id_fk": {
+          "name": "bill_section_parent_section_id_bill_section_id_fk",
+          "tableFrom": "bill_section",
+          "tableTo": "bill_section",
+          "columnsFrom": ["parent_section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bill_section_sourceVersionId_structuralPath_unique": {
+          "name": "bill_section_sourceVersionId_structuralPath_unique",
+          "nullsNotDistinct": false,
+          "columns": ["source_version_id", "structural_path"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bill_source_version": {
+      "name": "bill_source_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bill_id": {
+          "name": "bill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_code": {
+          "name": "version_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_type": {
+          "name": "version_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "official_date": {
+          "name": "official_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_xml": {
+          "name": "raw_xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parse_status": {
+          "name": "parse_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "parse_error": {
+          "name": "parse_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bill_source_version_bill_idx": {
+          "name": "bill_source_version_bill_idx",
+          "columns": [
+            {
+              "expression": "bill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bill_source_version_bill_id_bill_id_fk": {
+          "name": "bill_source_version_bill_id_bill_id_fk",
+          "tableFrom": "bill_source_version",
+          "tableTo": "bill",
+          "columnsFrom": ["bill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bill_source_version_billId_versionCode_sourceHash_unique": {
+          "name": "bill_source_version_billId_versionCode_sourceHash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["bill_id", "version_code", "source_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_content": {
+      "name": "blocked_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocked_content_user_id_idx": {
+          "name": "blocked_content_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocked_content_userId_name_type_unique": {
+          "name": "blocked_content_userId_name_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name", "type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate": {
+      "name": "candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "party": {
+          "name": "party",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_url": {
+          "name": "candidate_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incumbent": {
+          "name": "incumbent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "biography": {
+          "name": "biography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_contest_id_idx": {
+          "name": "candidate_contest_id_idx",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.civic_api_cache": {
+      "name": "civic_api_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address_hash": {
+          "name": "address_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "response_data": {
+          "name": "response_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "civic_cache_expires_idx": {
+          "name": "civic_cache_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "civic_api_cache_addressHash_endpoint_params_unique": {
+          "name": "civic_api_cache_addressHash_endpoint_params_unique",
+          "nullsNotDistinct": false,
+          "columns": ["address_hash", "endpoint", "params"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_brief": {
+      "name": "content_brief",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "content_brief_content_id_idx": {
+          "name": "content_brief_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_brief_contentType_contentId_unique": {
+          "name": "content_brief_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["content_type", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_lens": {
+      "name": "content_lens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lens_data": {
+          "name": "lens_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "content_lens_content_id_idx": {
+          "name": "content_lens_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_lens_contentType_contentId_unique": {
+          "name": "content_lens_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["content_type", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest": {
+      "name": "contest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "election_id": {
+          "name": "election_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "office": {
+          "name": "office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_name": {
+          "name": "district_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_scope": {
+          "name": "district_scope",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_elected": {
+          "name": "number_elected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referendum_title": {
+          "name": "referendum_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_subtitle": {
+          "name": "referendum_subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_text": {
+          "name": "referendum_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_pro_statement": {
+          "name": "referendum_pro_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_con_statement": {
+          "name": "referendum_con_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_url": {
+          "name": "referendum_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_description": {
+          "name": "role_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_is_ai_generated": {
+          "name": "summary_is_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fiscal_impact": {
+          "name": "fiscal_impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citations": {
+          "name": "citations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contest_election_id_idx": {
+          "name": "contest_election_id_idx",
+          "columns": [
+            {
+              "expression": "election_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.court_case": {
+      "name": "court_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court": {
+          "name": "court",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_date": {
+          "name": "filed_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(case_number, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(description, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(full_text, '')), 'C')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "court_case_search_vector_idx": {
+          "name": "court_case_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "court_case_number_trgm_idx": {
+          "name": "court_case_number_trgm_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "court_case_caseNumber_court_unique": {
+          "name": "court_case_caseNumber_court_unique",
+          "nullsNotDistinct": false,
+          "columns": ["case_number", "court"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.election": {
+      "name": "election",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_type": {
+          "name": "election_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ocd_division_id": {
+          "name": "ocd_division_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadlines": {
+          "name": "deadlines",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "election_externalId_source_unique": {
+          "name": "election_externalId_source_unique",
+          "nullsNotDistinct": false,
+          "columns": ["external_id", "source"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.government_content": {
+      "name": "government_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whitehouse.gov'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(description, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(full_text, '')), 'C')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "government_content_search_vector_idx": {
+          "name": "government_content_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "government_content_url_unique": {
+          "name": "government_content_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_agenda_item": {
+      "name": "legistar_agenda_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_item_id": {
+          "name": "event_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda_sequence": {
+          "name": "agenda_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_number": {
+          "name": "agenda_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed_flag_name": {
+          "name": "passed_flag_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tally": {
+          "name": "tally",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mover_name": {
+          "name": "mover_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seconder_name": {
+          "name": "seconder_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_file": {
+          "name": "matter_file",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_name": {
+          "name": "matter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_type": {
+          "name": "matter_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_status": {
+          "name": "matter_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "agenda_note": {
+          "name": "agenda_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_note": {
+          "name": "minutes_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_agenda_item_event_idx": {
+          "name": "legistar_agenda_item_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_agenda_item_jurisdiction_eventItemId_unique": {
+          "name": "legistar_agenda_item_jurisdiction_eventItemId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "event_item_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_body": {
+      "name": "legistar_body",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_guid": {
+          "name": "body_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_flag": {
+          "name": "active_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "number_of_members": {
+          "name": "number_of_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_body_jurisdiction_bodyId_unique": {
+          "name": "legistar_body_jurisdiction_bodyId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "body_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_matter": {
+      "name": "legistar_matter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matter_guid": {
+          "name": "matter_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_file": {
+          "name": "matter_file",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_name": {
+          "name": "body_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_date": {
+          "name": "intro_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_date": {
+          "name": "agenda_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed_date": {
+          "name": "passed_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enactment_date": {
+          "name": "enactment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enactment_number": {
+          "name": "enactment_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester": {
+          "name": "requester",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_matter_file_idx": {
+          "name": "legistar_matter_file_idx",
+          "columns": [
+            {
+              "expression": "matter_file",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_matter_jurisdiction_matterId_unique": {
+          "name": "legistar_matter_jurisdiction_matterId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "matter_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_meeting": {
+      "name": "legistar_meeting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_guid": {
+          "name": "event_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_name": {
+          "name": "body_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_file": {
+          "name": "agenda_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_file": {
+          "name": "minutes_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_path": {
+          "name": "video_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_status_name": {
+          "name": "agenda_status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_status_name": {
+          "name": "minutes_status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_site_url": {
+          "name": "in_site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_meeting_date_idx": {
+          "name": "legistar_meeting_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_meeting_jurisdiction_eventId_unique": {
+          "name": "legistar_meeting_jurisdiction_eventId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_vote": {
+      "name": "legistar_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_id": {
+          "name": "vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_item_id": {
+          "name": "event_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_name": {
+          "name": "person_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_name": {
+          "name": "value_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legistar_vote_event_item_idx": {
+          "name": "legistar_vote_event_item_idx",
+          "columns": [
+            {
+              "expression": "event_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legistar_vote_person_idx": {
+          "name": "legistar_vote_person_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_vote_jurisdiction_voteId_unique": {
+          "name": "legistar_vote_jurisdiction_voteId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "vote_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polling_location": {
+      "name": "polling_location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "election_id": {
+          "name": "election_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line2": {
+          "name": "address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours": {
+          "name": "hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_services": {
+          "name": "voter_services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "polling_location_election_id_idx": {
+          "name": "polling_location_election_id_idx",
+          "columns": [
+            {
+              "expression": "election_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_description": {
+      "name": "role_description",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'seed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "role_description_role_level_unique": {
+          "name": "role_description_role_level_unique",
+          "nullsNotDistinct": false,
+          "columns": ["role", "level"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_article": {
+      "name": "saved_article",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_article_user_id_idx": {
+          "name": "saved_article_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "saved_article_userId_contentId_unique": {
+          "name": "saved_article_userId_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraper_cursor": {
+      "name": "scraper_cursor",
+      "schema": "",
+      "columns": {
+        "scraper_key": {
+          "name": "scraper_key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraper_retry": {
+      "name": "scraper_retry",
+      "schema": "",
+      "columns": {
+        "scraper_key": {
+          "name": "scraper_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_key": {
+          "name": "item_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_reason": {
+          "name": "last_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_failed_at": {
+          "name": "first_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scraper_retry_due_idx": {
+          "name": "scraper_retry_due_idx",
+          "columns": [
+            {
+              "expression": "scraper_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scraper_retry_scraper_key_item_key_pk": {
+          "name": "scraper_retry_scraper_key_item_key_pk",
+          "columns": ["scraper_key", "item_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "content_types": {
+          "name": "content_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preference_userId_unique": {
+          "name": "user_preference_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "personalize": {
+          "name": "personalize",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "analytics": {
+          "name": "analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "crash": {
+          "name": "crash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "offline": {
+          "name": "offline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_userId_unique": {
+          "name": "user_settings_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video": {
+      "name": "video",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_data": {
+          "name": "image_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_mime_type": {
+          "name": "image_mime_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_width": {
+          "name": "image_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_height": {
+          "name": "image_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement_metrics": {
+          "name": "engagement_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"likes\":0,\"comments\":0,\"shares\":0}'::jsonb"
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "video_content_id_idx": {
+          "name": "video_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "video_created_at_idx": {
+          "name": "video_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "video_contentType_contentId_unique": {
+          "name": "video_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["content_type", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1785223528709,
       "tag": "0008_strong_maginty",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1785282153862,
+      "tag": "0009_flashy_steel_serpent",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,5 @@
 import type { SQL } from "drizzle-orm";
+import type { AnyPgColumn } from "drizzle-orm/pg-core";
 import { sql } from "drizzle-orm";
 import {
   check,
@@ -166,16 +167,15 @@ export const Bill = pgTable(
     updatedAt: t
       .timestamp({ mode: "date", withTimezone: true })
       .$onUpdateFn(() => sql`now()`),
-    // Weighted full-text search vector: bill number + title (A), sponsor +
-    // summary/description (B), full text (C). Backs the `content.search`
-    // procedure alongside the trigram index below for loose code matching.
+    // Bill-level metadata only. Legislative text is indexed per section below;
+    // keeping a multi-megabyte omnibus out of this generated expression avoids
+    // PostgreSQL's 1 MiB to_tsvector input ceiling.
     searchVector: tsvector("search_vector").generatedAlwaysAs(
       (): SQL => sql`(
         setweight(to_tsvector('english', coalesce(bill_number, '')), 'A') ||
         setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
         setweight(to_tsvector('english', coalesce(sponsor, '')), 'B') ||
-        setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(description, '')), 'B') ||
-        setweight(to_tsvector('english', coalesce(full_text, '')), 'C')
+        setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(description, '')), 'B')
       )`,
     ),
   }),
@@ -201,6 +201,82 @@ export const CreateBillSchema = createInsertSchema(Bill).omit({
   createdAt: true,
   updatedAt: true,
 });
+
+/** Immutable snapshots of every official congress.gov text version we ingest. */
+export const BillSourceVersion = pgTable(
+  "bill_source_version",
+  (t) => ({
+    id: t.uuid().notNull().primaryKey().defaultRandom(),
+    billId: t
+      .uuid()
+      .notNull()
+      .references(() => Bill.id, { onDelete: "cascade" }),
+    versionCode: t.varchar({ length: 50 }).notNull(),
+    versionType: t.text().notNull(),
+    officialDate: t.timestamp({ withTimezone: true }),
+    sourceUrl: t.text().notNull(),
+    // Congress XML is retained byte-for-byte. PostgreSQL text uses TOAST for
+    // large values, so multi-megabyte omnibus versions remain practical.
+    rawXml: t.text().notNull(),
+    sourceHash: t.varchar({ length: 64 }).notNull(),
+    parseStatus: t.varchar({ length: 20 }).notNull().default("pending"),
+    parseError: t.text(),
+    createdAt: t.timestamp({ withTimezone: true }).defaultNow().notNull(),
+    updatedAt: t
+      .timestamp({ mode: "date", withTimezone: true })
+      .$onUpdateFn(() => sql`now()`),
+  }),
+  (table) => ({
+    uniqueVersion: unique().on(
+      table.billId,
+      table.versionCode,
+      table.sourceHash,
+    ),
+    billIdx: index("bill_source_version_bill_idx").on(table.billId),
+  }),
+);
+
+/** Addressable, independently searchable units parsed from a source version. */
+export const BillSection = pgTable(
+  "bill_section",
+  (t) => ({
+    id: t.uuid().notNull().primaryKey().defaultRandom(),
+    sourceVersionId: t
+      .uuid()
+      .notNull()
+      .references(() => BillSourceVersion.id, { onDelete: "cascade" }),
+    parentSectionId: t
+      .uuid()
+      .references((): AnyPgColumn => BillSection.id, { onDelete: "cascade" }),
+    structuralPath: t.text().notNull(),
+    displayedNumber: t.text(),
+    heading: t.text(),
+    order: t.integer().notNull(),
+    text: t.text().notNull(),
+    sectionHash: t.varchar({ length: 64 }).notNull(),
+    tokenCount: t.integer().notNull(),
+    sourceStartOffset: t.integer(),
+    sourceEndOffset: t.integer(),
+    xmlId: t.text(),
+    crossReferences: t.jsonb().$type<string[]>().notNull().default([]),
+    searchVector: tsvector("search_vector").generatedAlwaysAs(
+      (): SQL =>
+        sql`to_tsvector('english', coalesce(heading, '') || ' ' || coalesce(text, ''))`,
+    ),
+    createdAt: t.timestamp({ withTimezone: true }).defaultNow().notNull(),
+  }),
+  (table) => ({
+    uniquePath: unique().on(table.sourceVersionId, table.structuralPath),
+    sourceVersionIdx: index("bill_section_source_version_idx").on(
+      table.sourceVersionId,
+    ),
+    parentIdx: index("bill_section_parent_idx").on(table.parentSectionId),
+    searchVectorIdx: index("bill_section_search_vector_idx").using(
+      "gin",
+      table.searchVector,
+    ),
+  }),
+);
 
 // Government Content table (executive orders, memoranda, proclamations, news articles, briefings, etc.)
 export const GovernmentContent = pgTable(


### PR DESCRIPTION
Closes #234.

Stack root for the issue #191 core sequence. Merge this PR first.

## Summary

- Adds immutable `bill_source_version` storage for every complete Congress.gov Formatted XML version, keyed by bill, version code, and source hash.
- Parses USLM structure into stable, independently addressable `bill_section` rows with hierarchy paths, hashes, complete text, token counts, XML IDs/source offsets, and extracted cross-references.
- Preserves quoted amendments and splits unusually large sections at structural/word boundaries so section search vectors remain below PostgreSQL's input ceiling.
- Makes identical source reprocessing a no-op and records parse status/errors.
- Moves bill full-text search from the giant `bill.full_text` vector to per-section vectors while retaining weighted bill metadata search.
- Removes the oversized-bill refusal and adds simple/omnibus fixtures plus a multi-megabyte regression test.

## Validation

- `pnpm --filter @acme/scraper test` (43 tests passed)
- Scraper, database, and API TypeScript checks passed
- Database and API ESLint checks passed
- `drizzle-kit check` passed
- Migration applied successfully to isolated local Postgres
- Live H.R. 8800 reported XML validation: retained all 4,946,603 bytes, parsed/stored 727 unique hashed sections, and a second identical ingest remained one source version

The repository-wide lint command also reaches an existing validators lint failure in `packages/validators/src/bill-brief.ts` (lines 446–447); the changed database/API packages lint cleanly.