### PR TITLE
Split bill briefs into analysis and writing passes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,10 @@ OPENROUTER_API_KEY=
 # OpenRouter model slug used for AI text generation.
 # OPENROUTER_MODEL=deepseek/deepseek-v4-flash
 
+# Conservative per-call input budgets for bill section analysis and brief writing.
+# BILL_ANALYSIS_INPUT_TOKEN_BUDGET=16000
+# BILL_BRIEF_WRITING_INPUT_TOKEN_BUDGET=128000
+
 # Deprecated direct DeepSeek key; use OPENROUTER_API_KEY for AI text generation.
 # Get it: https://platform.deepseek.com/api_keys
 # DEEPSEEK_API_KEY=

--- a/apps/scraper/src/retroactive-briefs.ts
+++ b/apps/scraper/src/retroactive-briefs.ts
@@ -11,9 +11,10 @@ import pLimit from "p-limit";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { and, desc, eq, isNotNull, isNull, ne, or } from "@acme/db";
+import { and, desc, eq, isNotNull, isNull, ne, or, sql } from "@acme/db";
 import { db } from "@acme/db/client";
 import { Bill, ContentBrief } from "@acme/db/schema";
+import { BILL_ANALYSIS_SCHEMA_VERSION } from "@acme/validators";
 
 import { AIRateLimitError } from "./utils/ai/text-generation.js";
 import { upsertBillBrief } from "./utils/db/operations.js";
@@ -60,6 +61,7 @@ async function findBills(limit: number): Promise<BriefCandidate[]> {
         or(
           isNull(ContentBrief.id),
           ne(ContentBrief.contentHash, Bill.contentHash),
+          sql`${ContentBrief.brief}->>'analysisSchemaVersion' is distinct from ${BILL_ANALYSIS_SCHEMA_VERSION}`,
         ),
       ),
     )

--- a/apps/scraper/src/utils/ai/bill-brief.test.ts
+++ b/apps/scraper/src/utils/ai/bill-brief.test.ts
@@ -93,6 +93,7 @@ void test("older brief records stay renderable but are not current cache hits", 
   const current = {
     ...v5,
     version: BILL_BRIEF_VERSION,
+    analysisSchemaVersion: "bill-section-notes-v1",
   };
   assert.equal(isCurrentBillBrief(current), true);
 });
@@ -318,7 +319,12 @@ void test("verification strips unverified quotes but keeps the claim", () => {
       {
         label: "Authorized funding",
         value: "$1.2B",
-        quote: { text: "appropriated $1,200,000,000 for fiscal year 2027" },
+        quote: {
+          text: "appropriated $1,200,000,000 for fiscal year 2027",
+          sectionHash: "b".repeat(64),
+          startOffset: 220,
+          endOffset: 269,
+        },
       },
     ],
     changes: [
@@ -343,6 +349,7 @@ void test("verification strips unverified quotes but keeps the claim", () => {
   assert.equal(verified, 1);
   assert.equal(dropped, 1);
   assert.ok(cleaned.facts[0]?.quote, "grounded quote is kept");
+  assert.deepEqual(cleaned.facts[0]?.quote, input.facts[0]?.quote);
   assert.equal(cleaned.changes[0]?.quote, undefined, "invented quote is gone");
   assert.equal(
     cleaned.changes[0]?.title,

--- a/apps/scraper/src/utils/ai/bill-brief.ts
+++ b/apps/scraper/src/utils/ai/bill-brief.ts
@@ -4,10 +4,9 @@
  *
  * The pipeline is deliberately three steps, only one of which costs a token:
  *
- *   1. Structure (LLM). One schema-validated call grounded in the official text
- *      plus, when we have it, the existing long-form article — that article has
- *      already done the careful nonpartisan analysis, so this pass is mostly a
- *      restructuring job rather than a fresh reading.
+ *   1. Write (LLM). One schema-validated call grounded in cached, per-section
+ *      analysis notes plus outside research. Raw bill text never enters this
+ *      pass, so long bills cannot silently disappear at a context boundary.
  *   2. Verify quotes (deterministic). Every quote is checked against the full
  *      source text. Unverified quotes are dropped, not shipped — a brief may
  *      say less than the model wrote, but it never attributes words to a bill
@@ -25,6 +24,7 @@ import type {
   BriefLegalStatus,
 } from "@acme/validators";
 import {
+  BILL_ANALYSIS_SCHEMA_VERSION,
   BILL_BRIEF_VERSION,
   BillBriefSchema,
   BriefChangeSchema,
@@ -44,13 +44,11 @@ import {
   rateLimitHit,
   researchBillContext,
   setRateLimitHit,
-  SOURCE_WINDOW,
 } from "./text-generation.js";
 
 const logger = createLogger("ai-brief");
 
-// Shared with the research and lens steps — see SOURCE_WINDOW's own comment for
-// why they must not diverge.
+const DEFAULT_WRITING_INPUT_TOKEN_BUDGET = 128_000;
 
 /** Attempts at structuring before giving up (each is one LLM call). */
 const MAX_ATTEMPTS = 2;
@@ -62,6 +60,9 @@ const MAX_ATTEMPTS = 2;
  */
 const GeneratedBriefQuoteSchema = BriefQuoteSchema.extend({
   locator: z.string().trim().max(120).nullish(),
+  sectionHash: z.string().length(64).nullish(),
+  startOffset: z.number().int().min(0).nullish(),
+  endOffset: z.number().int().positive().nullish(),
 });
 const GeneratedBillBriefSchema = BillBriefSchema.extend({
   facts: z
@@ -167,7 +168,18 @@ export function verifyBriefQuotes(
     item: T,
   ): T => {
     if (!item.quote) return item;
-    if (isQuoteGrounded(item.quote.text, normalizedSource)) {
+    const quote = item.quote as T["quote"] & {
+      sectionHash?: string;
+      startOffset?: number;
+      endOffset?: number;
+    };
+    if (
+      quote.sectionHash &&
+      quote.startOffset !== undefined &&
+      quote.endOffset !== undefined &&
+      quote.endOffset > quote.startOffset &&
+      isQuoteGrounded(quote.text, normalizedSource)
+    ) {
       verified++;
       return item;
     }
@@ -541,7 +553,7 @@ function buildBriefPrompt(args: {
   billNumber: string;
   url: string;
   legalStatus: BriefLegalStatus;
-  sourceText: string;
+  analysisNotes: string;
   officialSummary?: string | null;
   priorArticle?: string | null;
   readingResearch?: string;
@@ -555,7 +567,7 @@ function buildBriefPrompt(args: {
     billNumber,
     url,
     legalStatus,
-    sourceText,
+    analysisNotes,
     officialSummary,
     priorArticle,
     readingResearch,
@@ -596,7 +608,7 @@ function buildBriefPrompt(args: {
 
 ${tense}
 
-Your job is to explain the policy, not to promote or attack it. Treat the title, acronym, findings, purpose clauses, and sponsor statements as claims about intent — not proof of results. Base every factual statement on the supplied source text.
+Your job is to explain the policy, not to promote or attack it. Treat the title, acronym, findings, purpose clauses, and sponsor statements as claims about intent — not proof of results. Base every factual statement on the supplied section notes.
 
 Before filling in the fields, silently identify:
 1. The concrete mechanisms: what authority, rule, funding, eligibility, deadline, review, oversight, enforcement, or safeguard is added, removed, weakened, expanded, or transferred.
@@ -607,7 +619,7 @@ Before filling in the fields, silently identify:
 Rules that decide whether this brief ships:
 
 - **Mechanism over marketing.** Removing or waiving rules, reviews, reporting, or oversight is deregulation or reduced oversight. Say that. Do not hide it behind "cuts red tape", "modernizes", "streamlines", or "speeds up". Equally, do not attach a hostile label the text does not support.
-- **Quotes are verbatim.** Every "quote" field must be an exact, unedited span copied character-for-character from the source text below. Do not paraphrase, splice, trim mid-word, or fix grammar. Quotes that do not appear in the source are removed automatically, so a paraphrase in quotation marks just loses you a citation.
+- **Quotes are verbatim and addressable.** Use only exact evidence quotes present in the section notes. Copy text, sectionHash, startOffset, and endOffset together without alteration. Never quote the CRS summary, prior article, or outside research.
 - **No invented figures.** A number, date, or dollar amount goes in "facts" only if the source states it. Fewer facts is correct; a plausible-looking invented figure is not.
 - **No manufactured symmetry.** If the text supports one consequence more strongly than another, say so. Use "mixed" or "unclear" for an affected group rather than balancing the list for its own sake.
 - **Use only the allowed change kinds.** Every change "kind" must be exactly one of: "creates", "repeals", "expands", "restricts", "requires", "waives", "funds", or "transfers". Map synonyms such as "sets" or "establishes" to "creates", and "restructures" to the closest allowed mechanism.
@@ -635,7 +647,7 @@ Status: ${legalStatus === "enacted" ? "enacted" : "proposed, not yet law"}
 Source URL: ${url}
 ${
   priorArticle
-    ? `\nPrior nonpartisan analysis of this bill (already vetted for framing — reuse its judgments, but pull all quotes from the official text below):\n${priorArticle.slice(0, 6000)}\n`
+    ? `\nPrior nonpartisan analysis of this bill (already vetted for framing — reuse its judgments, but use only evidence quotes from the section notes):\n${priorArticle.slice(0, 6000)}\n`
     : ""
 }
 ${
@@ -652,11 +664,11 @@ ${
 }
 ${
   officialSummary
-    ? `\nOfficial CRS summary of the whole bill (nonpartisan, written by the Congressional Research Service). The official text below may be windowed and end mid-section, so treat this summary as authoritative for the bill's overall scope — including provisions the excerpt cuts off, such as penalties and effective dates. Do not report something as unspecified when this summary specifies it. Never quote from this summary: every "quote" must come verbatim from the official text below.\n${officialSummary.slice(0, 6000)}\n`
+    ? `\nOfficial CRS summary of the whole bill (nonpartisan, written by the Congressional Research Service). Use it as authoritative context for the bill's overall scope, but never quote from it: every "quote" must copy a referenced evidence span from the section notes.\n${officialSummary.slice(0, 6000)}\n`
     : ""
 }
-Official text:
-${sourceText.slice(0, SOURCE_WINDOW)}
+Section-by-section analysis inventory:
+${analysisNotes}
 ---
 
 Produce the structured brief now.`;
@@ -674,6 +686,7 @@ export async function generateBillBrief(args: {
   billNumber: string;
   url: string;
   fullText: string;
+  analysisNotes: string;
   officialSummary?: string | null;
   status?: string | null;
   priorArticle?: string | null;
@@ -684,7 +697,7 @@ export async function generateBillBrief(args: {
   const readingResearch = await researchBillContext(
     args.title,
     args.billNumber,
-    args.fullText,
+    args.analysisNotes,
   );
   let loadedPhrases: string[] | undefined;
   let jargonPhrases: string[] | undefined;
@@ -695,23 +708,32 @@ export async function generateBillBrief(args: {
 
   for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     try {
+      const prompt = buildBriefPrompt({
+        title: args.title,
+        billNumber: args.billNumber,
+        url: args.url,
+        legalStatus,
+        analysisNotes: args.analysisNotes,
+        officialSummary: args.officialSummary,
+        priorArticle: args.priorArticle,
+        readingResearch: readingResearch.notes,
+        readingSources: readingResearch.sources,
+        loadedPhrases,
+        jargonPhrases,
+        missingEmphasis,
+      });
+      const writingBudget =
+        Number(process.env.BILL_BRIEF_WRITING_INPUT_TOKEN_BUDGET) ||
+        DEFAULT_WRITING_INPUT_TOKEN_BUDGET;
+      if (Buffer.byteLength(prompt, "utf8") > writingBudget) {
+        throw new Error(
+          `Bill brief writing prompt exceeds BILL_BRIEF_WRITING_INPUT_TOKEN_BUDGET=${writingBudget}`,
+        );
+      }
       const { output: generatedOutput, usage } = await generateText({
         model: getStructuredLlm(),
         output: Output.object({ schema: GeneratedBillBriefSchema }),
-        prompt: buildBriefPrompt({
-          title: args.title,
-          billNumber: args.billNumber,
-          url: args.url,
-          legalStatus,
-          sourceText: args.fullText,
-          officialSummary: args.officialSummary,
-          priorArticle: args.priorArticle,
-          readingResearch: readingResearch.notes,
-          readingSources: readingResearch.sources,
-          loadedPhrases,
-          jargonPhrases,
-          missingEmphasis,
-        }),
+        prompt,
       });
       trackLLMUsage(usage.inputTokens, usage.outputTokens);
 
@@ -745,6 +767,7 @@ export async function generateBillBrief(args: {
         verifiedFallback = {
           ...brief,
           version: BILL_BRIEF_VERSION,
+          analysisSchemaVersion: BILL_ANALYSIS_SCHEMA_VERSION,
           legalStatus,
           verifiedQuotes: verified,
         };
@@ -778,6 +801,7 @@ export async function generateBillBrief(args: {
       return {
         ...brief,
         version: BILL_BRIEF_VERSION,
+        analysisSchemaVersion: BILL_ANALYSIS_SCHEMA_VERSION,
         legalStatus,
         verifiedQuotes: verified,
       };

--- a/apps/scraper/src/utils/ai/bill-section-analysis.test.ts
+++ b/apps/scraper/src/utils/ai/bill-section-analysis.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildSectionAnalysisPrompt,
+  chunkSectionForAnalysis,
+  conservativeTokenUpperBound,
+  formatSectionAnalysesForWriting,
+  normalizeSectionNotes,
+} from "./bill-section-analysis.js";
+
+const HASH = "a".repeat(64);
+
+function section(text: string) {
+  return {
+    id: "section-id",
+    structuralPath: "title-i/section-4",
+    heading: "Penalties",
+    displayedNumber: "SEC. 4.",
+    order: 3,
+    text,
+    sectionHash: HASH,
+    sourceStartOffset: 100,
+    sourceEndOffset: 100 + text.length,
+  };
+}
+
+void test("large canonical sections are chunked without crossing the input budget", () => {
+  const source = Array.from(
+    { length: 300 },
+    (_, index) =>
+      `(a) Rule ${index}. A covered person shall pay a civil penalty of $2,000.\n\n`,
+  ).join("");
+  const inputBudget = 2_400;
+  const chunks = chunkSectionForAnalysis(section(source), inputBudget);
+
+  assert.ok(chunks.length > 1);
+  assert.equal(chunks.map((chunk) => chunk.text).join(""), source);
+  for (const chunk of chunks) {
+    const prompt = buildSectionAnalysisPrompt({
+      section: section(source),
+      excerpt: chunk.text,
+      excerptStartOffset: chunk.startOffset,
+    });
+    assert.ok(conservativeTokenUpperBound(prompt) <= inputBudget);
+  }
+});
+
+void test("evidence is grounded and rewritten to canonical section offsets", () => {
+  const prefix = "Introductory language. ";
+  const quote = "The violator shall pay a civil penalty of $2,000.";
+  const chunk = { text: `${prefix}${quote}`, startOffset: 500 };
+  const notes = normalizeSectionNotes(
+    {
+      summary: "Creates a civil penalty.",
+      provisions: [
+        {
+          kind: "penalty",
+          statement: "Violators face a $2,000 civil penalty.",
+          subjects: ["violators"],
+          evidence: [{ quote, startOffset: 0, endOffset: 4 }],
+        },
+      ],
+    },
+    chunk,
+    HASH,
+  );
+
+  assert.deepEqual(notes.provisions[0]?.evidence[0], {
+    quote,
+    sectionHash: HASH,
+    startOffset: 500 + prefix.length,
+    endOffset: 500 + prefix.length + quote.length,
+  });
+});
+
+void test("ungrounded evidence cannot survive into cached notes", () => {
+  const notes = normalizeSectionNotes(
+    {
+      summary: "The model invented a penalty.",
+      provisions: [
+        {
+          kind: "penalty",
+          statement: "Violators face a penalty.",
+          subjects: ["violators"],
+          evidence: [
+            {
+              quote: "This sentence is not in the section.",
+              startOffset: 0,
+              endOffset: 36,
+            },
+          ],
+        },
+      ],
+    },
+    { text: "The section contains definitions only.", startOffset: 0 },
+    HASH,
+  );
+
+  assert.deepEqual(notes.provisions, []);
+});
+
+void test("late H.R. 7008 penalties remain visible to the writing pass", () => {
+  const penaltyText =
+    "the greater of $2,000 or 10 percent of the value of the transaction, plus the net gain";
+  const penaltySection = section(penaltyText);
+  const writingInput = formatSectionAnalysesForWriting([
+    {
+      section: penaltySection,
+      status: "analyzed",
+      notes: {
+        summary:
+          "Creates a civil penalty that cannot be paid from campaign funds.",
+        provisions: [
+          {
+            kind: "penalty",
+            statement:
+              "The penalty is the greater of $2,000 or 10% of transaction value, plus net gain, and campaign funds may not pay it.",
+            subjects: ["covered officeholders"],
+            evidence: [
+              {
+                quote: penaltyText,
+                sectionHash: HASH,
+                startOffset: 0,
+                endOffset: penaltyText.length,
+              },
+            ],
+          },
+        ],
+      },
+      error: null,
+    },
+  ]);
+
+  assert.match(writingInput, /greater of \$2,000 or 10%/);
+  assert.match(writingInput, /campaign funds may not pay it/);
+  assert.match(writingInput, new RegExp(`${HASH}:0-${penaltyText.length}`));
+});

--- a/apps/scraper/src/utils/ai/bill-section-analysis.ts
+++ b/apps/scraper/src/utils/ai/bill-section-analysis.ts
@@ -1,0 +1,270 @@
+import { APICallError, generateText, Output, RetryError } from "ai";
+import { z } from "zod";
+
+import type { BillSectionEvidence, BillSectionNotes } from "@acme/validators";
+import { BillSectionNotesSchema } from "@acme/validators";
+
+import { trackLLMUsage } from "../costs.js";
+import { getStructuredLlm } from "./provider.js";
+import { AIRateLimitError, setRateLimitHit } from "./text-generation.js";
+
+export const BILL_ANALYSIS_PROMPT_VERSION = "section-mechanisms-v1";
+export const DEFAULT_BILL_ANALYSIS_INPUT_TOKEN_BUDGET = 16_000;
+const MIN_INPUT_TOKEN_BUDGET = 2_000;
+const ANALYSIS_OUTPUT_TOKEN_BUDGET = 2_000;
+
+const GeneratedEvidenceSchema = z.object({
+  quote: z.string().trim().min(1),
+  startOffset: z.number().int().min(0),
+  endOffset: z.number().int().positive(),
+});
+
+const GeneratedNotesSchema = BillSectionNotesSchema.extend({
+  summary: z.string().trim().min(1).max(1_200),
+  provisions: z
+    .array(
+      BillSectionNotesSchema.shape.provisions.element.extend({
+        evidence: z.array(GeneratedEvidenceSchema).min(1).max(6),
+      }),
+    )
+    .max(30),
+});
+
+export interface BillSectionForAnalysis {
+  id: string;
+  structuralPath: string;
+  heading: string | null;
+  displayedNumber: string | null;
+  order: number;
+  text: string;
+  sectionHash: string;
+  sourceStartOffset: number | null;
+  sourceEndOffset: number | null;
+}
+
+interface SectionChunk {
+  text: string;
+  startOffset: number;
+}
+
+function configuredInputTokenBudget(): number {
+  const configured = Number(process.env.BILL_ANALYSIS_INPUT_TOKEN_BUDGET);
+  return Number.isInteger(configured) && configured >= MIN_INPUT_TOKEN_BUDGET
+    ? configured
+    : DEFAULT_BILL_ANALYSIS_INPUT_TOKEN_BUDGET;
+}
+
+/**
+ * UTF-8 bytes are a conservative upper bound for modern subword tokenizers.
+ * Keeping the entire prompt below this value prevents an unexpectedly dense
+ * statute or non-ASCII text from exceeding the configured input budget.
+ */
+export function conservativeTokenUpperBound(text: string): number {
+  return Buffer.byteLength(text, "utf8");
+}
+
+function sectionLabel(section: BillSectionForAnalysis): string {
+  return (
+    [section.displayedNumber, section.heading].filter(Boolean).join(" — ") ||
+    section.structuralPath
+  );
+}
+
+export function buildSectionAnalysisPrompt(args: {
+  section: BillSectionForAnalysis;
+  excerpt: string;
+  excerptStartOffset: number;
+}): string {
+  return `You are taking structured, evidence-grounded notes on one section of a U.S. bill. These notes will be the only bill-text input available to a later writer.
+
+Extract each operative provision separately. Classify it as one of: change, binding, effective_date, penalty, exemption, definition, cross_reference, funding, oversight, or other. Record who or what it applies to in subjects. Prefer specific mechanisms over general purpose language.
+
+Coverage rules:
+- Look explicitly for duties, prohibitions, eligibility, discretion, money, deadlines, effective dates, penalties, exemptions, definitions, and cross-references.
+- Do not infer current law, intent, effects, or absence beyond this excerpt.
+- Every provision needs at least one exact, unedited evidence quote from the excerpt.
+- Evidence offsets are zero-based within this excerpt and end-exclusive.
+- Preserve numbers, thresholds, dates, exceptions, and enforcement language.
+- Return an empty provisions array only when the excerpt contains no operative provision.
+
+Section: ${sectionLabel(args.section)}
+Structural path: ${args.section.structuralPath}
+Excerpt begins at section offset: ${args.excerptStartOffset}
+
+<section-excerpt>
+${args.excerpt}
+</section-excerpt>`;
+}
+
+function splitAtBoundary(text: string, start: number, maximumBytes: number) {
+  let end = Math.min(text.length, start + maximumBytes);
+  while (
+    end > start &&
+    Buffer.byteLength(text.slice(start, end), "utf8") > maximumBytes
+  ) {
+    end--;
+  }
+  if (end === text.length) return end;
+
+  const floor = start + Math.floor((end - start) * 0.6);
+  const candidate = text.slice(floor, end);
+  const boundary = Math.max(
+    candidate.lastIndexOf("\n\n"),
+    candidate.lastIndexOf("\n"),
+    candidate.lastIndexOf(". "),
+    candidate.lastIndexOf("; "),
+  );
+  return boundary >= 0 ? floor + boundary + 1 : end;
+}
+
+export function chunkSectionForAnalysis(
+  section: BillSectionForAnalysis,
+  inputTokenBudget = configuredInputTokenBudget(),
+): SectionChunk[] {
+  const emptyPrompt = buildSectionAnalysisPrompt({
+    section,
+    excerpt: "",
+    excerptStartOffset: section.text.length,
+  });
+  const availableBytes =
+    inputTokenBudget - conservativeTokenUpperBound(emptyPrompt);
+  if (availableBytes < 256) {
+    throw new Error(
+      `BILL_ANALYSIS_INPUT_TOKEN_BUDGET=${inputTokenBudget} is too small for the analysis prompt`,
+    );
+  }
+
+  const chunks: SectionChunk[] = [];
+  let startOffset = 0;
+  while (startOffset < section.text.length) {
+    const endOffset = splitAtBoundary(
+      section.text,
+      startOffset,
+      availableBytes,
+    );
+    const text = section.text.slice(startOffset, endOffset);
+    const prompt = buildSectionAnalysisPrompt({
+      section,
+      excerpt: text,
+      excerptStartOffset: startOffset,
+    });
+    if (conservativeTokenUpperBound(prompt) > inputTokenBudget) {
+      throw new Error(
+        "Section analysis prompt exceeded its input token budget",
+      );
+    }
+    chunks.push({ text, startOffset });
+    startOffset = endOffset;
+  }
+  return chunks;
+}
+
+function locateEvidence(
+  evidence: z.infer<typeof GeneratedEvidenceSchema>,
+  chunk: SectionChunk,
+  sectionHash: string,
+): BillSectionEvidence | null {
+  let relativeStart = evidence.startOffset;
+  let relativeEnd = evidence.endOffset;
+  if (
+    chunk.text.slice(relativeStart, relativeEnd) !== evidence.quote ||
+    relativeEnd <= relativeStart
+  ) {
+    relativeStart = chunk.text.indexOf(evidence.quote);
+    relativeEnd = relativeStart + evidence.quote.length;
+  }
+  if (relativeStart < 0 || relativeEnd > chunk.text.length) return null;
+  return {
+    quote: evidence.quote,
+    sectionHash,
+    startOffset: chunk.startOffset + relativeStart,
+    endOffset: chunk.startOffset + relativeEnd,
+  };
+}
+
+export function normalizeSectionNotes(
+  generated: z.infer<typeof GeneratedNotesSchema>,
+  chunk: SectionChunk,
+  sectionHash: string,
+): BillSectionNotes {
+  return BillSectionNotesSchema.parse({
+    summary: generated.summary,
+    provisions: generated.provisions.flatMap((provision) => {
+      const evidence = provision.evidence.flatMap((item) => {
+        const located = locateEvidence(item, chunk, sectionHash);
+        return located ? [located] : [];
+      });
+      return evidence.length > 0 ? [{ ...provision, evidence }] : [];
+    }),
+  });
+}
+
+/** Analyze one canonical bill section, chunking only within that section. */
+export async function analyzeBillSection(
+  section: BillSectionForAnalysis,
+): Promise<BillSectionNotes> {
+  try {
+    const chunks = chunkSectionForAnalysis(section);
+    const notes: BillSectionNotes[] = [];
+    for (const chunk of chunks) {
+      const { output, usage } = await generateText({
+        model: getStructuredLlm(),
+        output: Output.object({ schema: GeneratedNotesSchema }),
+        maxOutputTokens: ANALYSIS_OUTPUT_TOKEN_BUDGET,
+        prompt: buildSectionAnalysisPrompt({
+          section,
+          excerpt: chunk.text,
+          excerptStartOffset: chunk.startOffset,
+        }),
+      });
+      trackLLMUsage(usage.inputTokens, usage.outputTokens);
+      notes.push(normalizeSectionNotes(output, chunk, section.sectionHash));
+    }
+
+    return BillSectionNotesSchema.parse({
+      summary: notes.map((note) => note.summary).join(" "),
+      provisions: notes.flatMap((note) => note.provisions),
+    });
+  } catch (error) {
+    const rateLimited =
+      (error instanceof APICallError && error.statusCode === 429) ||
+      (error instanceof RetryError &&
+        error.lastError instanceof APICallError &&
+        error.lastError.statusCode === 429) ||
+      (error instanceof Error &&
+        /(?:429|rate limit|resource_exhausted|quota)/i.test(error.message));
+    if (rateLimited) {
+      setRateLimitHit(true);
+      throw new AIRateLimitError();
+    }
+    throw error;
+  }
+}
+
+export function formatSectionAnalysesForWriting(
+  analyses: readonly {
+    section: BillSectionForAnalysis;
+    status: "analyzed" | "skipped" | "failed";
+    notes: BillSectionNotes | null;
+    error: string | null;
+  }[],
+): string {
+  return analyses
+    .map(({ section, status, notes, error }) => {
+      const header = `## ${sectionLabel(section)}\nsectionHash: ${section.sectionHash}\ncoverage: ${status}`;
+      if (!notes) return `${header}\n${error ? `reason: ${error}` : ""}`.trim();
+      const provisions = notes.provisions
+        .map(
+          (provision) =>
+            `- [${provision.kind}] ${provision.statement}\n  subjects: ${provision.subjects.join(", ") || "(none)"}\n${provision.evidence
+              .map(
+                (evidence) =>
+                  `  evidence ${evidence.sectionHash}:${evidence.startOffset}-${evidence.endOffset}: ${JSON.stringify(evidence.quote)}`,
+              )
+              .join("\n")}`,
+        )
+        .join("\n");
+      return `${header}\nsummary: ${notes.summary}\n${provisions}`.trim();
+    })
+    .join("\n\n");
+}

--- a/apps/scraper/src/utils/ai/text-generation.ts
+++ b/apps/scraper/src/utils/ai/text-generation.ts
@@ -588,16 +588,26 @@ export interface BillContextResearch {
 export async function researchBillContext(
   title: string,
   billNumber: string,
-  fullText: string,
+  analysisNotes: string,
 ): Promise<BillContextResearch> {
   try {
+    const groundingBudget = 12_000;
+    const groundingLines: string[] = [];
+    let groundingBytes = 0;
+    for (const line of analysisNotes.split("\n")) {
+      if (!/^(## |summary:|- \[)/.test(line)) continue;
+      const lineBytes = Buffer.byteLength(`${line}\n`, "utf8");
+      if (groundingBytes + lineBytes > groundingBudget) break;
+      groundingLines.push(line);
+      groundingBytes += lineBytes;
+    }
     const res = await generateText({
       model: getTextLlm(),
       tools: { web_search: webResearchTool, fetch_page: fetchPageTool },
       stopWhen: stepCountIs(7),
       prompt: `You are researching historical context and useful follow-up reading for an average citizen reading about ${billNumber}, "${title}".
 
-1. Read the bill text below before searching, and identify every distinct subject it legislates on. A bill's title names one of them at best. If the text contains provisions **unrelated to the title's subject** — separate policy riding along in the same bill — those are as important to research as the headline subject, and a reader will find them nowhere else. Note them explicitly.
+1. Read the section-analysis topic index below before searching, and identify every distinct subject the bill legislates on. A bill's title names one of them at best. If the analysis contains provisions **unrelated to the title's subject** — separate policy riding along in the same bill — those are as important to research as the headline subject, and a reader will find them nowhere else. Note them explicitly.
 2. Then investigate why this policy has not already been implemented. Look for earlier bills, documented disagreements, legal or budget constraints, implementation tradeoffs, and circumstances that changed. Do not guess at lawmakers' motives.
 3. Prefer the Congressional Research Service, GAO, CBO, established newsrooms, universities, and transparent research organizations. Avoid campaign pages, SEO summaries, scraped copies, and sources that merely repeat a press release. Reject a URL carrying referral or campaign tracking parameters (utm_source, utm_campaign, ref=) — find the publisher's own canonical link instead.
 4. Search separately for clear explanatory reporting or authoritative background that helps a reader understand the bill's most important mechanism or uncertainty. **Cover each distinct subject you identified in step 1**, not just the one the title names: a reading list that only addresses the headline subject leaves the reader with no way to learn about the rest of what the bill does.
@@ -607,8 +617,8 @@ export async function researchBillContext(
    - FURTHER READING: the two to four best articles, who published each, and what each helps a reader understand. Say which subject each one covers.
 Do not cite or recommend a page you did not open.
 
-Official bill text:
-${fullText.slice(0, SOURCE_WINDOW)}`,
+Section-analysis topic index:
+${groundingLines.join("\n")}`,
     });
     trackLLMUsage(res.usage.inputTokens, res.usage.outputTokens);
     return {

--- a/apps/scraper/src/utils/db/bill-analysis-operations.ts
+++ b/apps/scraper/src/utils/db/bill-analysis-operations.ts
@@ -1,0 +1,298 @@
+import type { BillAnalysisStatus, BillSectionNotes } from "@acme/validators";
+import { and, asc, desc, eq, sql } from "@acme/db";
+import { db } from "@acme/db/client";
+import {
+  BillSection,
+  BillSectionAnalysis,
+  BillSourceVersion,
+} from "@acme/db/schema";
+import {
+  BILL_ANALYSIS_SCHEMA_VERSION,
+  BillSectionNotesSchema,
+} from "@acme/validators";
+
+import type { BillSectionForAnalysis } from "../ai/bill-section-analysis.js";
+import {
+  analyzeBillSection,
+  BILL_ANALYSIS_PROMPT_VERSION,
+} from "../ai/bill-section-analysis.js";
+import { getTextModelVersion } from "../ai/provider.js";
+import { AIRateLimitError } from "../ai/text-generation.js";
+
+export const BILL_ANALYSIS_CACHE_PROMPT_VERSION = `${BILL_ANALYSIS_SCHEMA_VERSION}:${BILL_ANALYSIS_PROMPT_VERSION}`;
+
+export interface CompletedBillSectionAnalysis {
+  section: BillSectionForAnalysis;
+  status: BillAnalysisStatus;
+  notes: BillSectionNotes | null;
+  error: string | null;
+}
+
+/**
+ * Analyze sections that have not been stored yet.
+ *
+ * New bills build every required reader-facing asset before their first
+ * database write. This path lets the brief's analysis pass participate in that
+ * assembly while the persisted path below continues to provide caching for
+ * existing bills.
+ */
+export async function analyzeBillSectionsInMemory(
+  sections: readonly BillSectionForAnalysis[],
+): Promise<CompletedBillSectionAnalysis[]> {
+  const completed: CompletedBillSectionAnalysis[] = [];
+
+  for (let index = 0; index < sections.length; index++) {
+    const section = sections[index]!;
+    if (!section.text.trim()) {
+      completed.push({
+        section,
+        status: "skipped",
+        notes: null,
+        error: "Empty canonical section",
+      });
+      continue;
+    }
+
+    try {
+      completed.push({
+        section,
+        status: "analyzed",
+        notes: await analyzeBillSection(section),
+        error: null,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      completed.push({
+        section,
+        status: "failed",
+        notes: null,
+        error: message,
+      });
+
+      if (error instanceof AIRateLimitError) {
+        completed.push(
+          ...sections.slice(index + 1).map((remaining) => ({
+            section: remaining,
+            status: "failed" as const,
+            notes: null,
+            error: "Not analyzed because the provider rate limit was reached",
+          })),
+        );
+        throw error;
+      }
+    }
+  }
+
+  return completed;
+}
+
+async function currentSections(
+  billId: string,
+): Promise<BillSectionForAnalysis[]> {
+  const [sourceVersion] = await db
+    .select({
+      id: BillSourceVersion.id,
+      parseStatus: BillSourceVersion.parseStatus,
+    })
+    .from(BillSourceVersion)
+    .where(eq(BillSourceVersion.billId, billId))
+    .orderBy(
+      sql`${BillSourceVersion.officialDate} desc nulls last`,
+      desc(BillSourceVersion.createdAt),
+    )
+    .limit(1);
+  if (!sourceVersion || sourceVersion.parseStatus !== "parsed") return [];
+
+  return db
+    .select({
+      id: BillSection.id,
+      structuralPath: BillSection.structuralPath,
+      heading: BillSection.heading,
+      displayedNumber: BillSection.displayedNumber,
+      order: BillSection.order,
+      text: BillSection.text,
+      sectionHash: BillSection.sectionHash,
+      sourceStartOffset: BillSection.sourceStartOffset,
+      sourceEndOffset: BillSection.sourceEndOffset,
+    })
+    .from(BillSection)
+    .where(eq(BillSection.sourceVersionId, sourceVersion.id))
+    .orderBy(asc(BillSection.order));
+}
+
+async function storeTerminalState(args: {
+  section: BillSectionForAnalysis;
+  modelVersion: string;
+  status: BillAnalysisStatus;
+  notes: BillSectionNotes | null;
+  error: string | null;
+}) {
+  await db
+    .insert(BillSectionAnalysis)
+    .values({
+      sectionId: args.section.id,
+      sectionHash: args.section.sectionHash,
+      promptVersion: BILL_ANALYSIS_CACHE_PROMPT_VERSION,
+      modelVersion: args.modelVersion,
+      status: args.status,
+      notes: args.notes,
+      error: args.error,
+    })
+    .onConflictDoUpdate({
+      target: [
+        BillSectionAnalysis.sectionId,
+        BillSectionAnalysis.promptVersion,
+        BillSectionAnalysis.modelVersion,
+      ],
+      set: {
+        sectionHash: args.section.sectionHash,
+        status: args.status,
+        notes: args.notes,
+        error: args.error,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+/**
+ * Attach pre-commit analysis results to the canonical sections created for a
+ * new bill. Structural path plus content hash is stable across the in-memory
+ * parse and the subsequent persisted parse.
+ */
+export async function persistCompletedBillSectionAnalyses(
+  billId: string,
+  analyses: readonly CompletedBillSectionAnalysis[],
+): Promise<void> {
+  const sections = await currentSections(billId);
+  const byIdentity = new Map(
+    sections.map((section) => [
+      `${section.structuralPath}\0${section.sectionHash}`,
+      section,
+    ]),
+  );
+  const modelVersion = getTextModelVersion();
+
+  for (const analysis of analyses) {
+    const section = byIdentity.get(
+      `${analysis.section.structuralPath}\0${analysis.section.sectionHash}`,
+    );
+    if (!section) continue;
+    await storeTerminalState({ ...analysis, section, modelVersion });
+  }
+}
+
+function usableCachedNotes(value: unknown): BillSectionNotes | null {
+  const parsed = BillSectionNotesSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+/**
+ * Analyze the operative source version section by section.
+ *
+ * Every canonical section receives a terminal-state row. Reusable analyzed or
+ * skipped results are copied from any identical section hash produced by the
+ * same prompt/model tuple; failed rows are recorded but retried on a later run.
+ */
+export async function analyzeCurrentBillSections(
+  billId: string,
+): Promise<CompletedBillSectionAnalysis[]> {
+  const sections = await currentSections(billId);
+  if (sections.length === 0) return [];
+
+  const modelVersion = getTextModelVersion();
+  const completed: CompletedBillSectionAnalysis[] = [];
+
+  for (let index = 0; index < sections.length; index++) {
+    const section = sections[index]!;
+    const [cached] = await db
+      .select({
+        status: BillSectionAnalysis.status,
+        notes: BillSectionAnalysis.notes,
+        error: BillSectionAnalysis.error,
+      })
+      .from(BillSectionAnalysis)
+      .where(
+        and(
+          eq(BillSectionAnalysis.sectionHash, section.sectionHash),
+          eq(
+            BillSectionAnalysis.promptVersion,
+            BILL_ANALYSIS_CACHE_PROMPT_VERSION,
+          ),
+          eq(BillSectionAnalysis.modelVersion, modelVersion),
+          sql`${BillSectionAnalysis.status} in ('analyzed', 'skipped')`,
+        ),
+      )
+      .orderBy(desc(BillSectionAnalysis.updatedAt))
+      .limit(1);
+
+    const cachedStatus: "analyzed" | "skipped" | null =
+      cached?.status === "analyzed" || cached?.status === "skipped"
+        ? cached.status
+        : null;
+    const cachedNotes =
+      cached && cachedStatus === "analyzed"
+        ? usableCachedNotes(cached.notes)
+        : null;
+    if (cached && (cachedStatus === "skipped" || cachedNotes)) {
+      const result: CompletedBillSectionAnalysis = {
+        section,
+        status: cachedStatus ?? "analyzed",
+        notes: cachedNotes,
+        error: cached.error,
+      };
+      await storeTerminalState({ ...result, modelVersion });
+      completed.push(result);
+      continue;
+    }
+
+    if (!section.text.trim()) {
+      const result: CompletedBillSectionAnalysis = {
+        section,
+        status: "skipped",
+        notes: null,
+        error: "Empty canonical section",
+      };
+      await storeTerminalState({ ...result, modelVersion });
+      completed.push(result);
+      continue;
+    }
+
+    try {
+      const notes = await analyzeBillSection(section);
+      const result: CompletedBillSectionAnalysis = {
+        section,
+        status: "analyzed",
+        notes,
+        error: null,
+      };
+      await storeTerminalState({ ...result, modelVersion });
+      completed.push(result);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const result: CompletedBillSectionAnalysis = {
+        section,
+        status: "failed",
+        notes: null,
+        error: message,
+      };
+      await storeTerminalState({ ...result, modelVersion });
+      completed.push(result);
+
+      if (error instanceof AIRateLimitError) {
+        for (const remaining of sections.slice(index + 1)) {
+          const deferred: CompletedBillSectionAnalysis = {
+            section: remaining,
+            status: "failed",
+            notes: null,
+            error: "Not analyzed because the provider rate limit was reached",
+          };
+          await storeTerminalState({ ...deferred, modelVersion });
+          completed.push(deferred);
+        }
+        throw error;
+      }
+    }
+  }
+
+  return completed;
+}

--- a/apps/scraper/src/utils/db/operations.ts
+++ b/apps/scraper/src/utils/db/operations.ts
@@ -12,7 +12,11 @@ import {
 } from "@acme/db/schema";
 import { isCurrentBillBrief } from "@acme/validators";
 
-import type { BillSourceVersionInput } from "../bill-sections.js";
+import type {
+  BillSourceVersionInput,
+  ParsedBillSection,
+} from "../bill-sections.js";
+import { parseBillSections } from "../bill-sections.js";
 import type { NewItemLimiter } from "../new-item-limit.js";
 import type {
   BillData,
@@ -20,6 +24,7 @@ import type {
   GovernmentContentData,
 } from "../types.js";
 import { generateBillBrief } from "../ai/bill-brief.js";
+import { formatSectionAnalysesForWriting } from "../ai/bill-section-analysis.js";
 import { generateImageSearchKeywords } from "../ai/image-keywords.js";
 import { getTextModelVersion } from "../ai/provider.js";
 import {
@@ -37,6 +42,11 @@ import { createContentHash } from "../hash.js";
 import { createLogger } from "../log.js";
 import { tickProgress } from "../progress.js";
 import { isUsableSourceText } from "../reprocessing-policy.js";
+import {
+  analyzeBillSectionsInMemory,
+  analyzeCurrentBillSections,
+  persistCompletedBillSectionAnalyses,
+} from "./bill-analysis-operations.js";
 import { persistBillSourceVersions } from "./bill-source-operations.js";
 import {
   checkExistingBill,
@@ -911,11 +921,31 @@ async function assembleNewBill(args: {
 
   logger.start(`Assembling ${label} before storing it`);
 
+  const currentSource = args.billSourceVersions?.reduce<
+    BillSourceVersionInput | undefined
+  >((latest, candidate) => {
+    if (!latest) return candidate;
+    const latestDate = latest.officialDate?.getTime() ?? -Infinity;
+    const candidateDate = candidate.officialDate?.getTime() ?? -Infinity;
+    return candidateDate >= latestDate ? candidate : latest;
+  }, undefined);
+  const sections = currentSource
+    ? parseBillSections(currentSource.rawXml).map(sectionForAnalysis)
+    : [];
+  if (sections.length === 0) {
+    return {
+      status: "incomplete",
+      reason: "no parsed canonical sections are available",
+    };
+  }
+  const analyses = await analyzeBillSectionsInMemory(sections);
+
   const brief = await buildBillBriefRecord({
     title: data.title,
     billNumber: data.billNumber,
     url: data.url,
     fullText: data.fullText,
+    analysisNotes: formatSectionAnalysesForWriting(analyses),
     officialSummary: data.summary,
     status: data.status,
   });
@@ -961,6 +991,7 @@ async function assembleNewBill(args: {
 
   if (args.billSourceVersions?.length) {
     await persistBillSourceVersions(billId, args.billSourceVersions);
+    await persistCompletedBillSectionAnalyses(billId, analyses);
   }
 
   incrementVideosGenerated();
@@ -1009,12 +1040,27 @@ export interface BuiltBillBrief {
   modelVersion: string;
 }
 
+function sectionForAnalysis(section: ParsedBillSection) {
+  return {
+    id: randomUUID(),
+    structuralPath: section.structuralPath,
+    heading: section.heading ?? null,
+    displayedNumber: section.displayedNumber ?? null,
+    order: section.order,
+    text: section.text,
+    sectionHash: section.sectionHash,
+    sourceStartOffset: section.sourceStartOffset ?? null,
+    sourceEndOffset: section.sourceEndOffset ?? null,
+  };
+}
+
 /** Generate a brief in memory. Returns null when generation fails. */
 export async function buildBillBriefRecord(args: {
   title: string;
   billNumber: string;
   url: string;
   fullText: string;
+  analysisNotes: string;
   officialSummary?: string | null;
   status?: string | null;
   priorArticle?: string | null;
@@ -1024,6 +1070,7 @@ export async function buildBillBriefRecord(args: {
     billNumber: args.billNumber,
     url: args.url,
     fullText: args.fullText,
+    analysisNotes: args.analysisNotes,
     officialSummary: args.officialSummary,
     status: args.status,
     priorArticle: args.priorArticle,
@@ -1113,7 +1160,18 @@ export async function upsertBillBrief(args: {
     return false;
   }
 
-  const record = await buildBillBriefRecord(args);
+  const analyses = await analyzeCurrentBillSections(args.contentId);
+  if (analyses.length === 0) {
+    logger.warn(
+      `No parsed canonical sections are available for ${args.billNumber}; deferring brief generation`,
+    );
+    return false;
+  }
+
+  const record = await buildBillBriefRecord({
+    ...args,
+    analysisNotes: formatSectionAnalysesForWriting(analyses),
+  });
   if (!record) return false;
 
   await persistBillBrief(db, args.contentId, args.contentHash, record);

--- a/docs/article-generation.md
+++ b/docs/article-generation.md
@@ -75,11 +75,26 @@ drift into argument, and the argument layer keeps its own provenance.
 
 ## The pipeline
 
-`generateBillBrief()` in
-[`apps/scraper/src/utils/ai/bill-brief.ts`](../apps/scraper/src/utils/ai/bill-brief.ts)
-has a research pass, a structured writing pass, and deterministic verification.
+Bill generation has a versioned section-analysis pass, a research pass, a
+structured writing pass, and deterministic verification.
 
-### 1. Research history and deeper reading (agentic LLM loop)
+### 1. Analyze every bill section
+
+The scraper reads the canonical sections stored by `BillSection`, never a flat
+prefix of `Bill.fullText`. Each section is analyzed independently into typed
+notes for operative changes, affected parties, dates, penalties, exemptions,
+definitions, funding, oversight, and cross-references. Every evidence quote
+carries the section hash and end-exclusive offsets within that section.
+
+Sections larger than the configured input budget are split at text boundaries,
+but each call still contains text from only one canonical section. Every
+section reaches a recorded `analyzed`, `skipped`, or `failed` state.
+
+Analysis rows cache on section hash, `BILL_ANALYSIS_SCHEMA_VERSION`, and the
+provider-qualified model version. An unchanged section therefore reuses its
+notes even when another part of a bill changes or the writing pass is rerun.
+
+### 2. Research history and deeper reading (agentic LLM loop)
 
 The model first investigates why the policy has not already been adopted:
 earlier bills, documented disagreements, legal or budget limits, implementation
@@ -87,18 +102,16 @@ tradeoffs, and changed circumstances. It separately searches for useful
 follow-up reading, opens at least three promising pages, and records only
 successfully opened URLs. Snippets are never treated as evidence.
 
-### 2. Structure (LLM)
+### 3. Write from notes (LLM)
 
-One schema-validated call (AI SDK `Output.object`) grounded in the official
-text plus, when available, the existing long-form article. That article already
-did the careful nonpartisan reading, so this pass is mostly restructuring —
-cheaper and more consistent than reading the statute cold. The model sees a
-24k-character window of source text plus the verified research. It may produce
-an expandable `whyNotBefore` explanation, but only with citations to opened
-pages, and may also write one focused `deepDive` article for readers who opt
-into more depth.
+One schema-validated call (AI SDK `Output.object`) receives the complete
+section-note inventory, the CRS summary, and verified outside research. It
+never receives raw bill text. Failed or skipped coverage is explicit in the
+inventory, so absence cannot be inferred from an arbitrarily severed excerpt.
+The call is refused before reaching the provider if its conservative input
+estimate exceeds `BILL_BRIEF_WRITING_INPUT_TOKEN_BUDGET`.
 
-### 3. Verify quotes and research links (deterministic)
+### 4. Verify quotes and research links (deterministic)
 
 Every `quote.text` is checked against the **whole** source document, not just
 the window the model saw. Matching normalizes away formatting — casing, smart
@@ -113,7 +126,7 @@ links are checked against the URLs opened by the research loop; invented links
 are dropped. The historical-context section is removed entirely unless at least
 two distinct opened sources remain after verification.
 
-### 4. Lint framing and jargon (deterministic)
+### 5. Lint framing and jargon (deterministic)
 
 Loaded political vocabulary — `common sense`, `radical`, `landmark`,
 `burdensome`, `handout`, `job-killing`, `red tape`, `power grab` — is matched
@@ -139,6 +152,12 @@ encounters them. The API separately accepts shipped v1 and v5 records and
 normalizes them into the current client shape (including affected-group
 takeaways and an empty reading list where needed). Invalid or unknown shapes
 are still dropped, so the client can treat every present brief as renderable.
+
+`BILL_ANALYSIS_SCHEMA_VERSION` independently invalidates section notes. The
+retroactive brief command selects a brief whose analysis version is stale even
+when its source content hash is unchanged. It re-analyzes only sections missing
+the current `(sectionHash, promptVersion, modelVersion)` cache entry, then
+rewrites the brief. A writing-only rerun reuses all current notes.
 
 ## Rendering
 

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -228,10 +228,14 @@ Each new/changed item runs through:
 
 1. **Summary** (`text-generation.ts`) — ≤100-char punchy summary, 8th-grade reading level.
 2. **Article** (`text-generation.ts`) — structured 4-section markdown: _What This Means For You_, _Overview_, _Impact & Implications_, _The Debate_; balanced across perspectives. Stored in `ai_generated_article`. Throws a typed `AIRateLimitError` on 429.
-3. **Brief** (`bill-brief.ts`, bills only) — the structured document that replaces the markdown wall of text in the app: hook, stat tiles, before/after changes, affected groups, unknowns, glossary, optional prose. Quotes are verified verbatim against the source and stripped if they don't match; loaded political phrasing in the model's own voice triggers one regeneration. The brief also receives the official CRS summary as authoritative,
-   explicitly non-quotable context, so provisions past its source window are still
-   known to it; quotes are verified against the official text alone. Cached in
-   `content_brief` by `contentHash`. See [Article generation](./article-generation.md).
+3. **Brief analysis + writing** (`bill-section-analysis.ts` and
+   `bill-brief.ts`, bills only) — every persisted bill section first becomes
+   structured, evidence-grounded notes with a terminal analyzed/skipped/failed
+   state. The writing pass receives only those notes, the official CRS summary,
+   and outside research; it never receives a raw-text prefix. Section notes
+   cache by section hash, analysis prompt version, and model version, while the
+   final structured brief remains cached in `content_brief`. See
+   [Article generation](./article-generation.md).
 4. **Dual lens** (`text-generation.ts`) — proponent/opponent arguments grounded in an agentic web-research loop, cached in `content_lens`. This is the most expensive step and the only one whose output is not reproducible: the same input can return different arguments, and the row is overwritten in place with no history. It is therefore cached on **its own inputs** (title + full text + article type + model version), not on the bill's overall `contentHash` — that hash also covers status and summary, so a routine action update ("Referred to committee" → "Received in the Senate") used to invalidate it and re-roll the dice. One such re-roll lost a finding that H.R. 7008 carried unrelated voter-ID provisions.
 5. **Marketing copy** (`marketing-generation.ts`) — Zod-validated `{ title ≤25 chars, description ≤25 words, imagePrompt }` for the `video` feed card.
 6. **Imagery** — multiple sources:

--- a/packages/db/drizzle/0010_parallel_lifeguard.sql
+++ b/packages/db/drizzle/0010_parallel_lifeguard.sql
@@ -1,0 +1,17 @@
+CREATE TABLE "bill_section_analysis" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"section_id" uuid NOT NULL,
+	"section_hash" varchar(64) NOT NULL,
+	"prompt_version" varchar(100) NOT NULL,
+	"model_version" varchar(100) NOT NULL,
+	"status" varchar(20) NOT NULL,
+	"notes" jsonb,
+	"error" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone,
+	CONSTRAINT "bill_section_analysis_sectionId_promptVersion_modelVersion_unique" UNIQUE("section_id","prompt_version","model_version")
+);
+--> statement-breakpoint
+ALTER TABLE "bill_section_analysis" ADD CONSTRAINT "bill_section_analysis_section_id_bill_section_id_fk" FOREIGN KEY ("section_id") REFERENCES "public"."bill_section"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "bill_section_analysis_cache_key_idx" ON "bill_section_analysis" USING btree ("section_hash","prompt_version","model_version","status");--> statement-breakpoint
+CREATE INDEX "bill_section_analysis_section_idx" ON "bill_section_analysis" USING btree ("section_id");

--- a/packages/db/drizzle/meta/0010_snapshot.json
+++ b/packages/db/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,3371 @@
+{
+  "id": "426b44cb-3f7d-4702-b32a-e01b7faacfa1",
+  "prevId": "f212562b-8399-426d-9f53-3f3df17c8385",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bill": {
+      "name": "bill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bill_number": {
+          "name": "bill_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sponsor": {
+          "name": "sponsor",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "introduced_date": {
+          "name": "introduced_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "congress": {
+          "name": "congress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chamber": {
+          "name": "chamber",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_website": {
+          "name": "source_website",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(bill_number, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(sponsor, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(description, '')), 'B')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "bill_search_vector_idx": {
+          "name": "bill_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bill_number_trgm_idx": {
+          "name": "bill_number_trgm_idx",
+          "columns": [
+            {
+              "expression": "bill_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bill_billNumber_sourceWebsite_unique": {
+          "name": "bill_billNumber_sourceWebsite_unique",
+          "nullsNotDistinct": false,
+          "columns": ["bill_number", "source_website"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bill_description_max_100_chars": {
+          "name": "bill_description_max_100_chars",
+          "value": "\"bill\".\"description\" is null or char_length(\"bill\".\"description\") <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bill_section": {
+      "name": "bill_section",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "source_version_id": {
+          "name": "source_version_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_section_id": {
+          "name": "parent_section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "structural_path": {
+          "name": "structural_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "displayed_number": {
+          "name": "displayed_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_hash": {
+          "name": "section_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_start_offset": {
+          "name": "source_start_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_end_offset": {
+          "name": "source_end_offset",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xml_id": {
+          "name": "xml_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cross_references": {
+          "name": "cross_references",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "to_tsvector('english', coalesce(heading, '') || ' ' || coalesce(text, ''))",
+            "type": "stored"
+          }
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bill_section_source_version_idx": {
+          "name": "bill_section_source_version_idx",
+          "columns": [
+            {
+              "expression": "source_version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bill_section_parent_idx": {
+          "name": "bill_section_parent_idx",
+          "columns": [
+            {
+              "expression": "parent_section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bill_section_search_vector_idx": {
+          "name": "bill_section_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bill_section_source_version_id_bill_source_version_id_fk": {
+          "name": "bill_section_source_version_id_bill_source_version_id_fk",
+          "tableFrom": "bill_section",
+          "tableTo": "bill_source_version",
+          "columnsFrom": ["source_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bill_section_parent_section_id_bill_section_id_fk": {
+          "name": "bill_section_parent_section_id_bill_section_id_fk",
+          "tableFrom": "bill_section",
+          "tableTo": "bill_section",
+          "columnsFrom": ["parent_section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bill_section_sourceVersionId_structuralPath_unique": {
+          "name": "bill_section_sourceVersionId_structuralPath_unique",
+          "nullsNotDistinct": false,
+          "columns": ["source_version_id", "structural_path"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bill_section_analysis": {
+      "name": "bill_section_analysis",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_hash": {
+          "name": "section_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_version": {
+          "name": "prompt_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bill_section_analysis_cache_key_idx": {
+          "name": "bill_section_analysis_cache_key_idx",
+          "columns": [
+            {
+              "expression": "section_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "prompt_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bill_section_analysis_section_idx": {
+          "name": "bill_section_analysis_section_idx",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bill_section_analysis_section_id_bill_section_id_fk": {
+          "name": "bill_section_analysis_section_id_bill_section_id_fk",
+          "tableFrom": "bill_section_analysis",
+          "tableTo": "bill_section",
+          "columnsFrom": ["section_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bill_section_analysis_sectionId_promptVersion_modelVersion_unique": {
+          "name": "bill_section_analysis_sectionId_promptVersion_modelVersion_unique",
+          "nullsNotDistinct": false,
+          "columns": ["section_id", "prompt_version", "model_version"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bill_source_version": {
+      "name": "bill_source_version",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bill_id": {
+          "name": "bill_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_code": {
+          "name": "version_code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_type": {
+          "name": "version_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "official_date": {
+          "name": "official_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "raw_xml": {
+          "name": "raw_xml",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_hash": {
+          "name": "source_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parse_status": {
+          "name": "parse_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "parse_error": {
+          "name": "parse_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bill_source_version_bill_idx": {
+          "name": "bill_source_version_bill_idx",
+          "columns": [
+            {
+              "expression": "bill_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bill_source_version_bill_id_bill_id_fk": {
+          "name": "bill_source_version_bill_id_bill_id_fk",
+          "tableFrom": "bill_source_version",
+          "tableTo": "bill",
+          "columnsFrom": ["bill_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bill_source_version_billId_versionCode_sourceHash_unique": {
+          "name": "bill_source_version_billId_versionCode_sourceHash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["bill_id", "version_code", "source_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocked_content": {
+      "name": "blocked_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocked_content_user_id_idx": {
+          "name": "blocked_content_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocked_content_userId_name_type_unique": {
+          "name": "blocked_content_userId_name_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name", "type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate": {
+      "name": "candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "party": {
+          "name": "party",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_url": {
+          "name": "candidate_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incumbent": {
+          "name": "incumbent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "biography": {
+          "name": "biography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_contest_id_idx": {
+          "name": "candidate_contest_id_idx",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.civic_api_cache": {
+      "name": "civic_api_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address_hash": {
+          "name": "address_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "response_data": {
+          "name": "response_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "civic_cache_expires_idx": {
+          "name": "civic_cache_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "civic_api_cache_addressHash_endpoint_params_unique": {
+          "name": "civic_api_cache_addressHash_endpoint_params_unique",
+          "nullsNotDistinct": false,
+          "columns": ["address_hash", "endpoint", "params"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_brief": {
+      "name": "content_brief",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "content_brief_content_id_idx": {
+          "name": "content_brief_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_brief_contentType_contentId_unique": {
+          "name": "content_brief_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["content_type", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_lens": {
+      "name": "content_lens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lens_data": {
+          "name": "lens_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "content_lens_content_id_idx": {
+          "name": "content_lens_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_lens_contentType_contentId_unique": {
+          "name": "content_lens_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["content_type", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest": {
+      "name": "contest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "election_id": {
+          "name": "election_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "office": {
+          "name": "office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_name": {
+          "name": "district_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_scope": {
+          "name": "district_scope",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_elected": {
+          "name": "number_elected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referendum_title": {
+          "name": "referendum_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_subtitle": {
+          "name": "referendum_subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_text": {
+          "name": "referendum_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_pro_statement": {
+          "name": "referendum_pro_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_con_statement": {
+          "name": "referendum_con_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_url": {
+          "name": "referendum_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_description": {
+          "name": "role_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_is_ai_generated": {
+          "name": "summary_is_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fiscal_impact": {
+          "name": "fiscal_impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citations": {
+          "name": "citations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contest_election_id_idx": {
+          "name": "contest_election_id_idx",
+          "columns": [
+            {
+              "expression": "election_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.court_case": {
+      "name": "court_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court": {
+          "name": "court",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_date": {
+          "name": "filed_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(case_number, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(description, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(full_text, '')), 'C')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "court_case_search_vector_idx": {
+          "name": "court_case_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "court_case_number_trgm_idx": {
+          "name": "court_case_number_trgm_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "court_case_caseNumber_court_unique": {
+          "name": "court_case_caseNumber_court_unique",
+          "nullsNotDistinct": false,
+          "columns": ["case_number", "court"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.election": {
+      "name": "election",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_type": {
+          "name": "election_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ocd_division_id": {
+          "name": "ocd_division_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadlines": {
+          "name": "deadlines",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "election_externalId_source_unique": {
+          "name": "election_externalId_source_unique",
+          "nullsNotDistinct": false,
+          "columns": ["external_id", "source"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.government_content": {
+      "name": "government_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whitehouse.gov'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(description, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(full_text, '')), 'C')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "government_content_search_vector_idx": {
+          "name": "government_content_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "government_content_url_unique": {
+          "name": "government_content_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_agenda_item": {
+      "name": "legistar_agenda_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_item_id": {
+          "name": "event_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda_sequence": {
+          "name": "agenda_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_number": {
+          "name": "agenda_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed_flag_name": {
+          "name": "passed_flag_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tally": {
+          "name": "tally",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mover_name": {
+          "name": "mover_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seconder_name": {
+          "name": "seconder_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_file": {
+          "name": "matter_file",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_name": {
+          "name": "matter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_type": {
+          "name": "matter_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_status": {
+          "name": "matter_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "agenda_note": {
+          "name": "agenda_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_note": {
+          "name": "minutes_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_agenda_item_event_idx": {
+          "name": "legistar_agenda_item_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_agenda_item_jurisdiction_eventItemId_unique": {
+          "name": "legistar_agenda_item_jurisdiction_eventItemId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "event_item_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_body": {
+      "name": "legistar_body",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_guid": {
+          "name": "body_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_flag": {
+          "name": "active_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "number_of_members": {
+          "name": "number_of_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_body_jurisdiction_bodyId_unique": {
+          "name": "legistar_body_jurisdiction_bodyId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "body_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_matter": {
+      "name": "legistar_matter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matter_guid": {
+          "name": "matter_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_file": {
+          "name": "matter_file",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_name": {
+          "name": "body_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_date": {
+          "name": "intro_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_date": {
+          "name": "agenda_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed_date": {
+          "name": "passed_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enactment_date": {
+          "name": "enactment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enactment_number": {
+          "name": "enactment_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester": {
+          "name": "requester",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_matter_file_idx": {
+          "name": "legistar_matter_file_idx",
+          "columns": [
+            {
+              "expression": "matter_file",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_matter_jurisdiction_matterId_unique": {
+          "name": "legistar_matter_jurisdiction_matterId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "matter_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_meeting": {
+      "name": "legistar_meeting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_guid": {
+          "name": "event_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_name": {
+          "name": "body_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_file": {
+          "name": "agenda_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_file": {
+          "name": "minutes_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_path": {
+          "name": "video_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_status_name": {
+          "name": "agenda_status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_status_name": {
+          "name": "minutes_status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_site_url": {
+          "name": "in_site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_meeting_date_idx": {
+          "name": "legistar_meeting_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_meeting_jurisdiction_eventId_unique": {
+          "name": "legistar_meeting_jurisdiction_eventId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_vote": {
+      "name": "legistar_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_id": {
+          "name": "vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_item_id": {
+          "name": "event_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_name": {
+          "name": "person_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_name": {
+          "name": "value_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legistar_vote_event_item_idx": {
+          "name": "legistar_vote_event_item_idx",
+          "columns": [
+            {
+              "expression": "event_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legistar_vote_person_idx": {
+          "name": "legistar_vote_person_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_vote_jurisdiction_voteId_unique": {
+          "name": "legistar_vote_jurisdiction_voteId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "vote_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polling_location": {
+      "name": "polling_location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "election_id": {
+          "name": "election_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line2": {
+          "name": "address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours": {
+          "name": "hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_services": {
+          "name": "voter_services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "polling_location_election_id_idx": {
+          "name": "polling_location_election_id_idx",
+          "columns": [
+            {
+              "expression": "election_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_description": {
+      "name": "role_description",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'seed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "role_description_role_level_unique": {
+          "name": "role_description_role_level_unique",
+          "nullsNotDistinct": false,
+          "columns": ["role", "level"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_article": {
+      "name": "saved_article",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_article_user_id_idx": {
+          "name": "saved_article_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "saved_article_userId_contentId_unique": {
+          "name": "saved_article_userId_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraper_cursor": {
+      "name": "scraper_cursor",
+      "schema": "",
+      "columns": {
+        "scraper_key": {
+          "name": "scraper_key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraper_retry": {
+      "name": "scraper_retry",
+      "schema": "",
+      "columns": {
+        "scraper_key": {
+          "name": "scraper_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_key": {
+          "name": "item_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_reason": {
+          "name": "last_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_failed_at": {
+          "name": "first_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scraper_retry_due_idx": {
+          "name": "scraper_retry_due_idx",
+          "columns": [
+            {
+              "expression": "scraper_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scraper_retry_scraper_key_item_key_pk": {
+          "name": "scraper_retry_scraper_key_item_key_pk",
+          "columns": ["scraper_key", "item_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "content_types": {
+          "name": "content_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preference_userId_unique": {
+          "name": "user_preference_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "personalize": {
+          "name": "personalize",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "analytics": {
+          "name": "analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "crash": {
+          "name": "crash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "offline": {
+          "name": "offline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_userId_unique": {
+          "name": "user_settings_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video": {
+      "name": "video",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_data": {
+          "name": "image_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_mime_type": {
+          "name": "image_mime_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_width": {
+          "name": "image_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_height": {
+          "name": "image_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement_metrics": {
+          "name": "engagement_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"likes\":0,\"comments\":0,\"shares\":0}'::jsonb"
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "video_content_id_idx": {
+          "name": "video_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "video_created_at_idx": {
+          "name": "video_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "video_contentType_contentId_unique": {
+          "name": "video_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["content_type", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1785222208508,
       "tag": "0009_fat_harrier",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1785282399905,
+      "tag": "0010_parallel_lifeguard",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1785282153862,
       "tag": "0009_flashy_steel_serpent",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1785222208508,
+      "tag": "0009_fat_harrier",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/seed.ts
+++ b/packages/db/seed.ts
@@ -2,6 +2,10 @@ import { createHash } from "node:crypto";
 import { and, eq, inArray, sql } from "drizzle-orm";
 
 import type { BillBriefRecord } from "@acme/validators";
+import {
+  BILL_ANALYSIS_SCHEMA_VERSION,
+  BILL_BRIEF_VERSION,
+} from "@acme/validators";
 
 import { clampBillDescription } from "./src/bill-description";
 import { db } from "./src/client";
@@ -434,7 +438,8 @@ const billBriefs: (Omit<
   "generatedAt" | "modelVersion"
 > | null)[] = [
   {
-    version: 7,
+    version: BILL_BRIEF_VERSION,
+    analysisSchemaVersion: BILL_ANALYSIS_SCHEMA_VERSION,
     legalStatus: "proposed",
     verifiedQuotes: 1,
     hook: "If this bill becomes law, states would get **a longer window to plan road and bridge repairs**, while cities could apply for **new public-transit money**. The $200 billion is a maximum, not guaranteed money; Congress would still decide how much can actually be spent each year.",
@@ -556,7 +561,8 @@ const billBriefs: (Omit<
     ],
   },
   {
-    version: 7,
+    version: BILL_BRIEF_VERSION,
+    analysisSchemaVersion: BILL_ANALYSIS_SCHEMA_VERSION,
     legalStatus: "proposed",
     verifiedQuotes: 2,
     hook: "If passed, the bill would require companies to **get permission before collecting or selling personal data**. People across the country could also **review and delete information held about them**, although the text does not settle whether **stronger state privacy laws** would remain in place.",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -12,7 +12,7 @@ import {
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod/v4";
 
-import type { BillBriefRecord } from "@acme/validators";
+import type { BillBriefRecord, BillSectionNotes } from "@acme/validators";
 
 // Custom bytea type for binary data storage
 const bytea = customType<{ data: Buffer; notNull: false; default: false }>({
@@ -275,6 +275,49 @@ export const BillSection = pgTable(
       "gin",
       table.searchVector,
     ),
+  }),
+);
+
+/**
+ * Versioned analysis of one canonical bill section.
+ *
+ * A row records the terminal state for that specific persisted section. On a
+ * new source version, the scraper may copy a reusable result found by the
+ * (sectionHash, promptVersion, modelVersion) cache key into the new section's
+ * row without calling the model again.
+ */
+export const BillSectionAnalysis = pgTable(
+  "bill_section_analysis",
+  (t) => ({
+    id: t.uuid().notNull().primaryKey().defaultRandom(),
+    sectionId: t
+      .uuid()
+      .notNull()
+      .references(() => BillSection.id, { onDelete: "cascade" }),
+    sectionHash: t.varchar({ length: 64 }).notNull(),
+    promptVersion: t.varchar({ length: 100 }).notNull(),
+    modelVersion: t.varchar({ length: 100 }).notNull(),
+    status: t.varchar({ length: 20 }).notNull(),
+    notes: t.jsonb().$type<BillSectionNotes>(),
+    error: t.text(),
+    createdAt: t.timestamp({ withTimezone: true }).defaultNow().notNull(),
+    updatedAt: t
+      .timestamp({ mode: "date", withTimezone: true })
+      .$onUpdateFn(() => sql`now()`),
+  }),
+  (table) => ({
+    uniqueSectionAnalysis: unique().on(
+      table.sectionId,
+      table.promptVersion,
+      table.modelVersion,
+    ),
+    cacheKeyIdx: index("bill_section_analysis_cache_key_idx").on(
+      table.sectionHash,
+      table.promptVersion,
+      table.modelVersion,
+      table.status,
+    ),
+    sectionIdx: index("bill_section_analysis_section_idx").on(table.sectionId),
   }),
 );
 

--- a/packages/env/src/registry.ts
+++ b/packages/env/src/registry.ts
@@ -322,6 +322,26 @@ export const envRegistry = [
     schema: string,
   }),
   define({
+    key: "BILL_ANALYSIS_INPUT_TOKEN_BUDGET",
+    description:
+      "Conservative maximum input tokens for each bill-section analysis call.",
+    group: "AI",
+    secret: false,
+    defaultValue: "16000",
+    requirements: { scraper: "optional" },
+    schema: positiveInteger,
+  }),
+  define({
+    key: "BILL_BRIEF_WRITING_INPUT_TOKEN_BUDGET",
+    description:
+      "Conservative maximum input tokens for the bill-brief writing call.",
+    group: "AI",
+    secret: false,
+    defaultValue: "128000",
+    requirements: { scraper: "optional" },
+    schema: positiveInteger,
+  }),
+  define({
     key: "DEEPSEEK_API_KEY",
     description:
       "Deprecated direct DeepSeek key; use OPENROUTER_API_KEY for AI text generation.",

--- a/packages/validators/src/bill-analysis.ts
+++ b/packages/validators/src/bill-analysis.ts
@@ -1,0 +1,59 @@
+import { z } from "zod/v4";
+
+export const BILL_ANALYSIS_SCHEMA_VERSION = "bill-section-notes-v1";
+
+export const BillAnalysisStatusSchema = z.enum([
+  "analyzed",
+  "skipped",
+  "failed",
+]);
+export type BillAnalysisStatus = z.infer<typeof BillAnalysisStatusSchema>;
+
+export const BillSectionEvidenceSchema = z.object({
+  quote: z.string().trim().min(1),
+  /** SHA-256 of the exact section analysis unit that contains this quote. */
+  sectionHash: z.string().length(64),
+  /** Zero-based offsets within the section analysis unit, end-exclusive. */
+  startOffset: z.number().int().min(0),
+  endOffset: z.number().int().positive(),
+});
+export type BillSectionEvidence = z.infer<typeof BillSectionEvidenceSchema>;
+
+export const BillSectionProvisionSchema = z.object({
+  kind: z.enum([
+    "change",
+    "binding",
+    "effective_date",
+    "penalty",
+    "exemption",
+    "definition",
+    "cross_reference",
+    "funding",
+    "oversight",
+    "other",
+  ]),
+  statement: z.string().trim().min(1).max(800),
+  subjects: z.array(z.string().trim().min(1).max(120)).max(12),
+  evidence: z.array(BillSectionEvidenceSchema).min(1).max(6),
+});
+export type BillSectionProvision = z.infer<typeof BillSectionProvisionSchema>;
+
+export const BillSectionNotesSchema = z.object({
+  summary: z.string().trim().min(1).max(100_000),
+  provisions: z.array(BillSectionProvisionSchema).max(2_000),
+});
+export type BillSectionNotes = z.infer<typeof BillSectionNotesSchema>;
+
+export const BillSectionAnalysisRecordSchema = z.object({
+  ordinal: z.number().int().min(0),
+  heading: z.string().trim().min(1),
+  sectionHash: z.string().length(64),
+  documentStartOffset: z.number().int().min(0),
+  documentEndOffset: z.number().int().positive(),
+  status: BillAnalysisStatusSchema,
+  notes: BillSectionNotesSchema.nullable(),
+  error: z.string().nullable(),
+});
+export type BillSectionAnalysisRecord = z.infer<
+  typeof BillSectionAnalysisRecordSchema
+>;

--- a/packages/validators/src/bill-brief.ts
+++ b/packages/validators/src/bill-brief.ts
@@ -31,8 +31,10 @@
  */
 import { z } from "zod";
 
+import { BILL_ANALYSIS_SCHEMA_VERSION } from "./bill-analysis";
+
 /** Bump when the shape or generation contract requires cached rows to refresh. */
-export const BILL_BRIEF_VERSION = 7;
+export const BILL_BRIEF_VERSION = 8;
 
 /**
  * What a provision mechanically does. Deliberately descriptive: a reader can
@@ -85,6 +87,23 @@ export const BriefQuoteSchema = z.object({
     .describe(
       'Where the quote appears, as written in the document — e.g. "Sec. 4(b)(2)" or "Title II". Omit if the source has no usable label.',
     ),
+  sectionHash: z
+    .string()
+    .length(64)
+    .optional()
+    .describe("SHA-256 of the analyzed bill section containing this quote."),
+  startOffset: z
+    .number()
+    .int()
+    .min(0)
+    .optional()
+    .describe("Zero-based quote start offset within the analyzed section."),
+  endOffset: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("End-exclusive quote offset within the analyzed section."),
 });
 export type BriefQuote = z.infer<typeof BriefQuoteSchema>;
 
@@ -394,9 +413,16 @@ const BriefRecordMetadataSchema = {
 /** A stored brief: model output plus pipeline-owned provenance. */
 export const BillBriefRecordSchema = BillBriefSchema.extend({
   version: z.literal(BILL_BRIEF_VERSION),
+  analysisSchemaVersion: z.literal(BILL_ANALYSIS_SCHEMA_VERSION),
   ...BriefRecordMetadataSchema,
 });
 export type BillBriefRecord = z.infer<typeof BillBriefRecordSchema>;
+
+/** The last single-pass brief shape, before section-note provenance. */
+const BillBriefV7RecordSchema = BillBriefSchema.extend({
+  version: z.literal(7),
+  ...BriefRecordMetadataSchema,
+});
 
 /** The rich brief shape before emphasis became a brief-wide contract. */
 const BillBriefV6RecordSchema = BillBriefSchema.extend({
@@ -458,14 +484,31 @@ export function parseBillBriefRecord(value: unknown): BillBriefRecord | null {
   const current = BillBriefRecordSchema.safeParse(value);
   if (current.success) return current.data;
 
+  const v7 = BillBriefV7RecordSchema.safeParse(value);
+  if (v7.success) {
+    return {
+      ...v7.data,
+      version: BILL_BRIEF_VERSION,
+      analysisSchemaVersion: BILL_ANALYSIS_SCHEMA_VERSION,
+    };
+  }
+
   const v6 = BillBriefV6RecordSchema.safeParse(value);
   if (v6.success) {
-    return { ...v6.data, version: BILL_BRIEF_VERSION };
+    return {
+      ...v6.data,
+      version: BILL_BRIEF_VERSION,
+      analysisSchemaVersion: BILL_ANALYSIS_SCHEMA_VERSION,
+    };
   }
 
   const v5 = BillBriefV5RecordSchema.safeParse(value);
   if (v5.success) {
-    return { ...v5.data, version: BILL_BRIEF_VERSION };
+    return {
+      ...v5.data,
+      version: BILL_BRIEF_VERSION,
+      analysisSchemaVersion: BILL_ANALYSIS_SCHEMA_VERSION,
+    };
   }
 
   const v1 = BillBriefV1RecordSchema.safeParse(value);
@@ -474,6 +517,7 @@ export function parseBillBriefRecord(value: unknown): BillBriefRecord | null {
   return {
     ...legacy,
     version: BILL_BRIEF_VERSION,
+    analysisSchemaVersion: BILL_ANALYSIS_SCHEMA_VERSION,
     affected: legacy.affected.map((item) => ({
       ...item,
       takeaway: conciseTakeaway(item.effect),

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 
 export * from "./bill-brief";
+export * from "./bill-analysis";
 
 export const unused = z.string().describe(
   `This lib is currently not used as we use drizzle-zod for simple schemas


### PR DESCRIPTION
Closes #235.

Stacked on #244 (`codex/issue-234-bill-sections`). Review against that branch; the PR diff is the focused analysis-and-writing change. Merge #244 first.

## What changed

- Added a structured section-note schema covering operative changes, bindings, effective dates, penalties, exemptions, definitions, cross-references, funding, and oversight.
- Added per-section analysis with conservative configurable input budgets, within-section chunking, deterministic evidence grounding, and section-relative source offsets.
- Added `bill_section_analysis` terminal-state storage (`analyzed` / `skipped` / `failed`) and reusable caching keyed by section hash, analysis schema/prompt version, and provider-qualified model version.
- Reworked brief writing so the model receives accumulated section notes, the CRS summary, and researched outside sources—never a sliced raw bill-text window.
- Preserved section hash and source offsets on final brief quotes, and dropped quotes without addressable evidence provenance.
- Versioned brief invalidation with `BILL_ANALYSIS_SCHEMA_VERSION`; `retroactive-briefs` now selects stale analysis schemas while cached current section notes make writing-only reruns analysis-free.
- Documented cache invalidation, retroactive behavior, configured budgets, and the two-pass pipeline.

The note-taking strategy follows hierarchical long-document summarization and evidence-extraction findings: analyze discourse-aligned sections independently, retain typed semantic roles, and attach exact evidence spans before synthesis.

## Validation

- `pnpm --filter @acme/scraper test` — 47 tests passed, including oversized-section budget coverage and the H.R. 7008 penalty regression.
- `pnpm typecheck` — 16 tasks passed.
- `pnpm lint` — 13 tasks passed.
- `pnpm --filter @acme/scraper build` — production build passed.
- Applied migrations `0000`–`0009` to isolated local Postgres successfully.
- `pnpm --filter @acme/db db-check` — passed.
- `git diff --check` — passed.

`pnpm format` still reports the repository's generated Drizzle metadata snapshots `0004`–`0008` (plus the newly generated snapshot) as non-Prettier output; changed TypeScript/Markdown files were formatted directly and pass their package formatting checks.