### PR TITLE
Verify brief quotes against persisted bill sections

### DIFF
--- a/apps/scraper/src/fixtures/hr-7008-quote-verification.ts
+++ b/apps/scraper/src/fixtures/hr-7008-quote-verification.ts
@@ -1,0 +1,23 @@
+/**
+ * Regression excerpt from the engrossed House text of H.R. 7008 (119th
+ * Congress), section 3. This provision appeared after the source window that
+ * originally grounded brief generation, causing four valid citations to be
+ * discarded as "unverified".
+ *
+ * Source: BILLS-119hr7008eh, published by the U.S. Government Publishing
+ * Office. Whitespace is normalized the same way `bill_section.text` is stored.
+ */
+export const HR_7008_LATE_SECTION = [
+  "SEC. 3. REQUIRING VOTERS TO PROVIDE PHOTO IDENTIFICATION.",
+  "Notwithstanding any other provision of law and except as provided in subparagraph (B), the appropriate State or local election official may not provide a ballot for an election for Federal office to an individual who desires to vote in person unless the individual presents to the official a valid physical photo identification.",
+  "If an individual does not present the identification required under subparagraph (A), the individual shall be permitted to cast a provisional ballot with respect to the election under section 302(a), except that the appropriate State or local election official may not make a determination under section 302(a)(4) that the individual is eligible under State law to vote in the election unless, not later than 3 days after casting the provisional ballot, the individual presents to the official the identification required under subparagraph (A).",
+  "The appropriate State or local election official may not accept any ballot for an election for Federal office provided by an individual who votes other than in person unless the individual submits with the ballot a copy of a valid photo identification.",
+  "This section and the amendments made by this section shall take effect on the date that is 90 days after the date of the enactment of this Act.",
+].join(" ");
+
+export const HR_7008_PREVIOUSLY_DROPPED_QUOTES = [
+  "may not provide a ballot for an election for Federal office to an individual who desires to vote in person unless the individual presents to the official a valid physical photo identification",
+  "the individual shall be permitted to cast a provisional ballot with respect to the election under section 302(a)",
+  "may not accept any ballot for an election for Federal office provided by an individual who votes other than in person unless the individual submits with the ballot a copy of a valid photo identification",
+  "shall take effect on the date that is 90 days after the date of the enactment of this Act",
+] as const;

--- a/apps/scraper/src/utils/ai/bill-brief.test.ts
+++ b/apps/scraper/src/utils/ai/bill-brief.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import test from "node:test";
 
 import type { BillBrief } from "@acme/validators";
@@ -10,12 +11,18 @@ import {
 } from "@acme/validators";
 
 import {
+  HR_7008_LATE_SECTION,
+  HR_7008_PREVIOUSLY_DROPPED_QUOTES,
+} from "../../fixtures/hr-7008-quote-verification.js";
+import { getMetrics, resetMetrics } from "../db/metrics.js";
+import {
   deriveLegalStatus,
   findLoadedLanguage,
   findMissingEmphasis,
   findUnexplainedJargon,
   isQuoteGrounded,
-  normalizeForQuoteMatch,
+  QuoteVerificationError,
+  requireVerifiedBriefQuotes,
   verifyBriefContext,
   verifyBriefQuotes,
   verifyBriefReading,
@@ -33,6 +40,26 @@ necessary to meet an operational deadline.
 appropriated $1,200,000,000 for fiscal year 2027 to carry out this
 section.
 `;
+const SOURCE_SECTION = SOURCE.replace(/\s+/g, " ").trim();
+
+function sourceSection(text = SOURCE_SECTION, structuralPath = "section-4") {
+  return {
+    sectionHash: createHash("sha256").update(text).digest("hex"),
+    structuralPath,
+    text,
+  };
+}
+
+function referencedQuote(text: string, section = sourceSection()) {
+  const startOffset = section.text.indexOf(text);
+  assert.notEqual(startOffset, -1, `fixture quote not found: ${text}`);
+  return {
+    text,
+    sectionHash: section.sectionHash,
+    startOffset,
+    endOffset: startOffset + text.length,
+  };
+}
 
 function brief(overrides: Partial<BillBrief> = {}): BillBrief {
   return {
@@ -275,56 +302,51 @@ void test("historical context requires two opened research sources", () => {
 });
 
 void test("quote matching ignores whitespace, case, and smart punctuation", () => {
-  const normalized = normalizeForQuoteMatch(SOURCE);
   assert.equal(
     isQuoteGrounded(
-      "The Secretary may waive the requirements of section 102(2)(C)",
-      normalized,
+      "The Secretary may waive the requirements of section 102(2)(C).",
+      "the Secretary may waive the requirements of section 102(2)(C)",
     ),
     true,
   );
-  // Wrapped across a newline in the source, and re-typed with curly quotes.
   assert.equal(
     isQuoteGrounded(
-      "if the Secretary determines that the waiver is necessary",
-      normalized,
+      "The Secretary called it “necessary”—and acted.",
+      'The Secretary called it "necessary" - and acted.',
     ),
     true,
   );
 });
 
 void test("quote matching rejects paraphrase and reordered words", () => {
-  const normalized = normalizeForQuoteMatch(SOURCE);
   assert.equal(
     isQuoteGrounded(
       "The Secretary is allowed to waive environmental review requirements",
-      normalized,
+      "The Secretary may waive environmental review requirements",
     ),
     false,
   );
   assert.equal(
     isQuoteGrounded(
       "may waive the requirements of the National Environmental Policy Act of 1969",
-      normalized,
+      "may waive the National Environmental Policy Act of 1969 requirements",
     ),
     false,
   );
   // Too short to be meaningful once normalized.
-  assert.equal(isQuoteGrounded("the Secretary", normalized), false);
+  assert.equal(isQuoteGrounded("the Secretary", "the Secretary"), false);
 });
 
-void test("verification strips unverified quotes but keeps the claim", () => {
+void test("verification distinguishes a missing quote from an altered source span", () => {
+  const section = sourceSection();
+  const validText = "appropriated $1,200,000,000 for fiscal year 2027";
+  const validQuote = referencedQuote(validText, section);
   const input = brief({
     facts: [
       {
         label: "Authorized funding",
         value: "$1.2B",
-        quote: {
-          text: "appropriated $1,200,000,000 for fiscal year 2027",
-          sectionHash: "b".repeat(64),
-          startOffset: 220,
-          endOffset: 269,
-        },
+        quote: validQuote,
       },
     ],
     changes: [
@@ -334,28 +356,106 @@ void test("verification strips unverified quotes but keeps the claim", () => {
         before: "Covered projects must complete a review.",
         after: "The Secretary would be able to waive that review.",
         quote: {
-          text: "The Secretary shall have unlimited authority to ignore all federal law",
+          ...validQuote,
+          text: "appropriated $9,900,000,000 for fiscal year 2027",
           locator: "Sec. 4(a)",
+        },
+      },
+      {
+        kind: "requires",
+        title: "A quote points outside the current source version",
+        before: "The current rule is unchanged.",
+        after: "The model claimed a different requirement.",
+        quote: {
+          text: "The Secretary shall publish a monthly compliance report.",
+          sectionHash: "b".repeat(64),
+          startOffset: 10,
+          endOffset: 66,
         },
       },
     ],
   });
 
-  const {
-    brief: cleaned,
-    verified,
-    dropped,
-  } = verifyBriefQuotes(input, SOURCE);
+  const result = verifyBriefQuotes(input, [section]);
+  const cleaned = result.brief;
+  const { verified, notFound, altered } = result;
   assert.equal(verified, 1);
-  assert.equal(dropped, 1);
+  assert.equal(notFound.length, 1);
+  assert.equal(altered.length, 1);
   assert.ok(cleaned.facts[0]?.quote, "grounded quote is kept");
   assert.deepEqual(cleaned.facts[0]?.quote, input.facts[0]?.quote);
-  assert.equal(cleaned.changes[0]?.quote, undefined, "invented quote is gone");
+  assert.equal(cleaned.changes[0]?.quote, undefined, "altered quote is gone");
+  assert.equal(cleaned.changes[1]?.quote, undefined, "missing quote is gone");
   assert.equal(
     cleaned.changes[0]?.title,
     "Environmental review can be skipped",
     "the surrounding claim survives",
   );
+});
+
+void test("quote failures are loud and counted by failure type", () => {
+  const section = sourceSection();
+  const validQuote = referencedQuote(
+    "appropriated $1,200,000,000 for fiscal year 2027",
+    section,
+  );
+  const input = brief({
+    changes: [
+      {
+        kind: "funds",
+        title: "The amount is altered",
+        before: "No amount was authorized.",
+        after: "The bill would authorize a different amount.",
+        quote: { ...validQuote, text: "appropriated $9,200,000,000" },
+      },
+      {
+        kind: "requires",
+        title: "The source section is missing",
+        before: "No reporting rule applies.",
+        after: "A report would be required.",
+        quote: {
+          text: "The Secretary shall publish a monthly compliance report.",
+          sectionHash: "c".repeat(64),
+          startOffset: 0,
+          endOffset: 56,
+        },
+      },
+    ],
+  });
+
+  resetMetrics();
+  assert.throws(
+    () => requireVerifiedBriefQuotes(input, [section], "H.R. TEST"),
+    QuoteVerificationError,
+  );
+  const metrics = getMetrics();
+  assert.equal(metrics.quoteVerificationNotFound, 1);
+  assert.equal(metrics.quoteVerificationAltered, 1);
+  resetMetrics();
+});
+
+void test("H.R. 7008 retains four quotes from a section beyond the old model window", () => {
+  const lateSection = sourceSection(
+    HR_7008_LATE_SECTION,
+    "section-3-photo-identification",
+  );
+  const input = brief({
+    facts: HR_7008_PREVIOUSLY_DROPPED_QUOTES.map((text, index) => ({
+      label: `Late-section quote ${index + 1}`,
+      value: `H.R. 7008-${index + 1}`,
+      quote: referencedQuote(text, lateSection),
+    })),
+  });
+
+  const result = verifyBriefQuotes(input, [
+    sourceSection("Preamble ".repeat(4_000), "preamble"),
+    lateSection,
+  ]);
+
+  assert.equal(result.verified, 4);
+  assert.deepEqual(result.notFound, []);
+  assert.deepEqual(result.altered, []);
+  assert.equal(result.brief.facts.filter((fact) => fact.quote).length, 4);
 });
 
 void test("framing lint flags loaded language in the model's own voice", () => {

--- a/apps/scraper/src/utils/ai/bill-brief.ts
+++ b/apps/scraper/src/utils/ai/bill-brief.ts
@@ -7,10 +7,9 @@
  *   1. Write (LLM). One schema-validated call grounded in cached, per-section
  *      analysis notes plus outside research. Raw bill text never enters this
  *      pass, so long bills cannot silently disappear at a context boundary.
- *   2. Verify quotes (deterministic). Every quote is checked against the full
- *      source text. Unverified quotes are dropped, not shipped — a brief may
- *      say less than the model wrote, but it never attributes words to a bill
- *      that the bill does not contain.
+ *   2. Verify quotes (deterministic). Every quote is checked against its
+ *      recorded span in the persisted source section. A missing or altered
+ *      quote fails the writing attempt visibly instead of being dropped.
  *   3. Lint framing (deterministic). Loaded political phrasing in the model's
  *      own prose triggers one regeneration with the offending phrases named.
  *      Quotes are exempt: a source is allowed to be partisan, we are not.
@@ -22,6 +21,7 @@ import type {
   BillBrief,
   BillBriefRecord,
   BriefLegalStatus,
+  BriefQuote,
 } from "@acme/validators";
 import {
   BILL_ANALYSIS_SCHEMA_VERSION,
@@ -35,8 +35,13 @@ import {
   BriefVisualSchema,
 } from "@acme/validators";
 
+import type { BillSectionForAnalysis } from "./bill-section-analysis.js";
 import type { DualLensSource } from "./text-generation.js";
 import { trackLLMUsage } from "../costs.js";
+import {
+  incrementQuoteVerificationAltered,
+  incrementQuoteVerificationNotFound,
+} from "../db/metrics.js";
 import { createLogger } from "../log.js";
 import { getStructuredLlm } from "./provider.js";
 import {
@@ -134,57 +139,83 @@ export function normalizeForQuoteMatch(text: string): string {
     .trim();
 }
 
-/** Whether a quote appears verbatim (modulo formatting) in the source. */
-export function isQuoteGrounded(quote: string, normalizedSource: string) {
+/** Whether a quote matches its recorded source span modulo formatting. */
+export function isQuoteGrounded(quote: string, sourceSpan: string) {
   const needle = normalizeForQuoteMatch(quote);
   // Very short fragments match by accident; the schema floor is 20 chars, but
   // normalization can shrink a quote further.
   if (needle.length < 20) return false;
-  return normalizedSource.includes(needle);
+  return normalizeForQuoteMatch(sourceSpan) === needle;
+}
+
+export type QuoteVerificationFailureReason = "not_found" | "altered";
+
+export interface QuoteVerificationFailure {
+  reason: QuoteVerificationFailureReason;
+  quote: BriefQuote;
+  structuralPath?: string;
+  actualText?: string;
 }
 
 export interface QuoteVerification {
   brief: BillBrief;
   /** Quotes that matched the source and were kept. */
   verified: number;
-  /** Quotes that did not match and were stripped from the brief. */
-  dropped: number;
+  /** Quotes whose section reference or recorded span could not be resolved. */
+  notFound: QuoteVerificationFailure[];
+  /** Quotes whose recorded source span exists but contains different words. */
+  altered: QuoteVerificationFailure[];
 }
 
 /**
- * Strip every quote that does not appear in `sourceText`. The surrounding
- * claim is kept — losing a citation makes a point weaker, but deleting the
- * point would let a bad quote silently remove real analysis.
+ * Resolve every quote against the canonical section and section-relative span
+ * carried through from the analysis pass. Invalid quotes are removed from the
+ * returned brief, while their failure classification is retained for logging
+ * and metrics.
  */
 export function verifyBriefQuotes(
   brief: BillBrief,
-  sourceText: string,
+  sourceSections: readonly Pick<
+    BillSectionForAnalysis,
+    "sectionHash" | "structuralPath" | "text"
+  >[],
 ): QuoteVerification {
-  const normalizedSource = normalizeForQuoteMatch(sourceText);
+  const sectionsByHash = new Map(
+    sourceSections.map((section) => [section.sectionHash, section]),
+  );
   let verified = 0;
-  let dropped = 0;
+  const notFound: QuoteVerificationFailure[] = [];
+  const altered: QuoteVerificationFailure[] = [];
 
-  const check = <T extends { quote?: { text: string; locator?: string } }>(
-    item: T,
-  ): T => {
+  const check = <T extends { quote?: BriefQuote }>(item: T): T => {
     if (!item.quote) return item;
-    const quote = item.quote as T["quote"] & {
-      sectionHash?: string;
-      startOffset?: number;
-      endOffset?: number;
-    };
+    const { sectionHash, startOffset, endOffset } = item.quote;
+    const section = sectionHash ? sectionsByHash.get(sectionHash) : undefined;
     if (
-      quote.sectionHash &&
-      quote.startOffset !== undefined &&
-      quote.endOffset !== undefined &&
-      quote.endOffset > quote.startOffset &&
-      isQuoteGrounded(quote.text, normalizedSource)
+      !section ||
+      startOffset === undefined ||
+      endOffset === undefined ||
+      endOffset <= startOffset ||
+      endOffset > section.text.length
     ) {
+      notFound.push({ reason: "not_found", quote: item.quote });
+      const { quote: _removed, ...rest } = item;
+      return rest as T;
+    }
+
+    const actualText = section.text.slice(startOffset, endOffset);
+    if (isQuoteGrounded(item.quote.text, actualText)) {
       verified++;
       return item;
     }
-    dropped++;
-    const { quote: _dropped, ...rest } = item;
+
+    altered.push({
+      reason: "altered",
+      quote: item.quote,
+      structuralPath: section.structuralPath,
+      actualText,
+    });
+    const { quote: _removed, ...rest } = item;
     return rest as T;
   };
 
@@ -195,8 +226,63 @@ export function verifyBriefQuotes(
       changes: brief.changes.map(check),
     },
     verified,
-    dropped,
+    notFound,
+    altered,
   };
+}
+
+export class QuoteVerificationError extends Error {
+  constructor(readonly result: QuoteVerification) {
+    super(
+      `Quote verification failed: ${result.notFound.length} not found, ${result.altered.length} altered`,
+    );
+    this.name = "QuoteVerificationError";
+  }
+}
+
+/**
+ * A bad quote invalidates this writing attempt. Log and count the precise
+ * failure mode, then let the existing generation retry produce a clean brief.
+ */
+export function requireVerifiedBriefQuotes(
+  brief: BillBrief,
+  sourceSections: readonly Pick<
+    BillSectionForAnalysis,
+    "sectionHash" | "structuralPath" | "text"
+  >[],
+  billNumber: string,
+): QuoteVerification {
+  const result = verifyBriefQuotes(brief, sourceSections);
+  for (const failure of result.notFound) {
+    incrementQuoteVerificationNotFound();
+    logger.error(
+      `Brief for ${billNumber}: quote not found in current bill sections`,
+      {
+        sectionHash: failure.quote.sectionHash,
+        startOffset: failure.quote.startOffset,
+        endOffset: failure.quote.endOffset,
+        quote: failure.quote.text,
+      },
+    );
+  }
+  for (const failure of result.altered) {
+    incrementQuoteVerificationAltered();
+    logger.error(
+      `Brief for ${billNumber}: quote text altered at recorded section span`,
+      {
+        structuralPath: failure.structuralPath,
+        sectionHash: failure.quote.sectionHash,
+        startOffset: failure.quote.startOffset,
+        endOffset: failure.quote.endOffset,
+        expected: failure.actualText,
+        received: failure.quote.text,
+      },
+    );
+  }
+  if (result.notFound.length > 0 || result.altered.length > 0) {
+    throw new QuoteVerificationError(result);
+  }
+  return result;
 }
 
 function comparableUrl(value: string): string {
@@ -685,7 +771,10 @@ export async function generateBillBrief(args: {
   title: string;
   billNumber: string;
   url: string;
-  fullText: string;
+  sourceSections: readonly Pick<
+    BillSectionForAnalysis,
+    "sectionHash" | "structuralPath" | "text"
+  >[];
   analysisNotes: string;
   officialSummary?: string | null;
   status?: string | null;
@@ -738,7 +827,11 @@ export async function generateBillBrief(args: {
       trackLLMUsage(usage.inputTokens, usage.outputTokens);
 
       const output = BillBriefSchema.parse(withoutNulls(generatedOutput));
-      const quoteResult = verifyBriefQuotes(output, args.fullText);
+      const quoteResult = requireVerifiedBriefQuotes(
+        output,
+        args.sourceSections,
+        args.billNumber,
+      );
       const briefWithReading = verifyBriefReading(
         quoteResult.brief,
         readingResearch.sources,
@@ -747,12 +840,7 @@ export async function generateBillBrief(args: {
         briefWithReading,
         readingResearch.sources,
       );
-      const { verified, dropped } = quoteResult;
-      if (dropped > 0) {
-        logger.warn(
-          `Brief for ${args.billNumber}: dropped ${dropped} unverified quote(s), kept ${verified}`,
-        );
-      }
+      const { verified } = quoteResult;
 
       const loaded = findLoadedLanguage(brief);
       const jargon = findUnexplainedJargon(brief);

--- a/apps/scraper/src/utils/db/metrics.ts
+++ b/apps/scraper/src/utils/db/metrics.ts
@@ -3,12 +3,12 @@
  * Tracks API calls, processing stats, and cost savings
  */
 
-import type { ScraperMetrics } from '../types.js';
-import { printHeader, printKeyValue, printFooter } from '../log.js';
-import { getCostSummary, resetCosts } from '../costs.js';
-import { stopProgress, resetProgress, tickAI } from '../progress.js';
+import type { ScraperMetrics } from "../types.js";
+import { getCostSummary, resetCosts } from "../costs.js";
+import { printFooter, printHeader, printKeyValue } from "../log.js";
+import { resetProgress, stopProgress, tickAI } from "../progress.js";
 
-export { addExpectedTotal as setExpectedTotal } from '../progress.js';
+export { addExpectedTotal as setExpectedTotal } from "../progress.js";
 
 // Global metrics object for the current run
 let currentMetrics: ScraperMetrics = {
@@ -20,6 +20,8 @@ let currentMetrics: ScraperMetrics = {
   imagesSearched: 0,
   videosGenerated: 0,
   videosSkipped: 0,
+  quoteVerificationNotFound: 0,
+  quoteVerificationAltered: 0,
 };
 
 /**
@@ -35,6 +37,8 @@ export function resetMetrics(): void {
     imagesSearched: 0,
     videosGenerated: 0,
     videosSkipped: 0,
+    quoteVerificationNotFound: 0,
+    quoteVerificationAltered: 0,
   };
   resetProgress();
   resetCosts();
@@ -105,14 +109,20 @@ export function incrementVideosSkipped(): void {
   currentMetrics.videosSkipped++;
 }
 
+export function incrementQuoteVerificationNotFound(): void {
+  currentMetrics.quoteVerificationNotFound++;
+}
+
+export function incrementQuoteVerificationAltered(): void {
+  currentMetrics.quoteVerificationAltered++;
+}
+
 /**
  * Print formatted metrics summary
  * @param scraperName - Name of the scraper (for display)
  */
 function formatUsd(amount: number): string {
-  return amount < 0.01 && amount > 0
-    ? `<$0.01`
-    : `$${amount.toFixed(2)}`;
+  return amount < 0.01 && amount > 0 ? `<$0.01` : `$${amount.toFixed(2)}`;
 }
 
 export function printMetricsSummary(scraperName: string): void {
@@ -129,6 +139,8 @@ export function printMetricsSummary(scraperName: string): void {
   printKeyValue("Images Searched", currentMetrics.imagesSearched);
   printKeyValue("Videos Generated", currentMetrics.videosGenerated);
   printKeyValue("Videos Skipped", currentMetrics.videosSkipped);
+  printKeyValue("Quotes Not Found", currentMetrics.quoteVerificationNotFound);
+  printKeyValue("Quotes Altered", currentMetrics.quoteVerificationAltered);
   printKeyValue("API Calls Saved", `~${apiCallsSaved}`);
   printFooter();
 
@@ -136,17 +148,29 @@ export function printMetricsSummary(scraperName: string): void {
     printHeader("Estimated Costs");
     if (costs.llmInputTokens > 0 || costs.llmOutputTokens > 0) {
       const totalTokens = costs.llmInputTokens + costs.llmOutputTokens;
-      printKeyValue("LLM tokens", `${totalTokens.toLocaleString()} (${formatUsd(costs.llmCost)})`);
+      printKeyValue(
+        "LLM tokens",
+        `${totalTokens.toLocaleString()} (${formatUsd(costs.llmCost)})`,
+      );
     }
     if (costs.visionInputTokens > 0 || costs.visionOutputTokens > 0) {
       const totalTokens = costs.visionInputTokens + costs.visionOutputTokens;
-      printKeyValue("Gemini 2.5 Flash vision tokens", `${totalTokens.toLocaleString()} (${formatUsd(costs.visionCost)})`);
+      printKeyValue(
+        "Gemini 2.5 Flash vision tokens",
+        `${totalTokens.toLocaleString()} (${formatUsd(costs.visionCost)})`,
+      );
     }
     if (costs.fluxImages > 0) {
-      printKeyValue("FLUX.2 Klein 9B images", `${costs.fluxImages} (${formatUsd(costs.fluxCost)})`);
+      printKeyValue(
+        "FLUX.2 Klein 9B images",
+        `${costs.fluxImages} (${formatUsd(costs.fluxCost)})`,
+      );
     }
     if (costs.googleSearches > 0) {
-      printKeyValue("Google searches", `${costs.googleSearches} (${formatUsd(costs.googleSearchCost)})`);
+      printKeyValue(
+        "Google searches",
+        `${costs.googleSearches} (${formatUsd(costs.googleSearchCost)})`,
+      );
     }
     printKeyValue("Total (estimated)", formatUsd(costs.totalCost));
     printFooter();

--- a/apps/scraper/src/utils/db/operations.ts
+++ b/apps/scraper/src/utils/db/operations.ts
@@ -24,6 +24,7 @@ import type {
   GovernmentContentData,
 } from "../types.js";
 import { generateBillBrief } from "../ai/bill-brief.js";
+import type { BillSectionForAnalysis } from "../ai/bill-section-analysis.js";
 import { formatSectionAnalysesForWriting } from "../ai/bill-section-analysis.js";
 import { generateImageSearchKeywords } from "../ai/image-keywords.js";
 import { getTextModelVersion } from "../ai/provider.js";
@@ -944,7 +945,7 @@ async function assembleNewBill(args: {
     title: data.title,
     billNumber: data.billNumber,
     url: data.url,
-    fullText: data.fullText,
+    sourceSections: sections,
     analysisNotes: formatSectionAnalysesForWriting(analyses),
     officialSummary: data.summary,
     status: data.status,
@@ -1059,7 +1060,7 @@ export async function buildBillBriefRecord(args: {
   title: string;
   billNumber: string;
   url: string;
-  fullText: string;
+  sourceSections: readonly BillSectionForAnalysis[];
   analysisNotes: string;
   officialSummary?: string | null;
   status?: string | null;
@@ -1069,7 +1070,7 @@ export async function buildBillBriefRecord(args: {
     title: args.title,
     billNumber: args.billNumber,
     url: args.url,
-    fullText: args.fullText,
+    sourceSections: args.sourceSections,
     analysisNotes: args.analysisNotes,
     officialSummary: args.officialSummary,
     status: args.status,
@@ -1170,6 +1171,7 @@ export async function upsertBillBrief(args: {
 
   const record = await buildBillBriefRecord({
     ...args,
+    sourceSections: analyses.map(({ section }) => section),
     analysisNotes: formatSectionAnalysesForWriting(analyses),
   });
   if (!record) return false;

--- a/apps/scraper/src/utils/types.ts
+++ b/apps/scraper/src/utils/types.ts
@@ -37,6 +37,8 @@ export interface ScraperMetrics {
   imagesSearched: number;
   videosGenerated: number;
   videosSkipped: number;
+  quoteVerificationNotFound: number;
+  quoteVerificationAltered: number;
 }
 
 // Existing record check result (helper return type, not a database entity)

--- a/docs/article-generation.md
+++ b/docs/article-generation.md
@@ -113,18 +113,21 @@ estimate exceeds `BILL_BRIEF_WRITING_INPUT_TOKEN_BUDGET`.
 
 ### 4. Verify quotes and research links (deterministic)
 
-Every `quote.text` is checked against the **whole** source document, not just
-the window the model saw. Matching normalizes away formatting — casing, smart
-quotes, em dashes, hyphenation across line breaks, and the erratic whitespace
-of scraped legislative text — while staying strict about words, so a dropped or
-reordered word still fails.
+Every `quote.text` carries the analyzed section's hash and section-relative
+offsets. Verification resolves that exact `bill_section` row from the current
+source version and compares the stored text at the recorded span. Matching
+normalizes away cosmetic formatting — casing, smart quotes, dashes, and
+whitespace — while staying strict about words.
 
-Unverified quotes are **stripped, and the surrounding claim is kept**. A brief
-may end up saying less than the model wrote, but it never puts words in a
-bill's mouth. The kept count is stored as `verifiedQuotes`. Outside reading
-links are checked against the URLs opened by the research loop; invented links
-are dropped. The historical-context section is removed entirely unless at least
-two distinct opened sources remain after verification.
+A missing section/span is reported as **quote not found**. A resolvable span
+whose words differ is reported separately as **quote altered**, because that is
+a fabrication signal. Either failure is logged, counted in scraper metrics,
+and rejects the writing attempt so the existing retry can produce a clean
+brief; quotes are never silently stripped and shipped. The successful count is
+stored as `verifiedQuotes`. Outside reading links are checked against the URLs
+opened by the research loop; invented links are dropped. The
+historical-context section is removed entirely unless at least two distinct
+opened sources remain after verification.
 
 ### 5. Lint framing and jargon (deterministic)
 

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -234,7 +234,9 @@ Each new/changed item runs through:
    state. The writing pass receives only those notes, the official CRS summary,
    and outside research; it never receives a raw-text prefix. Section notes
    cache by section hash, analysis prompt version, and model version, while the
-   final structured brief remains cached in `content_brief`. See
+   final structured brief remains cached in `content_brief`. Brief quotes carry
+   section-relative offsets and are verified against the current persisted
+   `bill_section` span; missing and altered quotes fail visibly. See
    [Article generation](./article-generation.md).
 4. **Dual lens** (`text-generation.ts`) — proponent/opponent arguments grounded in an agentic web-research loop, cached in `content_lens`. This is the most expensive step and the only one whose output is not reproducible: the same input can return different arguments, and the row is overwritten in place with no history. It is therefore cached on **its own inputs** (title + full text + article type + model version), not on the bill's overall `contentHash` — that hash also covers status and summary, so a routine action update ("Referred to committee" → "Received in the Senate") used to invalidate it and re-roll the dice. One such re-roll lost a finding that H.R. 7008 carried unrelated voter-ID provisions.
 5. **Marketing copy** (`marketing-generation.ts`) — Zod-validated `{ title ≤25 chars, description ≤25 words, imagePrompt }` for the `video` feed card.

--- a/packages/validators/src/bill-brief.ts
+++ b/packages/validators/src/bill-brief.ts
@@ -66,9 +66,9 @@ export const CHANGE_KIND_LABEL: Record<BriefChangeKind, string> = {
 };
 
 /**
- * A verbatim excerpt from the source document. `text` must appear in the
- * source — the generator drops quotes that fail verification rather than
- * shipping a plausible-looking paraphrase in quotation marks.
+ * A verbatim excerpt plus the analysis pass's canonical section span.
+ * Current-generation briefs must resolve this provenance before they ship;
+ * the fields remain optional here so previously stored brief versions parse.
  */
 export const BriefQuoteSchema = z.object({
   text: z


### PR DESCRIPTION
Closes #236.

Stacked on #245 (`codex/issue-235-split-bill-generation`). Review against that branch; the PR diff is one focused quote-verification commit. Merge #244 and #245 first.

## What changed

- Replaced whole-document quote searching with verification against the current persisted `bill_section` identified by the analysis evidence's `sectionHash`.
- Compared each quote with the exact section-relative `[startOffset, endOffset)` span, retaining cosmetic punctuation/whitespace normalization while rejecting changed, missing, or reordered words.
- Classified unresolved section/span references as `quote not found` and mismatched contents at a resolvable span as `quote altered`.
- Made either failure reject the writing attempt so the existing generation retry can recover; failures are emitted as error logs and counted separately in scraper-run metrics instead of being silently stripped.
- Removed raw `fullText` from the brief quote-verification path; generation now receives the current canonical sections returned by the analysis pass.
- Added an H.R. 7008 regression fixture proving four quotes from a late section survive even when earlier source material exceeds the old model window, plus tests for altered and missing quote handling.
- Updated the article-generation and scraper documentation to describe the section/span verification contract.

## Validation

- `pnpm --filter @acme/scraper test` — 49 tests passed.
- `pnpm --filter @acme/scraper exec tsx --test src/utils/ai/bill-brief.test.ts` — 15 focused tests passed.
- `pnpm typecheck` — 16 tasks passed.
- `pnpm lint` — 13 tasks passed.
- `pnpm --filter @acme/scraper build` — production build passed.
- `git diff --check` — passed.