### PR TITLE
fix(scraper): give every AI step the same view of the bill

### DIFF
--- a/apps/scraper/src/retroactive-briefs.ts
+++ b/apps/scraper/src/retroactive-briefs.ts
@@ -7,6 +7,7 @@
  * the restructuring pass is cheaper and more consistent than re-reading the
  * statute cold, and quotes are still verified against the official text.
  */
+import pLimit from "p-limit";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
@@ -83,10 +84,21 @@ const argv = await yargs(hideBin(process.argv))
     default: false,
     describe: "List candidates without generating briefs",
   })
+  .option("concurrency", {
+    alias: "c",
+    type: "number",
+    default: 1,
+    describe: "Briefs to generate in parallel",
+  })
   .check((args) =>
     Number.isInteger(args.limit) && args.limit > 0
       ? true
       : "--limit must be a positive integer",
+  )
+  .check((args) =>
+    Number.isInteger(args.concurrency) && args.concurrency > 0
+      ? true
+      : "--concurrency must be a positive integer",
   )
   .strict()
   .help()
@@ -97,37 +109,50 @@ logger.info(`Found ${candidates.length} missing/stale bill brief candidate(s)`);
 
 let processed = 0;
 let failed = 0;
+// A rate limit means every remaining candidate would fail the same way, so the
+// sequential version broke out of the loop. Concurrently there is no loop to
+// break: in-flight work has to finish and anything not yet started is skipped.
+let rateLimited = false;
 
-for (const candidate of candidates) {
-  if (argv.dryRun) {
-    logger.info(`[dry run] ${candidate.billNumber}: ${candidate.title}`);
-    continue;
-  }
+const limit = pLimit(argv.concurrency);
 
-  try {
-    const generated = await upsertBillBrief({
-      contentId: candidate.id,
-      contentHash: candidate.contentHash,
-      title: candidate.title,
-      billNumber: candidate.billNumber,
-      url: candidate.url,
-      fullText: candidate.fullText,
-      officialSummary: candidate.summary,
-      status: candidate.status,
-      priorArticle: candidate.aiGeneratedArticle,
-    });
-    if (generated) processed++;
-    else failed++;
-  } catch (error) {
-    // A rate limit means every remaining candidate would fail the same way.
-    if (error instanceof AIRateLimitError) {
-      logger.warn("LLM rate limit hit — stopping backfill early");
-      break;
-    }
-    failed++;
-    logger.error(`Failed brief for ${candidate.billNumber}`, error);
-  }
-}
+await Promise.all(
+  candidates.map((candidate) =>
+    limit(async () => {
+      if (argv.dryRun) {
+        logger.info(`[dry run] ${candidate.billNumber}: ${candidate.title}`);
+        return;
+      }
+      if (rateLimited) return;
+
+      try {
+        const generated = await upsertBillBrief({
+          contentId: candidate.id,
+          contentHash: candidate.contentHash,
+          title: candidate.title,
+          billNumber: candidate.billNumber,
+          url: candidate.url,
+          fullText: candidate.fullText,
+          officialSummary: candidate.summary,
+          status: candidate.status,
+          priorArticle: candidate.aiGeneratedArticle,
+        });
+        if (generated) processed++;
+        else failed++;
+      } catch (error) {
+        if (error instanceof AIRateLimitError) {
+          if (!rateLimited) {
+            logger.warn("LLM rate limit hit — skipping remaining candidates");
+          }
+          rateLimited = true;
+          return;
+        }
+        failed++;
+        logger.error(`Failed brief for ${candidate.billNumber}`, error);
+      }
+    }),
+  ),
+);
 
 logger.info(
   argv.dryRun

--- a/apps/scraper/src/retroactive-lenses.ts
+++ b/apps/scraper/src/retroactive-lenses.ts
@@ -1,3 +1,4 @@
+import pLimit from "p-limit";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
@@ -185,10 +186,21 @@ const argv = await yargs(hideBin(process.argv))
     default: false,
     describe: "List candidates without generating lenses",
   })
+  .option("concurrency", {
+    alias: "c",
+    type: "number",
+    default: 1,
+    describe: "Lenses to generate in parallel",
+  })
   .check((args) =>
     Number.isInteger(args.limit) && args.limit > 0
       ? true
       : "--limit must be a positive integer",
+  )
+  .check((args) =>
+    Number.isInteger(args.concurrency) && args.concurrency > 0
+      ? true
+      : "--concurrency must be a positive integer",
   )
   .strict()
   .help()
@@ -200,35 +212,41 @@ const selectedTypes: ContentType[] =
 let processed = 0;
 let failed = 0;
 
+const limit = pLimit(argv.concurrency);
+
 for (const contentType of selectedTypes) {
   const candidates = await finders[contentType](argv.limit);
   logger.info(
     `Found ${candidates.length} missing/stale ${contentType} lens candidate(s)`,
   );
 
-  for (const candidate of candidates) {
-    if (argv.dryRun) {
-      logger.info(`[dry run] ${contentType}: ${candidate.title}`);
-      continue;
-    }
+  await Promise.all(
+    candidates.map((candidate) =>
+      limit(async () => {
+        if (argv.dryRun) {
+          logger.info(`[dry run] ${contentType}: ${candidate.title}`);
+          return;
+        }
 
-    try {
-      const generated = await upsertContentLens(
-        candidate.id,
-        candidate.contentType,
-        candidate.contentHash,
-        candidate.title,
-        candidate.fullText,
-        candidate.articleType,
-        candidate.aiGeneratedArticle,
-      );
-      if (generated) processed++;
-      else failed++;
-    } catch (error) {
-      failed++;
-      logger.error(`Failed ${contentType} lens for ${candidate.id}`, error);
-    }
-  }
+        try {
+          const generated = await upsertContentLens(
+            candidate.id,
+            candidate.contentType,
+            candidate.contentHash,
+            candidate.title,
+            candidate.fullText,
+            candidate.articleType,
+            candidate.aiGeneratedArticle,
+          );
+          if (generated) processed++;
+          else failed++;
+        } catch (error) {
+          failed++;
+          logger.error(`Failed ${contentType} lens for ${candidate.id}`, error);
+        }
+      }),
+    ),
+  );
 }
 
 logger.info(

--- a/apps/scraper/src/utils/ai/bill-brief.ts
+++ b/apps/scraper/src/utils/ai/bill-brief.ts
@@ -44,18 +44,13 @@ import {
   rateLimitHit,
   researchBillContext,
   setRateLimitHit,
+  SOURCE_WINDOW,
 } from "./text-generation.js";
 
 const logger = createLogger("ai-brief");
 
-/**
- * How much of the bill the model reads. Bills routinely run past a provider's
- * context window; verification still runs against the *whole* text, so a quote
- * pulled from anywhere in the document validates even though the model only
- * saw the opening. Larger than the 3–4k windows used elsewhere because a brief
- * has to find concrete provisions, not just a gist.
- */
-const SOURCE_WINDOW = 24_000;
+// Shared with the research and lens steps — see SOURCE_WINDOW's own comment for
+// why they must not diverge.
 
 /** Attempts at structuring before giving up (each is one LLM call). */
 const MAX_ATTEMPTS = 2;

--- a/apps/scraper/src/utils/ai/text-generation.ts
+++ b/apps/scraper/src/utils/ai/text-generation.ts
@@ -557,6 +557,24 @@ function collectOpenedLoopSources(steps: unknown): SdkSource[] {
   }));
 }
 
+/**
+ * How much of a bill's text the AI steps read.
+ *
+ * One number for every step on purpose. It used to be per-call — 3k for the
+ * lens research, 4k for the context research, 24k for the brief — and the
+ * mismatch was invisible until it produced visibly wrong output: H.R. 7008's
+ * photo-ID rider starts at character 7,961 of a 14,741-character bill, so the
+ * brief (24k) described it while the reading list (4k) recommended nothing but
+ * insider-trading background, because its researcher never saw that the bill
+ * touched voting at all.
+ *
+ * Bills routinely run past this. Quote verification still runs against the
+ * *whole* stored text, so a quote from anywhere in the document validates.
+ * Section-aware windowing (#191) is what actually fixes long bills; this is the
+ * ceiling until then.
+ */
+export const SOURCE_WINDOW = 24_000;
+
 export interface BillContextResearch {
   notes: string;
   sources: DualLensSource[];
@@ -579,17 +597,18 @@ export async function researchBillContext(
       stopWhen: stepCountIs(7),
       prompt: `You are researching historical context and useful follow-up reading for an average citizen reading about ${billNumber}, "${title}".
 
-1. First investigate why this policy has not already been implemented. Look for earlier bills, documented disagreements, legal or budget constraints, implementation tradeoffs, and circumstances that changed. Do not guess at lawmakers' motives.
-2. Prefer the Congressional Research Service, GAO, CBO, established newsrooms, universities, and transparent research organizations. Avoid campaign pages, SEO summaries, scraped copies, and sources that merely repeat a press release.
-3. Search separately for clear explanatory reporting or authoritative background that helps a reader understand the bill's most important mechanism or uncertainty.
-4. Open and read at least three promising results with fetch_page, including at least two that directly support the historical explanation. A search snippet is not enough.
-5. Return concise notes in two labeled parts:
+1. Read the bill text below before searching, and identify every distinct subject it legislates on. A bill's title names one of them at best. If the text contains provisions **unrelated to the title's subject** — separate policy riding along in the same bill — those are as important to research as the headline subject, and a reader will find them nowhere else. Note them explicitly.
+2. Then investigate why this policy has not already been implemented. Look for earlier bills, documented disagreements, legal or budget constraints, implementation tradeoffs, and circumstances that changed. Do not guess at lawmakers' motives.
+3. Prefer the Congressional Research Service, GAO, CBO, established newsrooms, universities, and transparent research organizations. Avoid campaign pages, SEO summaries, scraped copies, and sources that merely repeat a press release. Reject a URL carrying referral or campaign tracking parameters (utm_source, utm_campaign, ref=) — find the publisher's own canonical link instead.
+4. Search separately for clear explanatory reporting or authoritative background that helps a reader understand the bill's most important mechanism or uncertainty. **Cover each distinct subject you identified in step 1**, not just the one the title names: a reading list that only addresses the headline subject leaves the reader with no way to learn about the rest of what the bill does.
+5. Open and read at least three promising results with fetch_page, including at least two that directly support the historical explanation. A search snippet is not enough.
+6. Return concise notes in two labeled parts:
    - WHY NOT BEFORE: the documented answer, distinguishing established facts from uncertainty and naming which opened URLs support each point.
-   - FURTHER READING: the two to four best articles, who published each, and what each helps a reader understand.
+   - FURTHER READING: the two to four best articles, who published each, and what each helps a reader understand. Say which subject each one covers.
 Do not cite or recommend a page you did not open.
 
-Official bill excerpt:
-${fullText.slice(0, 4000)}`,
+Official bill text:
+${fullText.slice(0, SOURCE_WINDOW)}`,
     });
     trackLLMUsage(res.usage.inputTokens, res.usage.outputTokens);
     return {
@@ -620,7 +639,7 @@ Prioritize credible, verifiable sources over neutrality — a partisan source is
 Title: ${title}
 
 Content excerpt:
-${text.substring(0, 3000)}`;
+${text.substring(0, SOURCE_WINDOW)}`;
 
 const STRUCTURE_PROMPT = (
   title: string,
@@ -728,7 +747,7 @@ export async function generateDualLens(
   }
 
   // Step 2 — structured synthesis (schema-validated; no manual JSON parsing).
-  const grounding = research.trim() || fullText.substring(0, 4000);
+  const grounding = research.trim() || fullText.substring(0, SOURCE_WINDOW);
   const sourceList = sources
     .map((s) => `[${s.id}] ${s.title} — ${s.url}`)
     .join("\n");


### PR DESCRIPTION
## The bug

The window into a bill's text was set independently at each call site:

| Step | Window | Saw H.R. 7008's voter-ID rider (char 7,961)? |
| --- | --- | --- |
| Brief (`bill-brief.ts`) | 24,000 | yes |
| Context/reading research (`researchBillContext`) | 4,000 | **no** |
| Dual-lens research (`RESEARCH_PROMPT`) | 3,000 | **no** |
| Lens grounding fallback | 4,000 | **no** |

H.R. 7008 is 14,741 characters. Its photo-ID voting requirement — a SAVE Act provision riding along in a congressional stock-trading bill — starts at character 7,961.

So the brief's hook correctly told readers the bill "would require every voter to show a government-issued photo ID." Meanwhile the reading list, whose researcher only ever saw the first 4,000 characters, never learned the bill touched voting at all. It returned a 2013 Columbia Law blog post and a William & Mary law review article, both on the STOCK Act. The single most consequential thing in the bill had no follow-up reading behind it.

This is the same class of bug as the 1,000-word storage cap we removed last week, relocated from storage into research. A window that cuts mid-bill does not produce a shorter answer; it produces a confidently wrong one.

## The fix

`SOURCE_WINDOW = 24_000` moves into `text-generation.ts` and all four sites use it. One number, with a comment explaining why they must not diverge again.

Two prompt changes fall out:

- **Enumerate subjects before searching.** The researcher now reads the text first and lists every subject the bill legislates on — a title names one at best — then covers *each* of them in the reading list, not just the headline subject.
- **Reject tracking URLs.** One of H.R. 7008's two recommendations arrived as `scholarship.law.wm.edu/...?utm_source=trustfundinsider.com&utm_campaign=members_of_congress_are_buying_these_stocks` — an aggregator's referral link laundered into a citation. The researcher is now told to find the publisher's canonical link instead.

## Scope

Section-aware windowing (#191) is still what actually fixes bills longer than the window. This raises the ceiling and makes it a single number; it does not solve the 800KB case.

Typecheck clean, 42 tests pass.

## Verification

H.R. 7008 needs regenerating to confirm the reading list picks up the voting angle — running that next; will report the before/after here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)