### PR TITLE
Scraper deployment: a daily recent-bills refresh, run by a supervisor instead of an SSH session

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,3 +90,61 @@ jobs:
 
       - name: Bundle Android
         run: cd apps/expo && npx expo export --platform android --output-dir dist
+
+  # Publishes the image the scrapers actually run in production.
+  #
+  # This lives in `ci.yml` rather than its own workflow so it can `needs:` the
+  # checks above. That dependency is the whole point: it makes "only tested code
+  # on main reaches production" a property of the graph instead of a convention
+  # someone has to remember. big-mac pulls from here and never builds, so a
+  # branch that was never merged has no path to prod.
+  #
+  # Runs on arm64 because big-mac is Apple Silicon under OrbStack; a native
+  # runner avoids shipping an emulated amd64 image.
+  scraper-image:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [lint, format, typecheck, test]
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.scraper
+          platforms: linux/arm64
+          push: true
+          # `:main` is a convenience pointer for humans. Deploys pin the
+          # immutable `:<sha>` tag, resolved to a digest, so a running host is
+          # never silently moved by a later push.
+          tags: |
+            ghcr.io/billion-app/billion-scraper:${{ github.sha }}
+            ghcr.io/billion-app/billion-scraper:main
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summarise
+        run: |
+          {
+            echo "### Scraper image published"
+            echo
+            echo '```'
+            echo "ghcr.io/billion-app/billion-scraper:${{ github.sha }}"
+            echo "digest: ${{ steps.push.outputs.digest }}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,23 @@ jobs:
       - name: Typecheck
         run: pnpm typecheck
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup
+        uses: ./tooling/github/setup
+
+      # The scraper and env packages read configuration at import time, so the
+      # suite needs a populated .env even though no test touches the network.
+      - name: Copy env
+        shell: bash
+        run: cp .env.example .env
+
+      - name: Test
+        run: pnpm test
+
   bundle-expo:
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile.scraper
+++ b/Dockerfile.scraper
@@ -8,6 +8,7 @@ RUN corepack enable && corepack prepare pnpm@10.15.1 --activate
 WORKDIR /app
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json .npmrc ./
 COPY apps/scraper/package.json ./apps/scraper/package.json
+COPY apps/supervisor/package.json ./apps/supervisor/package.json
 COPY packages/api/package.json ./packages/api/package.json
 COPY packages/auth/package.json ./packages/auth/package.json
 COPY packages/db/package.json ./packages/db/package.json
@@ -16,7 +17,7 @@ COPY packages/validators/package.json ./packages/validators/package.json
 COPY tooling/eslint/package.json ./tooling/eslint/package.json
 COPY tooling/prettier/package.json ./tooling/prettier/package.json
 COPY tooling/typescript/package.json ./tooling/typescript/package.json
-RUN pnpm install --frozen-lockfile --filter @acme/scraper...
+RUN pnpm install --frozen-lockfile --filter @acme/scraper... --filter @acme/supervisor...
 
 COPY tooling/typescript/base.json ./tooling/typescript/base.json
 COPY packages/api/src ./packages/api/src
@@ -25,9 +26,18 @@ COPY packages/env/src ./packages/env/src
 COPY packages/validators/src ./packages/validators/src
 COPY apps/scraper/src ./apps/scraper/src
 COPY apps/scraper/tsconfig.json apps/scraper/vite.config.ts ./apps/scraper/
-RUN pnpm --filter @acme/scraper build
+COPY apps/supervisor/src ./apps/supervisor/src
+COPY apps/supervisor/tsconfig.json apps/supervisor/vite.config.ts ./apps/supervisor/
+RUN pnpm --filter @acme/scraper build && pnpm --filter @acme/supervisor build
+
+# The supervisor rides in the scraper's deploy root rather than getting one of
+# its own. It spawns the scraper's entrypoints as child processes, so it has to
+# sit next to them anyway, and its only external imports are `consola` and
+# `zod` — both already production dependencies of the scraper, so sharing the
+# root costs no extra modules.
 RUN pnpm --filter @acme/scraper deploy --prod --legacy /app/deploy && \
-    cp -R apps/scraper/dist /app/deploy/dist
+    cp -R apps/scraper/dist /app/deploy/dist && \
+    cp apps/supervisor/dist/supervisor.js /app/deploy/dist/supervisor.js
 
 FROM node:22.20-slim
 

--- a/apps/scraper/src/main.ts
+++ b/apps/scraper/src/main.ts
@@ -46,6 +46,11 @@ const argv = await yargs(hideBin(process.argv))
     type: "number",
     describe: "Congress number for --bill (default: 119)",
   })
+  .option("recent", {
+    type: "number",
+    describe:
+      "Refresh the N most recently updated bills instead of walking the incremental cursor. Keeps active legislation current rather than pursuing complete historical coverage",
+  })
   .check((args) => {
     const maxItems = args.maxItems;
     if (
@@ -59,6 +64,15 @@ const argv = await yargs(hideBin(process.argv))
     const bills = args.bill;
     if (bills?.length && args.scraper !== "congress") {
       throw new Error('--bill requires the "congress" scraper');
+    }
+    const recent = args.recent;
+    if (recent !== undefined) {
+      if (!Number.isInteger(recent) || recent <= 0) {
+        throw new Error("--recent must be a positive integer");
+      }
+      if (bills?.length) {
+        throw new Error("--recent and --bill select bills different ways");
+      }
     }
     if (args.congress !== undefined && !bills?.length) {
       throw new Error("--congress only applies alongside --bill");
@@ -79,6 +93,7 @@ const concurrency = (argv as { concurrency: number }).concurrency;
 const maxItems = (argv as { maxItems?: number }).maxItems;
 const targets = (argv as { bill?: string[] }).bill;
 const congressNumber = (argv as { congress?: number }).congress;
+const recent = (argv as { recent?: number }).recent;
 
 function logDatabaseTarget(): void {
   const target = databaseTarget(process.env.POSTGRES_URL!);
@@ -123,7 +138,12 @@ async function main() {
     }
     validateScraperEnv([scraper]);
     logDatabaseTarget();
-    await scraper.scrape({ maxItems, targets, congress: congressNumber });
+    await scraper.scrape({
+      maxItems,
+      targets,
+      congress: congressNumber,
+      recent,
+    });
     printMetricsSummary(scraper.name);
   }
 }

--- a/apps/scraper/src/scrapers/congress.test.ts
+++ b/apps/scraper/src/scrapers/congress.test.ts
@@ -7,7 +7,28 @@ import {
   orderTextVersionsNewestFirst,
   parseBillIdentifier,
   parseBillUrl,
+  SORT_UPDATE_ASC,
+  SORT_UPDATE_DESC,
 } from "./congress.js";
+
+test("sort parameters survive URLSearchParams encoding", () => {
+  // congress.gov wants `updateDate+desc` on the wire. A literal `+` in the
+  // source string is percent-encoded to `%2B`, which the API does not
+  // recognise: it silently ignores the sort and returns its default (ascending)
+  // order. Writing the value with a space produces the `+` the API wants.
+  //
+  // This is not hypothetical. `sort=updateDate%2Bdesc` returns the *oldest*
+  // bills of the congress, so a "100 most recently updated" run served up
+  // January 2025 instead. The ascending walk only looked correct because
+  // ascending is the default it was falling back to.
+  const encode = (value: string) =>
+    new URLSearchParams({ sort: value }).toString();
+
+  assert.equal(encode(SORT_UPDATE_DESC), "sort=updateDate+desc");
+  assert.equal(encode(SORT_UPDATE_ASC), "sort=updateDate+asc");
+
+  assert.notEqual(encode("updateDate+desc"), "sort=updateDate+desc");
+});
 
 test("parseBillIdentifier accepts the forms people paste", () => {
   const expected = { billType: "hr", billNumber: "7008" };

--- a/apps/scraper/src/scrapers/congress.ts
+++ b/apps/scraper/src/scrapers/congress.ts
@@ -76,6 +76,23 @@ function getApiKey(): string {
   return key;
 }
 
+/**
+ * congress.gov sort values are documented as `<field>+<direction>`, and the `+`
+ * has to arrive at the API as a literal `+`.
+ *
+ * These are written with a **space** because `congressFetch` builds the query
+ * with `URLSearchParams`, which percent-encodes a literal `+` to `%2B` — and
+ * the API does not recognise `updateDate%2Basc`, so it silently ignores the
+ * parameter and falls back to its own default ordering. A space is encoded as
+ * `+`, which is exactly the wire format the docs ask for.
+ *
+ * This was verified against the live API: `sort=updateDate%2Bdesc` returns the
+ * *oldest* bills of the congress, while `sort=updateDate+desc` returns today's.
+ * The ascending walk appeared to work only because ascending is the default.
+ */
+export const SORT_UPDATE_ASC = "updateDate asc";
+export const SORT_UPDATE_DESC = "updateDate desc";
+
 async function congressFetch<T>(
   path: string,
   params: Record<string, string | number> = {},
@@ -489,6 +506,7 @@ async function scrape(config: CongressScraperConfig = {}) {
     return scrapeTargeted(config.bills, congress);
   }
 
+
   logger.info(`Starting (congress=${congress}, chamber=${chamber})...`);
 
   // The cursor is the newest *source* timestamp we have actually persisted,
@@ -518,7 +536,7 @@ async function scrape(config: CongressScraperConfig = {}) {
     // strands everything older, and the cursor then jumps past the strand.
     // Ascending drains monotonically — whatever we do not reach this run is
     // still the next run's first page.
-    sort: "updateDate+asc",
+    sort: SORT_UPDATE_ASC,
   };
 
   if (lastScrape?.lastUpdated) {

--- a/apps/scraper/src/scrapers/congress.ts
+++ b/apps/scraper/src/scrapers/congress.ts
@@ -21,6 +21,11 @@ interface CongressScraperConfig {
   chamber?: "House" | "Senate";
   /** Bill identifiers to fetch directly instead of walking the update feed. */
   bills?: string[];
+  /**
+   * Refresh the N most recently updated bills instead of walking the cursor.
+   * See `scrapeRecent`.
+   */
+  recent?: number;
 }
 
 interface ApiBillListItem {
@@ -499,6 +504,100 @@ async function scrapeTargeted(identifiers: string[], congress: number) {
   logger.success("Completed");
 }
 
+/**
+ * Refresh the `count` most recently updated bills in a congress.
+ *
+ * This is the daily production mode. It trades completeness for freshness: the
+ * app is a news feed, so a bill whose status changed today matters more than
+ * one introduced in early 2025 that nothing has touched since.
+ *
+ * Deliberately does **not** read or write `scraper_cursor`. The cursor exists to
+ * guarantee eventual coverage of an ordered walk, and this is not a walk — it
+ * re-reads the same head of the feed every day. Advancing a cursor from here
+ * would be actively harmful: a descending window's newest item is not a
+ * high-water mark for anything, and writing it would strand every older bill
+ * from a subsequent ascending walk. Because nothing is skipped-and-forgotten,
+ * a failed bill needs no retry bookkeeping — tomorrow's run sees it again as
+ * long as it is still in the window.
+ *
+ * The tradeoff to know about: this covers the *head* of the update feed, not
+ * all of it. Between 2026-07-21 and 2026-07-28, 1,742 House bills were updated
+ * upstream — roughly 250/day — so a 100-bill window sees the most recent
+ * activity, not every change. Raise `count` to widen it.
+ */
+async function scrapeRecent(
+  count: number,
+  congress: number,
+  chamber: "House" | "Senate",
+) {
+  logger.info(
+    `Refreshing the ${count} most recently updated bills (congress=${congress})`,
+  );
+
+  const fetched: ApiBillListItem[] = [];
+  const pageSize = 250;
+  let offset = 0;
+
+  while (fetched.length < count) {
+    const pageLimit = Math.min(count - fetched.length, pageSize);
+    const pageData = await congressFetch<{ bills: ApiBillListItem[] }>(
+      `/bill/${congress}`,
+      { sort: SORT_UPDATE_DESC, limit: pageLimit, offset },
+    );
+    const page = pageData.bills ?? [];
+    fetched.push(...page);
+    if (page.length < pageLimit) break;
+    offset += page.length;
+  }
+
+  const bills = fetched.slice(0, count);
+  logger.info(`Fetched ${bills.length} recently updated bill(s)`);
+
+  if (bills.length === 0) {
+    logger.success("No bills returned");
+    return;
+  }
+
+  setExpectedTotal(bills.length);
+
+  const limit = getItemLimit();
+  const newItemLimiter = createNewItemLimiter();
+  let failures = 0;
+
+  await Promise.all(
+    bills.map((item) =>
+      limit(async () => {
+        try {
+          await processBill(
+            congress,
+            item.type.toLowerCase(),
+            item.number,
+            chamber,
+            newItemLimiter,
+          );
+        } catch (error) {
+          if (error instanceof BillTextTooLargeError) {
+            logger.warn(`Skipping ${item.type}${item.number}: ${error.message}`);
+            return;
+          }
+          failures += 1;
+          logger.error(
+            `Error processing bill ${item.type}${item.number}`,
+            error,
+          );
+        }
+      }),
+    ),
+  );
+
+  if (failures > 0) {
+    logger.warn(
+      `${failures} bill(s) failed; they are re-offered by tomorrow's run while they remain in the window`,
+    );
+  }
+  logger.success("Completed");
+}
+
 async function scrape(config: CongressScraperConfig = {}) {
   const { maxBills = 100, congress = 119, chamber = "House" } = config;
 
@@ -506,6 +605,9 @@ async function scrape(config: CongressScraperConfig = {}) {
     return scrapeTargeted(config.bills, congress);
   }
 
+  if (config.recent) {
+    return scrapeRecent(config.recent, congress, chamber);
+  }
 
   logger.info(`Starting (congress=${congress}, chamber=${chamber})...`);
 
@@ -666,6 +768,7 @@ export const congress: Scraper = {
       maxBills:
         (options?.maxItems ?? Number(process.env.CONGRESS_MAX_ITEMS)) || 100,
       bills: options?.targets,
+      ...(options?.recent ? { recent: options.recent } : {}),
       ...(options?.congress ? { congress: options.congress } : {}),
     }),
 };

--- a/apps/scraper/src/utils/new-item-limit.test.ts
+++ b/apps/scraper/src/utils/new-item-limit.test.ts
@@ -1,7 +1,28 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { createNewItemLimiter } from "./new-item-limit.js";
+import { budgetFromEnv, createNewItemLimiter } from "./new-item-limit.js";
+
+test("a configured budget of zero is honoured, not treated as unset", () => {
+  // `Number(env) || DEFAULT` used to turn an explicit 0 into 10, so a run
+  // configured to fetch without generating anything quietly generated ten
+  // items' worth of briefs, lenses and header art.
+  assert.equal(budgetFromEnv("0"), 0);
+  assert.equal(createNewItemLimiter(budgetFromEnv("0")).tryConsume(), false);
+});
+
+test("budget falls back to the default when unset or malformed", () => {
+  assert.equal(budgetFromEnv(undefined), 10);
+  assert.equal(budgetFromEnv(""), 10);
+  assert.equal(budgetFromEnv("   "), 10);
+  assert.equal(budgetFromEnv("lots"), 10);
+  assert.equal(budgetFromEnv("-5"), 10);
+  assert.equal(budgetFromEnv("2.5"), 10);
+});
+
+test("a valid budget is read from the environment", () => {
+  assert.equal(budgetFromEnv("25"), 25);
+});
 
 /**
  * Mirrors the per-item claim in `upsertContent`. An item draws at most one

--- a/apps/scraper/src/utils/new-item-limit.ts
+++ b/apps/scraper/src/utils/new-item-limit.ts
@@ -13,9 +13,29 @@ export interface NewItemLimiter {
 
 const DEFAULT_MAX_NEW_ITEMS_PER_RUN = 10;
 
+/**
+ * Reads the per-run budget from the environment.
+ *
+ * Written out rather than `Number(env) || DEFAULT` because that idiom treats a
+ * configured `0` as absent and silently substitutes the default — so an
+ * operator asking for "fetch, but generate nothing" got ten generations. Zero
+ * is a legitimate budget and has to survive.
+ */
+export function budgetFromEnv(
+  raw: string | undefined = process.env.SCRAPER_MAX_NEW_ITEMS_PER_RUN,
+): number {
+  if (raw === undefined || raw.trim() === "") {
+    return DEFAULT_MAX_NEW_ITEMS_PER_RUN;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return DEFAULT_MAX_NEW_ITEMS_PER_RUN;
+  }
+  return parsed;
+}
+
 export function createNewItemLimiter(
-  max: number = Number(process.env.SCRAPER_MAX_NEW_ITEMS_PER_RUN) ||
-    DEFAULT_MAX_NEW_ITEMS_PER_RUN,
+  max: number = budgetFromEnv(),
 ): NewItemLimiter {
   let count = 0;
   return {

--- a/apps/scraper/src/utils/types.ts
+++ b/apps/scraper/src/utils/types.ts
@@ -67,4 +67,10 @@ export interface ScraperRunOptions {
   targets?: string[];
   /** Congress number for targeted congress.gov runs (e.g. 119). */
   congress?: number;
+  /**
+   * Refresh the N most recently updated records instead of walking the
+   * incremental cursor. Keeps active items current rather than pursuing
+   * complete historical coverage. Scrapers without a recent mode ignore this.
+   */
+  recent?: number;
 }

--- a/apps/supervisor/README.md
+++ b/apps/supervisor/README.md
@@ -1,0 +1,113 @@
+# @acme/supervisor
+
+Runs the Billion scrapers on `big-mac`, one job at a time.
+
+## Why this exists
+
+The scrapers used to be driven by four near-identical zsh scripts in
+`~/.local/bin` on the host, started by hand over SSH. On 2026-07-28 three
+backfills died the moment the SSH session that launched them closed — one had
+logged a single header line and no iterations. Nothing noticed, and the archive
+drain those jobs existed to perform did not happen.
+
+Three properties follow from that, and they are what this app is for:
+
+- **Jobs outlive the shell that started them.** launchd owns the supervisor
+  (`KeepAlive`), the supervisor owns the jobs. Closing a terminal changes
+  nothing; so does a reboot.
+- **Only one job runs at a time, structurally.** Each old script re-implemented
+  `docker container inspect <other-job>` to avoid overlap, which was O(n²) in
+  scripts and silently wrong for any job nobody remembered to add. There is now
+  one runner and one queue.
+- **Scheduling is code.** Intervals, priorities, timeouts, budgets and backoff
+  live in `src/config.ts`, get typechecked, and are covered by tests — instead
+  of being encoded in `sleep` calls and `grep` on another process's stdout.
+
+## Jobs
+
+Defined in `src/config.ts`. Each names a script in the scraper's `dist/` and
+the arguments it takes; the supervisor supplies everything else.
+
+| id | schedule | notes |
+| --- | --- | --- |
+| `congress-daily` | daily 03:15 local | Adds and updates the 100 most recently updated bills |
+| `federalregister-weekly` | Sundays 03:15 | Executive orders and presidential documents |
+| `scc-cvig-weekly` | Sundays 03:15 | Santa Clara County voter guide |
+| `ca-sos-weekly` | Sundays 03:15 | California SoS candidate statements |
+| `retro-briefs` | manual | Fills in missing structured briefs |
+| `retro-lenses` | manual | Fills in missing dual-lens perspectives |
+| `retro-videos` | manual | Header art backfill |
+
+`congress-daily` is the point of the whole arrangement: the app is a news feed,
+so a bill whose status changed today matters more than one introduced in early
+2025 that nothing has touched since. It re-reads the head of the update feed
+every day and does not use `scraper_cursor` at all.
+
+Know the tradeoff: this covers the *head* of the feed, not all of it. Roughly
+250 House bills are updated upstream per day, so a 100-bill window sees the most
+recent activity rather than every change. Widen it by raising `--recent`.
+
+There is deliberately **no scheduled archive backfill**. The cursor walk starts
+near the beginning of the congress (~17,000 measures), and each bill it enriches
+pays for a brief, a dual-lens research loop and header art. The retro jobs are
+manual for the same reason — filling in the archive is a supervised spend, not
+something a scheduler starts at 3am.
+
+The three weekly scrapers are listed individually rather than as one `main.js
+all` run, so that dropping `all` (which would drag the cursor walk back in)
+cannot silently stop them.
+
+A job that has never run fires immediately if it is interval-based, and waits
+for its next occurrence if it is on a calendar schedule — deploying at 4pm must
+not kick off the overnight run. A calendar job whose last run predates the most
+recent occurrence *is* due, so an outage over the scheduled time is caught up
+rather than skipped.
+
+## Operating it
+
+```sh
+# Deploy the current origin/main (refuses anything not merged)
+pnpm deploy:scraper
+
+# Check first, without touching the host
+pnpm deploy:scraper --dry-run
+
+# Watch it
+ssh big-mac 'tail -f ~/Library/Logs/billion/supervisor.log'
+
+# What ran, when, and what failed
+ssh big-mac 'cat ~/.local/state/billion/supervisor-state.json'
+
+# Run a job now, without waiting for its schedule
+ssh big-mac 'touch ~/.local/state/billion/requests/retro-videos'
+```
+
+Requests are a directory rather than a socket or an HTTP port: no client is
+needed, they survive a supervisor restart, and they are inspectable over SSH,
+which is how this host is actually operated.
+
+## Deployment model
+
+```
+push to main → CI (lint · format · typecheck · test) → ghcr.io/billion-app/billion-scraper:<sha>
+                                                     → big-mac pulls; it never builds
+```
+
+`scripts/deploy-scraper.mjs` refuses any commit that is not an ancestor of
+`origin/main`, so an unmerged branch has no path to production. It also
+reinstalls the launchd plist and the wrapper from this repo on every deploy —
+the host should never carry a hand-edited copy.
+
+The image pin lives in exactly one place, `~/.config/billion/deploy.env`. It is
+written only by the deploy script.
+
+## Failure handling
+
+A failed job backs off from 15 minutes, doubling, capped at a day — so a
+permanently broken job costs one attempt a day rather than one per tick. Any
+success resets the counter. State is written before a job starts as well as
+after it finishes, so a host that loses power mid-job does not restart it
+immediately and stack a second copy on whatever the first one left behind.
+
+Jobs have hard timeouts (`timeoutMinutes`). A job that ignores `SIGTERM` gets
+`SIGKILL` 30 seconds later, because a wedged job blocks the single queue.

--- a/apps/supervisor/deploy/billion-supervisor
+++ b/apps/supervisor/deploy/billion-supervisor
@@ -1,0 +1,75 @@
+#!/bin/zsh
+#
+# launchd entrypoint for the Billion scraper supervisor.
+#
+# This is the only shell that remains in the deployment path, and it is
+# deliberately dumb: it resolves an image, mounts state, and execs. Everything
+# that used to require editing a script by hand — which job runs, when, with
+# what budget, how failures back off — now lives in `apps/supervisor` where it
+# is typechecked and unit-tested.
+#
+# Deployed from the repo by `scripts/deploy-scraper.mjs`. Do not edit in place:
+# the next deploy overwrites it, and an edit here is invisible to code review.
+
+set -euo pipefail
+
+export PATH="/usr/local/bin:$HOME/.orbstack/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+readonly env_file="$HOME/.config/billion/scraper.env"
+readonly deploy_file="$HOME/.config/billion/deploy.env"
+readonly state_dir="$HOME/.local/state/billion"
+readonly container="billion-supervisor"
+
+if [[ ! -r "$env_file" ]]; then
+  print -u2 "Missing scraper environment: $env_file"
+  exit 1
+fi
+if [[ ! -r "$deploy_file" ]]; then
+  print -u2 "Missing deploy pin: $deploy_file (run scripts/deploy-scraper.mjs)"
+  exit 1
+fi
+
+# The single source of truth for which image runs. One line, one place, written
+# only by the deploy script — which refuses any commit not already on main.
+set -a
+source "$deploy_file"
+set +a
+
+if [[ -z "${SCRAPER_IMAGE:-}" ]]; then
+  print -u2 "$deploy_file does not define SCRAPER_IMAGE"
+  exit 1
+fi
+
+# Values in scraper.env are shell-quoted, so they are sourced (which strips the
+# quotes) and then forwarded by name. `docker --env-file` would pass the quote
+# characters through literally and corrupt POSTGRES_URL.
+set -a
+source "$env_file"
+set +a
+
+env_args=()
+while IFS='=' read -r key _; do
+  if [[ -z "$key" || "$key" == *[^A-Za-z0-9_]* || "$key" == [0-9]* ]]; then
+    continue
+  fi
+  env_args+=(--env "$key")
+done < "$env_file"
+
+if ! docker info >/dev/null 2>&1; then
+  print -u2 "Docker is unavailable; ensure OrbStack is running"
+  exit 1
+fi
+
+mkdir -p "$state_dir"
+
+# A leftover container from a hard kill would block the name. Removing it is
+# safe: job state lives in the mounted volume, not in the container.
+docker rm -f "$container" >/dev/null 2>&1 || true
+
+exec docker run --rm \
+  --name "$container" \
+  --pull always \
+  "${env_args[@]}" \
+  --volume "$state_dir:/var/lib/billion" \
+  --label com.billion.service=supervisor \
+  "$SCRAPER_IMAGE" node dist/supervisor.js

--- a/apps/supervisor/deploy/com.billion.supervisor.plist
+++ b/apps/supervisor/deploy/com.billion.supervisor.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Keeps the scraper supervisor running.
+
+  This replaces com.billion.scrapers.weekly. The old job fired once a week and
+  exited; everything else was run by hand over SSH, which is why three backfills
+  died the moment the session that started them closed. KeepAlive plus
+  RunAtLoad means the supervisor survives logout, crashes and reboots, and the
+  schedule lives in the supervisor rather than in launchd.
+-->
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.billion.supervisor</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/Users/bhu/.local/bin/billion-supervisor</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<!-- Without this, a supervisor that fails at startup restarts in a hot
+	     loop. Ten seconds is long enough to read the log and intervene. -->
+	<key>ThrottleInterval</key>
+	<integer>10</integer>
+	<key>LowPriorityIO</key>
+	<true/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>StandardOutPath</key>
+	<string>/Users/bhu/Library/Logs/billion/supervisor.log</string>
+	<key>StandardErrorPath</key>
+	<string>/Users/bhu/Library/Logs/billion/supervisor.error.log</string>
+</dict>
+</plist>

--- a/apps/supervisor/package.json
+++ b/apps/supervisor/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@acme/supervisor",
+  "version": "0.0.1",
+  "type": "module",
+  "description": "Serial job supervisor for the Billion scrapers",
+  "dependencies": {
+    "consola": "^3.4.2",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsx": "^4.21.0",
+    "typescript": "catalog:",
+    "vite": "^8.1.4"
+  },
+  "scripts": {
+    "dev": "tsx src/main.ts",
+    "start:prod": "node dist/supervisor.js",
+    "build": "pnpm run typecheck && vite build",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test \"src/**/*.test.ts\""
+  },
+  "author": "It's not you it's me",
+  "license": "ISC"
+}

--- a/apps/supervisor/src/config.ts
+++ b/apps/supervisor/src/config.ts
@@ -1,0 +1,105 @@
+import type { JobDefinition } from "./types.js";
+
+/**
+ * The jobs the supervisor knows how to run.
+ *
+ * These replace the hand-written runner scripts that lived in `~/.local/bin` on
+ * big-mac. Each one names a script in the scraper's `dist/` and the arguments
+ * it takes; the supervisor supplies serialisation, scheduling, backoff and
+ * logging, so the job definitions stay declarative.
+ */
+export const jobs: readonly JobDefinition[] = [
+  {
+    id: "congress-daily",
+    description: "Add and update the 100 most recently updated bills",
+    script: "main.js",
+    args: ["congress", "--recent", "100", "--concurrency", "4"],
+    schedule: { kind: "daily", hour: 3, minute: 15 },
+    // Most of the 100 will be unchanged and cost nothing beyond the fetch —
+    // derived assets are keyed on content, so an unchanged bill regenerates
+    // nothing. The budget bounds the days when that is not true, such as a bill
+    // whose text was replaced by a substitute amendment.
+    env: { SCRAPER_MAX_NEW_ITEMS_PER_RUN: "25" },
+    priority: 0,
+    timeoutMinutes: 6 * 60,
+  },
+  // The other three registered scrapers. These used to ride along in a weekly
+  // `main.js all` run; they are listed individually so that dropping the `all`
+  // run does not silently stop them, and so each can be rescheduled or paused
+  // without touching the others.
+  //
+  // They stay weekly because their sources move slowly compared with the
+  // congressional feed.
+  {
+    id: "federalregister-weekly",
+    description: "Executive orders and presidential documents",
+    script: "main.js",
+    args: ["federalregister", "--concurrency", "2"],
+    schedule: { kind: "weekly", weekday: 0, hour: 3, minute: 15 },
+    priority: 10,
+    timeoutMinutes: 6 * 60,
+  },
+  {
+    id: "scc-cvig-weekly",
+    description: "Santa Clara County voter information guide",
+    script: "main.js",
+    args: ["scc-cvig", "--concurrency", "2"],
+    schedule: { kind: "weekly", weekday: 0, hour: 3, minute: 15 },
+    priority: 11,
+    timeoutMinutes: 4 * 60,
+  },
+  {
+    id: "ca-sos-weekly",
+    description: "California Secretary of State candidate statements",
+    script: "main.js",
+    args: ["ca-sos-statements", "--concurrency", "2"],
+    schedule: { kind: "weekly", weekday: 0, hour: 3, minute: 15 },
+    priority: 12,
+    timeoutMinutes: 4 * 60,
+  },
+
+  // Everything below is manual: it runs only when someone drops a request file,
+  // never on a schedule.
+  //
+  // There is deliberately no scheduled archive backfill. The `scraper_cursor`
+  // walk starts near the beginning of the congress, so an unattended job would
+  // grind through ~17,000 measures paying for a brief, a dual-lens research
+  // loop and header art on each one it enriched. The daily job above keeps
+  // *active* legislation current, which is what a news feed needs.
+  //
+  // The retro jobs are manual for the same reason: each is bounded by how much
+  // unenriched content exists, which is currently most of the archive. Filling
+  // that in is a deliberate, supervised spend, not something a scheduler starts
+  // on its own at 3am.
+  {
+    id: "retro-briefs",
+    description: "Generate structured briefs for content missing one",
+    script: "retroactive-briefs.js",
+    args: ["--limit", "200", "--concurrency", "4"],
+    schedule: { kind: "manual" },
+    priority: 20,
+    timeoutMinutes: 6 * 60,
+  },
+  {
+    id: "retro-lenses",
+    description: "Generate dual-lens perspectives for content missing one",
+    script: "retroactive-lenses.js",
+    args: ["--type", "all", "--limit", "200", "--concurrency", "4"],
+    schedule: { kind: "manual" },
+    priority: 21,
+    timeoutMinutes: 6 * 60,
+  },
+  {
+    id: "retro-videos",
+    description: "Generate missing header art",
+    script: "retroactive-videos.js",
+    args: ["--type", "bill"],
+    schedule: { kind: "manual" },
+    priority: 30,
+    timeoutMinutes: 6 * 60,
+  },
+];
+
+export function findJob(jobId: string): JobDefinition | undefined {
+  return jobs.find((job) => job.id === jobId);
+}

--- a/apps/supervisor/src/main.ts
+++ b/apps/supervisor/src/main.ts
@@ -1,0 +1,176 @@
+import { mkdir, readdir, unlink } from "node:fs/promises";
+import { basename, extname, join } from "node:path";
+import { createConsola } from "consola";
+
+import { findJob, jobs } from "./config.js";
+import { JobQueue } from "./queue.js";
+import { runJob } from "./run.js";
+import { backoffMinutes, dueJobs } from "./schedule.js";
+import { loadState, saveState } from "./state.js";
+import type { QueueEntry, Schedule, SupervisorState } from "./types.js";
+
+const logger = createConsola({ formatOptions: { date: true } });
+
+const stateDir = process.env.SUPERVISOR_STATE_DIR ?? "/var/lib/billion";
+const scraperDist = process.env.SUPERVISOR_SCRAPER_DIST ?? "/app/dist";
+const statePath = join(stateDir, "supervisor-state.json");
+const requestsDir = join(stateDir, "requests");
+const tickSeconds = Number(process.env.SUPERVISOR_TICK_SECONDS ?? "30");
+
+const queue = new JobQueue();
+const shutdown = new AbortController();
+let stopping = false;
+
+/**
+ * Ad-hoc runs are requested by dropping a file named after a job into
+ * `requests/` — `touch requests/retro-videos`. A directory beats a socket or an
+ * HTTP port here: it needs no client, it survives a supervisor restart, and it
+ * is trivially inspectable over SSH, which is how this host is actually
+ * operated.
+ */
+async function drainRequests(): Promise<void> {
+  let entries: string[];
+  try {
+    entries = await readdir(requestsDir);
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (entry.startsWith(".")) continue;
+    const jobId = basename(entry, extname(entry));
+    const path = join(requestsDir, entry);
+
+    if (!findJob(jobId)) {
+      logger.error(`Ignoring request for unknown job "${jobId}"`);
+      await unlink(path).catch(() => undefined);
+      continue;
+    }
+
+    // Consume the file before running, so a job that crashes the supervisor
+    // cannot be re-requested in a loop by its own leftover request file.
+    await unlink(path).catch(() => undefined);
+
+    const job = findJob(jobId);
+    if (job && queue.enqueue({ jobId, priority: job.priority, reason: "requested" })) {
+      logger.info(`Queued "${jobId}" on request`);
+    } else {
+      logger.info(`"${jobId}" was already queued; request collapsed into it`);
+    }
+  }
+}
+
+async function execute(
+  entry: QueueEntry,
+  state: SupervisorState,
+): Promise<void> {
+  const job = findJob(entry.jobId);
+  if (!job) return;
+
+  const startedAt = new Date().toISOString();
+  const previous = state.jobs[entry.jobId];
+  state.jobs[entry.jobId] = {
+    ...previous,
+    lastStartedAt: startedAt,
+    consecutiveFailures: previous?.consecutiveFailures ?? 0,
+  };
+  // Persist before running: if the host loses power mid-job, the restarted
+  // supervisor must see that this job was attempted rather than start it again
+  // immediately and stack a second copy on whatever the first one left behind.
+  await saveState(statePath, state);
+
+  logger.start(`Running "${job.id}" (${entry.reason}) — ${job.description}`);
+
+  const result = await runJob(job, {
+    scraperDist,
+    logger,
+    signal: shutdown.signal,
+  });
+
+  const succeeded = result.exitCode === 0 && !result.timedOut;
+  const failures = succeeded ? 0 : (previous?.consecutiveFailures ?? 0) + 1;
+
+  state.jobs[entry.jobId] = {
+    lastStartedAt: startedAt,
+    lastFinishedAt: new Date().toISOString(),
+    lastExitCode: result.exitCode,
+    consecutiveFailures: failures,
+  };
+  await saveState(statePath, state);
+
+  const minutes = (result.durationMs / 60_000).toFixed(1);
+  if (succeeded) {
+    logger.success(`"${job.id}" finished in ${minutes}m`);
+  } else {
+    logger.error(
+      `"${job.id}" failed (exit ${result.exitCode}${
+        result.timedOut ? ", timed out" : ""
+      }) after ${minutes}m; ` +
+        `retry #${failures} in ${backoffMinutes(failures)}m`,
+    );
+  }
+}
+
+const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function describeSchedule(schedule: Schedule): string {
+  const at = (hour: number, minute: number) =>
+    `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+
+  switch (schedule.kind) {
+    case "interval":
+      return `every ${schedule.everyMinutes}m`;
+    case "daily":
+      return `daily at ${at(schedule.hour, schedule.minute)}`;
+    case "weekly":
+      return `${WEEKDAYS[schedule.weekday] ?? schedule.weekday} at ${at(schedule.hour, schedule.minute)}`;
+    case "manual":
+      return "manual (on request only)";
+  }
+}
+
+async function main(): Promise<void> {
+  await mkdir(requestsDir, { recursive: true });
+  const state = await loadState(statePath);
+
+  logger.info(
+    `Supervisor starting — ${jobs.length} jobs, state at ${statePath}, ` +
+      `scraper dist at ${scraperDist}`,
+  );
+  for (const job of jobs) {
+    logger.info(`  ${job.id} — ${describeSchedule(job.schedule)}`);
+  }
+
+  while (!stopping) {
+    await drainRequests();
+
+    for (const entry of dueJobs(jobs, state.jobs, new Date())) {
+      if (queue.enqueue(entry)) {
+        logger.info(`Queued "${entry.jobId}" (scheduled)`);
+      }
+    }
+
+    const next = queue.take();
+    if (next) {
+      await execute(next, state);
+      // Loop straight back round rather than sleeping: a finished job often
+      // leaves another one due, and the queue is the only thing serialising us.
+      continue;
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, tickSeconds * 1000));
+  }
+
+  logger.info("Supervisor stopped");
+}
+
+for (const signal of ["SIGTERM", "SIGINT"] as const) {
+  process.on(signal, () => {
+    if (stopping) return;
+    stopping = true;
+    logger.warn(`Received ${signal}; finishing shutdown`);
+    shutdown.abort();
+  });
+}
+
+await main();

--- a/apps/supervisor/src/queue.test.ts
+++ b/apps/supervisor/src/queue.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { JobQueue } from "./queue.js";
+import type { QueueEntry } from "./types.js";
+
+const entry = (jobId: string, priority: number): QueueEntry => ({
+  jobId,
+  priority,
+  reason: "scheduled",
+});
+
+void test("a job already queued is not queued twice", () => {
+  const queue = new JobQueue();
+  assert.equal(queue.enqueue(entry("backfill", 10)), true);
+  assert.equal(queue.enqueue(entry("backfill", 10)), false);
+  assert.equal(queue.size, 1);
+});
+
+void test("a long-running job cannot accumulate copies of itself", () => {
+  // The supervisor re-evaluates schedules every tick, and an hour-long job
+  // spans many ticks. Without dedup it would come back to an hour of queued
+  // duplicates and run them all.
+  const queue = new JobQueue();
+  for (let tick = 0; tick < 120; tick++) {
+    queue.enqueue(entry("backfill", 10));
+  }
+  assert.equal(queue.size, 1);
+});
+
+void test("entries come out highest priority first regardless of insert order", () => {
+  const queue = new JobQueue();
+  queue.enqueue(entry("retro-lenses", 21));
+  queue.enqueue(entry("weekly", 0));
+  queue.enqueue(entry("backfill", 10));
+
+  assert.equal(queue.take()?.jobId, "weekly");
+  assert.equal(queue.take()?.jobId, "backfill");
+  assert.equal(queue.take()?.jobId, "retro-lenses");
+  assert.equal(queue.take(), undefined);
+});
+
+void test("equal priorities break ties deterministically", () => {
+  const first = new JobQueue();
+  first.enqueue(entry("b", 5));
+  first.enqueue(entry("a", 5));
+
+  const second = new JobQueue();
+  second.enqueue(entry("a", 5));
+  second.enqueue(entry("b", 5));
+
+  assert.equal(first.take()?.jobId, "a");
+  assert.equal(second.take()?.jobId, "a");
+});
+
+void test("has reports membership without consuming", () => {
+  const queue = new JobQueue();
+  queue.enqueue(entry("weekly", 0));
+  assert.equal(queue.has("weekly"), true);
+  assert.equal(queue.size, 1);
+  assert.equal(queue.has("missing"), false);
+});

--- a/apps/supervisor/src/queue.ts
+++ b/apps/supervisor/src/queue.ts
@@ -1,0 +1,45 @@
+import type { QueueEntry } from "./types.js";
+
+/**
+ * A serial job queue that holds at most one pending entry per job.
+ *
+ * Deduplication is the point. The supervisor re-evaluates schedules every tick,
+ * and a long backfill can span many ticks — without dedup an hour-long job
+ * would accumulate an hour's worth of queued copies of itself and then run them
+ * all back to back.
+ *
+ * Serial execution is what replaces the `docker container inspect <other-job>`
+ * checks the shell runners each reimplemented: two scrapers cannot overlap
+ * because there is only ever one runner.
+ */
+export class JobQueue {
+  #entries: QueueEntry[] = [];
+
+  /** Returns false when the job was already queued. */
+  enqueue(entry: QueueEntry): boolean {
+    if (this.#entries.some((queued) => queued.jobId === entry.jobId)) {
+      return false;
+    }
+    this.#entries.push(entry);
+    this.#entries.sort(
+      (a, b) => a.priority - b.priority || a.jobId.localeCompare(b.jobId),
+    );
+    return true;
+  }
+
+  take(): QueueEntry | undefined {
+    return this.#entries.shift();
+  }
+
+  has(jobId: string): boolean {
+    return this.#entries.some((entry) => entry.jobId === jobId);
+  }
+
+  get size(): number {
+    return this.#entries.length;
+  }
+
+  get pending(): readonly QueueEntry[] {
+    return [...this.#entries];
+  }
+}

--- a/apps/supervisor/src/run.ts
+++ b/apps/supervisor/src/run.ts
@@ -1,0 +1,94 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import type { ConsolaInstance } from "consola";
+
+import type { JobDefinition } from "./types.js";
+
+export interface RunResult {
+  readonly exitCode: number;
+  readonly timedOut: boolean;
+  readonly durationMs: number;
+}
+
+export interface RunOptions {
+  /** Directory holding the scraper's built entrypoints. */
+  readonly scraperDist: string;
+  readonly logger: ConsolaInstance;
+  /** Resolves when the supervisor is shutting down and the job should stop. */
+  readonly signal: AbortSignal;
+}
+
+/**
+ * Runs one job as a child process and resolves when it exits.
+ *
+ * Jobs are child processes rather than sibling containers on purpose: the
+ * supervisor ships in the same image as the scraper, so it already has the
+ * entrypoints on disk. Spawning siblings would mean mounting the Docker socket
+ * into the container, which hands every job root on the host for no benefit.
+ */
+export async function runJob(
+  job: JobDefinition,
+  options: RunOptions,
+): Promise<RunResult> {
+  const { scraperDist, logger, signal } = options;
+  const startedAt = Date.now();
+
+  const child = spawn(
+    process.execPath,
+    [`${scraperDist}/${job.script}`, ...job.args],
+    {
+      env: { ...process.env, ...job.env },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  // Prefix every line so a shared log stays readable when jobs run back to
+  // back, and so grepping for one job's history is possible.
+  //
+  // Written raw rather than through consola on purpose. The scrapers do their
+  // own formatting (`[ai] ℹ …`), and routing their output through a second
+  // logger re-decorates each line — turning a single stack trace into a screen
+  // of padded blocks. The supervisor's own messages still use consola.
+  const pipe = (stream: NodeJS.ReadableStream, sink: NodeJS.WriteStream) => {
+    const lines = createInterface({ input: stream });
+    lines.on("line", (line) => sink.write(`[${job.id}] ${line}\n`));
+  };
+  if (child.stdout) pipe(child.stdout, process.stdout);
+  if (child.stderr) pipe(child.stderr, process.stderr);
+
+  let timedOut = false;
+
+  const timeout = setTimeout(
+    () => {
+      timedOut = true;
+      logger.error(
+        `[${job.id}] exceeded ${job.timeoutMinutes}m timeout, terminating`,
+      );
+      child.kill("SIGTERM");
+      // A job that ignores SIGTERM still has to go, or it wedges the queue.
+      setTimeout(() => child.kill("SIGKILL"), 30_000).unref();
+    },
+    job.timeoutMinutes * 60_000,
+  );
+
+  const onAbort = () => {
+    logger.warn(`[${job.id}] supervisor shutting down, terminating job`);
+    child.kill("SIGTERM");
+  };
+  signal.addEventListener("abort", onAbort, { once: true });
+
+  try {
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", (code, signalName) => {
+        // A signalled exit has no code; report it the way a shell would so the
+        // number in the log means something.
+        resolve(code ?? (signalName ? 128 : 1));
+      });
+    });
+    return { exitCode, timedOut, durationMs: Date.now() - startedAt };
+  } finally {
+    clearTimeout(timeout);
+    signal.removeEventListener("abort", onAbort);
+  }
+}

--- a/apps/supervisor/src/schedule.test.ts
+++ b/apps/supervisor/src/schedule.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { backoffMinutes, dueJobs, isDue, lastOccurrence } from "./schedule.js";
+import type { JobDefinition, JobState } from "./types.js";
+
+// 2026-07-26 is a Sunday; 2026-07-28 is a Tuesday. Dates are built with the
+// local-time constructor so these assertions hold in any timezone.
+const sundayAt = (hour: number, minute: number) =>
+  new Date(2026, 6, 26, hour, minute);
+const tuesdayNoon = new Date(2026, 6, 28, 12, 0);
+
+const weeklyJob: JobDefinition = {
+  id: "weekly",
+  description: "weekly",
+  script: "main.js",
+  args: [],
+  schedule: { kind: "weekly", weekday: 0, hour: 3, minute: 15 },
+  priority: 0,
+  timeoutMinutes: 60,
+};
+
+const intervalJob: JobDefinition = {
+  id: "backfill",
+  description: "backfill",
+  script: "main.js",
+  args: [],
+  schedule: { kind: "interval", everyMinutes: 5 },
+  priority: 10,
+  timeoutMinutes: 60,
+};
+
+const clean: JobState = { consecutiveFailures: 0 };
+
+void test("backoff doubles from 15 minutes and caps at a day", () => {
+  assert.equal(backoffMinutes(0), 0);
+  assert.equal(backoffMinutes(1), 15);
+  assert.equal(backoffMinutes(2), 30);
+  assert.equal(backoffMinutes(3), 60);
+  assert.equal(backoffMinutes(99), 24 * 60);
+});
+
+void test("the weekly occurrence is the most recent one already passed", () => {
+  assert.equal(
+    lastOccurrence(weeklyJob.schedule as never, tuesdayNoon).getTime(),
+    sundayAt(3, 15).getTime(),
+  );
+});
+
+void test("on the scheduled day but before the time, the occurrence is last week", () => {
+  const justBefore = sundayAt(2, 0);
+  const occurrence = lastOccurrence(weeklyJob.schedule as never, justBefore);
+  assert.equal(occurrence.getTime(), new Date(2026, 6, 19, 3, 15).getTime());
+});
+
+void test("the daily occurrence is today once the time has passed", () => {
+  assert.equal(
+    lastOccurrence({ kind: "daily", hour: 3, minute: 15 }, tuesdayNoon).getTime(),
+    new Date(2026, 6, 28, 3, 15).getTime(),
+  );
+});
+
+void test("before the daily time has come round, the occurrence is yesterday", () => {
+  const earlyTuesday = new Date(2026, 6, 28, 1, 0);
+  assert.equal(
+    lastOccurrence({ kind: "daily", hour: 3, minute: 15 }, earlyTuesday).getTime(),
+    new Date(2026, 6, 27, 3, 15).getTime(),
+  );
+});
+
+void test("a daily job runs once per day, and catches up after an outage", () => {
+  const daily: JobDefinition = {
+    ...weeklyJob,
+    id: "congress-daily",
+    schedule: { kind: "daily", hour: 3, minute: 15 },
+  };
+
+  // Never run: waits for tonight rather than firing on deploy.
+  assert.equal(isDue(daily, undefined, tuesdayNoon), false);
+
+  // Already ran after this morning's occurrence.
+  assert.equal(
+    isDue(
+      daily,
+      { ...clean, lastStartedAt: new Date(2026, 6, 28, 3, 16).toISOString() },
+      tuesdayNoon,
+    ),
+    false,
+  );
+
+  // Last ran three days ago — the supervisor was down, so catch up now.
+  assert.equal(
+    isDue(
+      daily,
+      { ...clean, lastStartedAt: new Date(2026, 6, 25, 3, 15).toISOString() },
+      tuesdayNoon,
+    ),
+    true,
+  );
+});
+
+void test("a weekly job does not fire the first time the supervisor starts", () => {
+  // Deploying on a Tuesday afternoon must not trigger the weekly archive walk.
+  assert.equal(isDue(weeklyJob, undefined, tuesdayNoon), false);
+});
+
+void test("a weekly job whose last run predates the occurrence is due", () => {
+  const state: JobState = {
+    ...clean,
+    lastStartedAt: new Date(2026, 6, 19, 3, 15).toISOString(),
+  };
+  assert.equal(isDue(weeklyJob, state, tuesdayNoon), true);
+});
+
+void test("a weekly job that already ran this occurrence is not due", () => {
+  const state: JobState = { ...clean, lastStartedAt: sundayAt(3, 20).toISOString() };
+  assert.equal(isDue(weeklyJob, state, tuesdayNoon), false);
+});
+
+void test("an interval job is due immediately when it has never run", () => {
+  assert.equal(isDue(intervalJob, undefined, tuesdayNoon), true);
+});
+
+void test("an interval job waits out its interval", () => {
+  const twoMinutesAgo = new Date(tuesdayNoon.getTime() - 2 * 60_000);
+  const state: JobState = { ...clean, lastStartedAt: twoMinutesAgo.toISOString() };
+  assert.equal(isDue(intervalJob, state, tuesdayNoon), false);
+
+  const tenMinutesAgo = new Date(tuesdayNoon.getTime() - 10 * 60_000);
+  assert.equal(
+    isDue(intervalJob, { ...clean, lastStartedAt: tenMinutesAgo.toISOString() }, tuesdayNoon),
+    true,
+  );
+});
+
+void test("backoff suppresses a job that would otherwise be due", () => {
+  const oneMinuteAgo = new Date(tuesdayNoon.getTime() - 60_000).toISOString();
+  const failing: JobState = {
+    consecutiveFailures: 2, // 30 minutes of backoff
+    lastStartedAt: new Date(tuesdayNoon.getTime() - 120_000).toISOString(),
+    lastFinishedAt: oneMinuteAgo,
+  };
+  assert.equal(isDue(intervalJob, failing, tuesdayNoon), false);
+
+  // Once the backoff has elapsed the job is offered again. Both timestamps move
+  // together: the interval is measured from `lastStartedAt`, so a state where
+  // the job finished before it started would not exercise anything real.
+  const settled: JobState = {
+    consecutiveFailures: 2,
+    lastStartedAt: new Date(tuesdayNoon.getTime() - 50 * 60_000).toISOString(),
+    lastFinishedAt: new Date(tuesdayNoon.getTime() - 45 * 60_000).toISOString(),
+  };
+  assert.equal(isDue(intervalJob, settled, tuesdayNoon), true);
+});
+
+void test("a manual job is never due on its own", () => {
+  const manual: JobDefinition = {
+    ...intervalJob,
+    id: "manual",
+    schedule: { kind: "manual" },
+  };
+  assert.equal(isDue(manual, undefined, tuesdayNoon), false);
+  assert.equal(isDue(manual, clean, tuesdayNoon), false);
+});
+
+void test("due jobs come back highest priority first", () => {
+  const state = {
+    weekly: { ...clean, lastStartedAt: new Date(2026, 6, 19, 3, 15).toISOString() },
+  };
+  const due = dueJobs([intervalJob, weeklyJob], state, tuesdayNoon);
+  assert.deepEqual(
+    due.map((entry) => entry.jobId),
+    ["weekly", "backfill"],
+  );
+});

--- a/apps/supervisor/src/schedule.ts
+++ b/apps/supervisor/src/schedule.ts
@@ -1,0 +1,100 @@
+import type { JobDefinition, JobState, QueueEntry, Schedule } from "./types.js";
+
+const MINUTE_MS = 60_000;
+
+/** First retry waits this long; each further failure doubles it. */
+const BASE_BACKOFF_MINUTES = 15;
+/** A permanently broken job costs one attempt a day, not one per tick. */
+const MAX_BACKOFF_MINUTES = 24 * 60;
+
+export function backoffMinutes(consecutiveFailures: number): number {
+  if (consecutiveFailures <= 0) return 0;
+  const raw = BASE_BACKOFF_MINUTES * 2 ** (consecutiveFailures - 1);
+  return Math.min(raw, MAX_BACKOFF_MINUTES);
+}
+
+/**
+ * The most recent moment matching a calendar schedule at or before `now`, in
+ * local time. Local rather than UTC because these times are chosen to land
+ * overnight for a human; keeping the same frame stops the run drifting an hour
+ * across a DST boundary.
+ */
+export function lastOccurrence(
+  schedule: Extract<Schedule, { kind: "daily" | "weekly" }>,
+  now: Date,
+): Date {
+  const candidate = new Date(now);
+  candidate.setHours(schedule.hour, schedule.minute, 0, 0);
+
+  if (schedule.kind === "daily") {
+    // Today's occurrence, unless the time has not come round yet.
+    if (candidate.getTime() > now.getTime()) {
+      candidate.setDate(candidate.getDate() - 1);
+    }
+    return candidate;
+  }
+
+  // Walk back to the scheduled weekday, then back one more week if that lands
+  // in the future (i.e. today is the right weekday but the time has not come).
+  const dayDelta = (candidate.getDay() - schedule.weekday + 7) % 7;
+  candidate.setDate(candidate.getDate() - dayDelta);
+  if (candidate.getTime() > now.getTime()) {
+    candidate.setDate(candidate.getDate() - 7);
+  }
+  return candidate;
+}
+
+/**
+ * Whether a job should run now.
+ *
+ * A job that has never run is due immediately if it is interval-based, and is
+ * *not* due if it is on a calendar schedule: a deploy at 4pm should not trigger
+ * the overnight run, but it should leave tonight's intact. A calendar job whose
+ * last run predates the most recent occurrence is due, so an outage over the
+ * scheduled time is caught up rather than skipped.
+ */
+export function isDue(
+  job: JobDefinition,
+  state: JobState | undefined,
+  now: Date,
+): boolean {
+  if (job.schedule.kind === "manual") return false;
+
+  const failures = state?.consecutiveFailures ?? 0;
+  if (failures > 0 && state?.lastFinishedAt) {
+    const waitMs = backoffMinutes(failures) * MINUTE_MS;
+    const readyAt = Date.parse(state.lastFinishedAt) + waitMs;
+    if (now.getTime() < readyAt) return false;
+  }
+
+  const lastStartedAt = state?.lastStartedAt;
+
+  if (job.schedule.kind === "interval") {
+    if (!lastStartedAt) return true;
+    const elapsed = now.getTime() - Date.parse(lastStartedAt);
+    return elapsed >= job.schedule.everyMinutes * MINUTE_MS;
+  }
+
+  if (!lastStartedAt) return false;
+  const occurrence = lastOccurrence(job.schedule, now);
+  return Date.parse(lastStartedAt) < occurrence.getTime();
+}
+
+/**
+ * Every job due right now, highest priority first. Ties break on job id so the
+ * order is deterministic and logs from two runs can be compared.
+ */
+export function dueJobs(
+  jobs: readonly JobDefinition[],
+  state: Record<string, JobState>,
+  now: Date,
+): QueueEntry[] {
+  return jobs
+    .filter((job) => isDue(job, state[job.id], now))
+    .map((job) => ({
+      jobId: job.id,
+      priority: job.priority,
+      reason: "scheduled" as const,
+    }))
+    .sort((a, b) => a.priority - b.priority || a.jobId.localeCompare(b.jobId));
+}

--- a/apps/supervisor/src/state.ts
+++ b/apps/supervisor/src/state.ts
@@ -1,0 +1,65 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { z } from "zod";
+
+import type { JobState, SupervisorState } from "./types.js";
+
+const jobStateSchema = z.object({
+  lastStartedAt: z.string().optional(),
+  lastFinishedAt: z.string().optional(),
+  lastExitCode: z.number().optional(),
+  consecutiveFailures: z.number().default(0),
+});
+
+const supervisorStateSchema = z.object({
+  jobs: z.record(z.string(), jobStateSchema).default({}),
+});
+
+export const emptyState: SupervisorState = { jobs: {} };
+
+/**
+ * Reads persisted job history.
+ *
+ * A missing or unreadable file yields empty state rather than throwing. The
+ * supervisor runs unattended under launchd `KeepAlive`, and refusing to start
+ * because a history file is corrupt would turn a cosmetic problem into an
+ * outage — losing the history costs at most one redundant run per job.
+ */
+export async function loadState(path: string): Promise<SupervisorState> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch {
+    return { jobs: {} };
+  }
+
+  try {
+    return supervisorStateSchema.parse(JSON.parse(raw));
+  } catch {
+    return { jobs: {} };
+  }
+}
+
+/**
+ * Writes state via a temporary file and a rename, so a crash mid-write cannot
+ * leave a half-written history behind. `rename` is atomic within a filesystem.
+ */
+export async function saveState(
+  path: string,
+  state: SupervisorState,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const temporary = join(
+    dirname(path),
+    `.${Date.now()}-${process.pid}.state.tmp`,
+  );
+  await writeFile(temporary, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  await rename(temporary, path);
+}
+
+export function jobStateFor(
+  state: SupervisorState,
+  jobId: string,
+): JobState | undefined {
+  return state.jobs[jobId];
+}

--- a/apps/supervisor/src/types.ts
+++ b/apps/supervisor/src/types.ts
@@ -1,0 +1,68 @@
+/** How a job decides it is due to run again. */
+export type Schedule =
+  | {
+      /** Fires at a fixed local weekday/time, at most once per occurrence. */
+      kind: "weekly";
+      /** 0 = Sunday, matching `Date.prototype.getDay`. */
+      weekday: number;
+      hour: number;
+      minute: number;
+    }
+  | {
+      /** Fires at a fixed local time each day, at most once per occurrence. */
+      kind: "daily";
+      hour: number;
+      minute: number;
+    }
+  | {
+      /** Fires when this long has passed since the job last *started*. */
+      kind: "interval";
+      everyMinutes: number;
+    }
+  | {
+      /** Never fires on its own; only runs when explicitly requested. */
+      kind: "manual";
+    };
+
+export interface JobDefinition {
+  /** Stable identifier. Used in state, logs, and request files. */
+  readonly id: string;
+  readonly description: string;
+  /** Script under the scraper's `dist/`, e.g. `main.js`. */
+  readonly script: string;
+  readonly args: readonly string[];
+  readonly schedule: Schedule;
+  /**
+   * Extra environment for this job only. Merged over the supervisor's own
+   * environment, so a job can raise a budget without the setting leaking into
+   * every other job in the container.
+   */
+  readonly env?: Readonly<Record<string, string>>;
+  /**
+   * Lower numbers run first when several jobs are due at once. The weekly run
+   * outranks the backfills so this week's legislation is never queued behind a
+   * multi-hour archive drain.
+   */
+  readonly priority: number;
+  /** Hard ceiling on a single run. Exceeding it is a failure, not a success. */
+  readonly timeoutMinutes: number;
+}
+
+export interface JobState {
+  lastStartedAt?: string;
+  lastFinishedAt?: string;
+  lastExitCode?: number;
+  /** Drives backoff. Reset to 0 on any successful run. */
+  consecutiveFailures: number;
+}
+
+export interface SupervisorState {
+  jobs: Record<string, JobState>;
+}
+
+export interface QueueEntry {
+  readonly jobId: string;
+  readonly priority: number;
+  /** Why this run was queued — surfaced in logs to make history readable. */
+  readonly reason: "scheduled" | "requested";
+}

--- a/apps/supervisor/tsconfig.json
+++ b/apps/supervisor/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tooling/typescript/base.json",
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["./src/**/*", "./vite.config.ts"]
+}

--- a/apps/supervisor/vite.config.ts
+++ b/apps/supervisor/vite.config.ts
@@ -1,0 +1,38 @@
+import { builtinModules } from "node:module";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+
+const workspacePackagePrefix = "@acme/";
+const nodeBuiltins = new Set([
+  ...builtinModules,
+  ...builtinModules.map((module) => `node:${module}`),
+]);
+
+function externalizeRuntimeDependency(id: string) {
+  if (id.startsWith(workspacePackagePrefix)) return false;
+
+  return (
+    nodeBuiltins.has(id) ||
+    (!id.startsWith(".") && !id.startsWith("/") && !id.startsWith("\0"))
+  );
+}
+
+export default defineConfig({
+  build: {
+    emptyOutDir: true,
+    minify: false,
+    outDir: "dist",
+    rollupOptions: {
+      external: externalizeRuntimeDependency,
+      input: {
+        supervisor: fileURLToPath(new URL("./src/main.ts", import.meta.url)),
+      },
+      output: {
+        chunkFileNames: "chunks/[name]-[hash].js",
+        entryFileNames: "[name].js",
+      },
+    },
+    ssr: true,
+    target: "node22",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "packageManager": "pnpm@10.15.1",
   "scripts": {
     "build": "turbo run build",
+    "test": "turbo run test",
     "clean": "git clean -xdf node_modules",
     "clean:workspaces": "turbo run clean",
     "auth:generate": "pnpm -F @acme/auth generate",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "android": "pnpm --dir apps/expo run android",
     "ios": "pnpm --dir apps/expo run ios",
     "bump": "node scripts/bump.mjs",
+    "deploy:scraper": "node scripts/deploy-scraper.mjs",
     "env:doctor": "pnpm --filter @acme/scraper exec tsx src/env-cli.ts doctor --",
     "env:example": "pnpm --filter @acme/scraper exec tsx src/env-cli.ts template --target all --output .env.example",
     "env:setup": "pnpm --filter @acme/scraper exec tsx src/env-cli.ts setup --",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -524,6 +524,28 @@ importers:
         specifier: ^8.1.4
         version: 8.1.4(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
 
+  apps/supervisor:
+    dependencies:
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.4
+        version: 8.1.4(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.46.1)(tsx@4.21.0)(yaml@2.9.0)
+
   packages/api:
     dependencies:
       '@acme/auth':
@@ -748,7 +770,7 @@ importers:
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react-native:
         specifier: '*'
-        version: 0.81.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)
+        version: 0.81.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -11999,7 +12021,7 @@ snapshots:
       tinyglobby: 0.2.15
       yargs: 17.7.2
 
-  '@react-native/community-cli-plugin@0.81.4(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(bufferutil@4.1.0)':
+  '@react-native/community-cli-plugin@0.81.4(@react-native/metro-config@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0))(bufferutil@4.1.0)':
     dependencies:
       '@react-native/dev-middleware': 0.81.4(bufferutil@4.1.0)
       debug: 4.4.3
@@ -12009,7 +12031,7 @@ snapshots:
       metro-core: 0.83.7
       semver: 7.7.4
     optionalDependencies:
-      '@react-native/metro-config': 0.84.1(@babel/core@7.29.0)
+      '@react-native/metro-config': 0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -12099,7 +12121,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/metro-config@0.84.1(@babel/core@7.29.0)':
+  '@react-native/metro-config@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)':
     dependencies:
       '@react-native/js-polyfills': 0.84.1
       '@react-native/metro-babel-transformer': 0.84.1(@babel/core@7.29.0)
@@ -12107,7 +12129,9 @@ snapshots:
       metro-runtime: 0.83.7
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
     optional: true
 
   '@react-native/metro-config@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0)(utf-8-validate@6.0.4)':
@@ -12128,12 +12152,12 @@ snapshots:
 
   '@react-native/normalize-colors@0.85.3': {}
 
-  '@react-native/virtualized-lists@0.81.4(@types/react@19.2.14)(react-native@0.81.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3))(react@19.2.3)':
+  '@react-native/virtualized-lists@0.81.4(@types/react@19.2.14)(react-native@0.81.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3))(react@19.2.3)':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
       react: 19.2.3
-      react-native: 0.81.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)
+      react-native: 0.81.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.14
 
@@ -16804,16 +16828,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native@0.81.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3):
+  react-native@0.81.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native/assets-registry': 0.81.4
       '@react-native/codegen': 0.81.4(@babel/core@7.29.0)
-      '@react-native/community-cli-plugin': 0.81.4(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(bufferutil@4.1.0)
+      '@react-native/community-cli-plugin': 0.81.4(@react-native/metro-config@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0))(bufferutil@4.1.0)
       '@react-native/gradle-plugin': 0.81.4
       '@react-native/js-polyfills': 0.81.4
       '@react-native/normalize-colors': 0.81.4
-      '@react-native/virtualized-lists': 0.81.4(@types/react@19.2.14)(react-native@0.81.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3))(react@19.2.3)
+      '@react-native/virtualized-lists': 0.81.4(@types/react@19.2.14)(react-native@0.81.4(@babel/core@7.29.0)(@react-native/metro-config@0.84.1(@babel/core@7.29.0)(bufferutil@4.1.0))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3))(react@19.2.3)
       abort-controller: 3.0.0
       anser: 1.4.10
       ansi-regex: 5.0.1

--- a/scripts/deploy-scraper.mjs
+++ b/scripts/deploy-scraper.mjs
@@ -1,0 +1,154 @@
+/**
+ * Deploys the scraper supervisor to big-mac.
+ *
+ * Replaces the previous flow, which was: build an image on the host from
+ * whatever happened to be checked out, then hand-edit the `readonly image=`
+ * line of four separate runner scripts with `sed`. That is how a build of an
+ * unmerged branch ended up running the production backfills.
+ *
+ * The guarantee this script exists to provide is the ancestry check below: a
+ * commit that is not already on `origin/main` cannot be deployed. Images are
+ * built and published by CI (which runs the tests first), so the host only ever
+ * pulls — it has no build path at all.
+ *
+ * Usage:
+ *   node scripts/deploy-scraper.mjs                 # deploy origin/main
+ *   node scripts/deploy-scraper.mjs <sha>           # deploy a specific commit
+ *   node scripts/deploy-scraper.mjs --host other    # non-default ssh host
+ *   node scripts/deploy-scraper.mjs --dry-run       # check without changing the host
+ */
+
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const IMAGE_REPO = "ghcr.io/billion-app/billion-scraper";
+const LABEL = "com.billion.supervisor";
+
+const args = process.argv.slice(2);
+const hostFlag = args.indexOf("--host");
+const host = hostFlag === -1 ? "big-mac" : args[hostFlag + 1];
+const dryRun = args.includes("--dry-run");
+const requested = args.find((arg) => !arg.startsWith("--") && arg !== host);
+
+function git(...gitArgs) {
+  return execFileSync("git", gitArgs, { cwd: repoRoot, encoding: "utf8" }).trim();
+}
+
+function ssh(script) {
+  return execFileSync("ssh", [host, "zsh", "-s"], {
+    input: script,
+    encoding: "utf8",
+  });
+}
+
+function fail(message) {
+  console.error(`\n✗ ${message}\n`);
+  process.exit(1);
+}
+
+console.log(`Fetching origin/main…`);
+execFileSync("git", ["fetch", "origin", "main", "--quiet"], { cwd: repoRoot });
+
+const sha = git("rev-parse", requested ?? "origin/main");
+const subject = git("log", "-1", "--format=%s", sha);
+
+// The whole point of this script. `--is-ancestor` exits non-zero when the
+// commit is not reachable from origin/main, which covers unmerged branches,
+// local-only commits, and anything rewritten out of history.
+try {
+  execFileSync("git", ["merge-base", "--is-ancestor", sha, "origin/main"], {
+    cwd: repoRoot,
+  });
+} catch {
+  fail(
+    `Refusing to deploy ${sha.slice(0, 7)} ("${subject}") — it is not on origin/main.\n` +
+      `  Production runs merged, tested code only. Open a PR and land it first.`,
+  );
+}
+
+const image = `${IMAGE_REPO}:${sha}`;
+console.log(`\nDeploying ${sha.slice(0, 7)} — ${subject}`);
+console.log(`  image: ${image}`);
+console.log(`  host:  ${host}\n`);
+
+// Install the launchd job and wrapper from the repo, so the host never carries
+// a hand-edited copy. Both are overwritten on every deploy by design.
+const wrapper = readFileSync(
+  join(repoRoot, "apps/supervisor/deploy/billion-supervisor"),
+  "utf8",
+);
+const plist = readFileSync(
+  join(repoRoot, "apps/supervisor/deploy/com.billion.supervisor.plist"),
+  "utf8",
+);
+
+if (dryRun) {
+  console.log("--dry-run: commit is deployable; stopping before host changes.\n");
+  process.exit(0);
+}
+
+console.log("Pulling image on host…");
+try {
+  ssh(`
+set -euo pipefail
+export PATH="/usr/local/bin:$HOME/.orbstack/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+docker pull --quiet ${image}
+`);
+} catch {
+  fail(
+    `Could not pull ${image}.\n` +
+      `  CI publishes on push to main; check the run for ${sha.slice(0, 7)} has finished.`,
+  );
+}
+
+console.log("Installing wrapper, plist and image pin…");
+ssh(`
+set -euo pipefail
+mkdir -p "$HOME/.local/bin" "$HOME/.config/billion" "$HOME/Library/LaunchAgents" "$HOME/Library/Logs/billion"
+
+cat > "$HOME/.local/bin/billion-supervisor" <<'WRAPPER_EOF'
+${wrapper}
+WRAPPER_EOF
+chmod 755 "$HOME/.local/bin/billion-supervisor"
+zsh -n "$HOME/.local/bin/billion-supervisor"
+
+cat > "$HOME/Library/LaunchAgents/${LABEL}.plist" <<'PLIST_EOF'
+${plist}
+PLIST_EOF
+
+# Written atomically: a half-written pin would leave the supervisor unable to
+# start on its next launchd restart.
+printf 'SCRAPER_IMAGE=%s\\n' '${image}' > "$HOME/.config/billion/deploy.env.tmp"
+mv "$HOME/.config/billion/deploy.env.tmp" "$HOME/.config/billion/deploy.env"
+`);
+
+console.log("Restarting supervisor…");
+ssh(`
+set -euo pipefail
+launchctl bootstrap "gui/$(id -u)" "$HOME/Library/LaunchAgents/${LABEL}.plist" 2>/dev/null || true
+launchctl kickstart -k "gui/$(id -u)/${LABEL}"
+`);
+
+// Confirm the thing actually came up, rather than reporting success because
+// the commands returned zero.
+await new Promise((resolve) => setTimeout(resolve, 6000));
+const running = ssh(`
+export PATH="/usr/local/bin:$HOME/.orbstack/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+docker ps --filter name=billion-supervisor --format '{{.Image}}' || true
+`).trim();
+
+if (running === image) {
+  console.log(`\n✓ Supervisor running on ${host} at ${sha.slice(0, 7)}\n`);
+  console.log(`  logs:   ssh ${host} 'tail -f ~/Library/Logs/billion/supervisor.log'`);
+  console.log(`  status: ssh ${host} 'cat ~/.local/state/billion/supervisor-state.json'`);
+  console.log(`  run a job now: ssh ${host} 'touch ~/.local/state/billion/requests/<job>'\n`);
+} else {
+  fail(
+    `Supervisor did not come up with the expected image.\n` +
+      `  saw: ${running || "(no container running)"}\n` +
+      `  Check: ssh ${host} 'tail -50 ~/Library/Logs/billion/supervisor.error.log'`,
+  );
+}

--- a/turbo.json
+++ b/turbo.json
@@ -26,6 +26,9 @@
       "dependsOn": ["^topo", "^build"],
       "outputs": [".cache/tsbuildinfo.json"]
     },
+    "test": {
+      "dependsOn": ["^topo", "^build"]
+    },
     "clean": {
       "cache": false
     },


### PR DESCRIPTION
Rewrites how the scrapers are deployed and run, and changes what they scrape day to day.

## Why

On 2026-07-28 three backfills died the moment the SSH session that launched them closed. `backfill-119.log` contains a single header line and no iterations. Nothing noticed. Every failure that night came from the deployment layer, not the scraper logic:

- jobs started by hand over SSH, dying with the shell
- images built on `big-mac` from whatever was checked out — two of them from a branch that was never merged
- four near-identical zsh runners, deployed by `sed` on line 8, with 14 `.bak` files beside them
- CI that never ran the tests

## What changes

**Daily model.** `--recent 100` refreshes the 100 most recently updated bills each day instead of walking the cursor from the start of the congress. The app is a news feed; a bill whose status changed today matters more than a 2025 procedural resolution nothing has touched since. It deliberately never reads or writes `scraper_cursor` — the newest item in a descending window is not a high-water mark, and advancing from it would strand every older bill.

The tradeoff to know: this covers the *head* of the feed. Roughly 250 House bills are updated upstream per day, so a 100-bill window sees recent activity, not every change. Widening it is cheap (~4 API calls per bill against a 5,000/hour key); only enrichment costs money, and that stays capped by `SCRAPER_MAX_NEW_ITEMS_PER_RUN`.

**`apps/supervisor`.** launchd owns one supervisor; the supervisor owns the jobs. Serial execution means two scrapers cannot overlap because there is one queue — not because four scripts each remember to run `docker container inspect` on the others. Schedules, priorities, timeouts, budgets and backoff are typechecked code with 19 tests.

**CI builds the image.** `big-mac` can no longer build at all; it only pulls `ghcr.io/billion-app/billion-scraper:<sha>`. The publish job `needs:` lint/format/typecheck/test, so "only tested code on main reaches production" is a property of the graph. `pnpm deploy:scraper` refuses any commit that is not an ancestor of `origin/main`.

## Two bugs found by running it

**The sort parameter has never been applied.** `URLSearchParams` percent-encodes the `+` in `updateDate+desc` to `%2B`; the API doesn't recognise it and falls back to its default order. The first `--recent 3` run returned bills from January 2025. This also means #232's oldest-first walk has been getting ascending order from an undocumented default rather than from the parameter it thought it was sending.

```
sort=updateDate%2Bdesc  -> 2025-01-13 HRES27, 2025-01-14 HR6
sort=updateDate+desc    -> 2026-07-28 HR8790, 2026-07-28 HR1703
```

**A budget of zero meant ten.** `Number(env) || DEFAULT` treats a configured `0` as absent, so a coverage-only run generated ten items' worth of briefs, research loops and header art. Caught when a run that should have cost nothing ran past a seven-minute timeout.

## No scheduled backfill

The retro jobs are `manual`, and there is no scheduled archive walk. The cursor starts near the beginning of the congress (~17,000 measures) and each enriched bill pays for a brief, a dual-lens research loop and header art. That is a supervised spend, not something a scheduler starts at 3am.

`federalregister`, `scc-cvig` and `ca-sos-statements` are listed as individual weekly jobs rather than reviving `main.js all`, so dropping the `all` run cannot silently stop them.

## Verification

- 65 tests (46 scraper, 19 supervisor), lint, format, typecheck clean
- image built on arm64; supervisor boots inside it and resolves its deps from the shared deploy root
- weekly jobs correctly do *not* fire on first boot; interval jobs do
- failure→backoff, ad-hoc `touch` requests, and clean SIGTERM all exercised against a stub dist
- `--recent 3` run against the local DB: fetched today's bills, cursor unchanged before and after
- deploy script refused an unmerged branch head before contacting the host

## Not in this PR

The cutover itself. `big-mac` still runs `com.billion.scrapers.weekly` on the old image — deliberately, so there is no gap. After merge: CI publishes, then `pnpm deploy:scraper`, then the old job comes out. The GHCR package also needs making public or a `read:packages` token on the host.

Dead runners, `.bak` files, 23 stale images and orphaned processes have already been cleared off `big-mac` (backup at `~/billion-runner-scripts-backup-20260728.tar.gz`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)