### PR TITLE
Image hygiene: stop double-shipping the bundle, keep secrets out of the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# Build context for Dockerfile.scraper (context is the repo root).
+#
+# Nothing here is load-bearing today: every COPY in the Dockerfile names an
+# explicit file or `src/` directory, so none of the paths below can reach the
+# image even without this file. It exists so that stays true. A single
+# `COPY . .` added later — the most natural thing in the world to write — would
+# otherwise sweep the three live secret files in the repo root into a layer of
+# a *public* image, where deleting them in a later layer does not remove them.
+#
+# Keep this list ahead of the Dockerfile, not in sync with it.
+
+# Secrets. The repo root holds real .env, .env.local and .env.prod.
+.env
+.env.*
+!.env.example
+!.env.prod.example
+**/*.pem
+**/*.key
+.netrc
+
+# Dependencies and build output are produced inside the image; copying local
+# copies in would both bloat the context and risk shipping a stale bundle.
+**/node_modules
+**/dist
+**/build
+**/.next
+**/.expo
+**/.turbo
+**/.cache
+.pnpm-store
+
+# Version control, CI and editor state.
+.git
+.gitignore
+.github
+.vscode
+.claude
+.codex
+.vercel
+
+# Local artifacts and scratch output.
+**/*.log
+**/.DS_Store
+artifacts
+deploy
+docs
+*.pdf
+*.html

--- a/Dockerfile.scraper
+++ b/Dockerfile.scraper
@@ -35,7 +35,12 @@ RUN pnpm --filter @acme/scraper build && pnpm --filter @acme/supervisor build
 # sit next to them anyway, and its only external imports are `consola` and
 # `zod` — both already production dependencies of the scraper, so sharing the
 # root costs no extra modules.
+# `pnpm deploy` already places a `dist/` in the deploy root, so copying the
+# built bundle in without clearing it first nests a second complete copy at
+# `dist/dist/`. Harmless at runtime — `node dist/main.js` resolves the right
+# one — but it ships every entrypoint twice.
 RUN pnpm --filter @acme/scraper deploy --prod --legacy /app/deploy && \
+    rm -rf /app/deploy/dist && \
     cp -R apps/scraper/dist /app/deploy/dist && \
     cp apps/supervisor/dist/supervisor.js /app/deploy/dist/supervisor.js
 


### PR DESCRIPTION
Two small build fixes, both found while scanning the newly-public image for leaked credentials.

## The scan result first

The image is clean. No `.env` files, no token in `.npmrc`, no credential-shaped strings in the bundle beyond `packages/env/src/registry.ts`'s documented `postgresql://postgres:postgres@127.0.0.1:54322/postgres` example. Secrets reach the scraper only at runtime via `--env`, so there is no build step that could bake one in.

## 1. The bundle shipped twice

`pnpm deploy` already places a `dist/` in the deploy root, so `cp -R apps/scraper/dist /app/deploy/dist` copied the directory *into* the existing one, producing a complete second copy at `dist/dist/`.

Harmless at runtime — `node dist/main.js` resolves the right one — which is why it went unnoticed. `/app/dist` drops from 600K to 308K.

## 2. A `.dockerignore`

Nothing in the repo root reaches the image today, because every `COPY` names an explicit file or `src/` directory. But that is a property of how the Dockerfile currently happens to be written, not a guarantee — and the root holds three live secret files (`.env`, `.env.local`, `.env.prod`).

One `COPY . .`, the most natural line in the world to add, would sweep all three into a layer of an image that is now **public**, where deleting them in a later layer does not remove them. This makes the filtering a property of the context instead.

It also drops `node_modules`, build output and the pnpm store from the context, which was most of what got uploaded to the daemon on every build.

## Verification

Built locally on arm64:

- `dist/dist` gone; `/app/dist` is 308K
- `find / -name ".env*"` returns nothing
- supervisor boots inside the image and lists the expected 7 jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)