### PR TITLE
Add a manual supervisor job for bills left without assets

### DIFF
--- a/apps/supervisor/src/config.ts
+++ b/apps/supervisor/src/config.ts
@@ -98,6 +98,34 @@ export const jobs: readonly JobDefinition[] = [
     priority: 30,
     timeoutMinutes: 6 * 60,
   },
+  {
+    id: "reprocess-bare",
+    description: "Fill in bills left without an article or header art",
+    script: "reprocess-content.js",
+    // `--mode missing` selects only rows whose derived assets are actually
+    // incomplete, so a run costs nothing once there is nothing left to fix.
+    // Deliberately no `--limit`: the selection is already the bound, and a
+    // limit would silently leave a remainder that nothing tracks.
+    //
+    // `--apply` and `--yes` are required for it to write at all; without them
+    // the command is read-only, which would make this job a slow no-op.
+    args: [
+      "--type",
+      "bill",
+      "--mode",
+      "missing",
+      "--concurrency",
+      "3",
+      "--apply",
+      "--yes",
+    ],
+    // Manual, and it should stay manual. Unlike the retro jobs this one can
+    // rewrite assets across the whole archive if the selection policy widens,
+    // so it wants a human deciding when it runs.
+    schedule: { kind: "manual" },
+    priority: 31,
+    timeoutMinutes: 8 * 60,
+  },
 ];
 
 export function findJob(jobId: string): JobDefinition | undefined {


### PR DESCRIPTION
Today's first `congress-daily` run inserted 76 bills but only had budget to enrich 25, leaving **54 in the app with no header art and no article** — visible at the top of Browse, since it sorts by recent.

#243 stops this recurring: a new bill past budget is no longer stored at all. It does not repair rows already written, which is what this job is for.

## Scope is bounded

`reprocess-content --mode missing` selects only rows whose derived assets are genuinely incomplete. Measured against prod:

```
total bills       832
null article       54
bad headings        2
no video image     54
would reprocess    56
```

So 56 rows, not the archive. Once there is nothing left to fix the job costs nothing, which is why it needs no `--limit` — the selection is already the bound, and a limit would silently leave a remainder nothing tracks.

## Why a supervisor job rather than a one-off `docker run`

Two reasons, both learned the hard way on 2026-07-28:

- a detached one-off dies with the SSH session that started it
- it would write concurrently with the 03:15 daily run; the supervisor's queue serialises them instead

## Manual, and staying manual

Unlike the retro jobs, this one can rewrite assets across the whole archive if the selection policy ever widens. It wants a human deciding when it runs.

```sh
ssh big-mac 'touch ~/.local/state/billion/requests/reprocess-bare'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)