### PR TITLE
A bill is never visible until it is complete

### DIFF
--- a/apps/scraper/src/utils/db/new-bill-readiness.test.ts
+++ b/apps/scraper/src/utils/db/new-bill-readiness.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { newBillReadiness } from "./operations.js";
+
+/**
+ * These assertions describe what a reader would see if the rule were loosened.
+ * A bill that fails any of them renders as a grey "bill · header art"
+ * placeholder above a wall of raw GPO text — which is the state that prompted
+ * this path to exist, not a hypothetical.
+ */
+
+// Long enough and prose-like enough to pass `isUsableSourceText`.
+const usableText = `A BILL To amend title 18 of the United States Code to do
+a specific thing that is described here at sufficient length to read as real
+legislative prose rather than boilerplate. It contains several sentences so the
+usability heuristic does not reject it as a header-only fragment. ${"Additional substantive text. ".repeat(
+  8,
+)}`;
+
+const complete = {
+  description: "This bill would require hospitals to publish their prices.",
+  fullText: usableText,
+  hasBrief: true,
+  headerArt: { imageData: Buffer.from("jpeg"), thumbnailUrl: null },
+};
+
+test("a bill with description, text, brief and art is ready", () => {
+  assert.deepEqual(newBillReadiness(complete), { ready: true });
+});
+
+test("a scraped thumbnail counts as header art", () => {
+  // Either one renders; only the absence of both shows the placeholder.
+  const result = newBillReadiness({
+    ...complete,
+    headerArt: { imageData: null, thumbnailUrl: "https://example.gov/i.jpg" },
+  });
+  assert.equal(result.ready, true);
+});
+
+test("art generation producing neither image nor thumbnail blocks the bill", () => {
+  const result = newBillReadiness({
+    ...complete,
+    headerArt: { imageData: null, thumbnailUrl: null },
+  });
+  assert.equal(result.ready, false);
+  assert.match(result.reason!, /header art/);
+});
+
+test("art generation failing outright blocks the bill", () => {
+  const result = newBillReadiness({ ...complete, headerArt: null });
+  assert.equal(result.ready, false);
+  assert.match(result.reason!, /header art/);
+});
+
+test("a missing brief blocks the bill", () => {
+  // Without a brief the detail screen falls back to the legacy article, which
+  // bills no longer generate — so the reader gets raw GPO text.
+  const result = newBillReadiness({ ...complete, hasBrief: false });
+  assert.equal(result.ready, false);
+  assert.match(result.reason!, /brief/);
+});
+
+test("a blank or whitespace description blocks the bill", () => {
+  for (const description of [undefined, null, "", "   "]) {
+    const result = newBillReadiness({ ...complete, description });
+    assert.equal(result.ready, false, `description ${JSON.stringify(description)}`);
+    assert.match(result.reason!, /description/);
+  }
+});
+
+test("unusable source text blocks the bill", () => {
+  for (const fullText of [undefined, null, "", "SHORT"]) {
+    const result = newBillReadiness({ ...complete, fullText });
+    assert.equal(result.ready, false, `fullText ${JSON.stringify(fullText)}`);
+    assert.match(result.reason!, /text/);
+  }
+});

--- a/apps/scraper/src/utils/db/operations.ts
+++ b/apps/scraper/src/utils/db/operations.ts
@@ -183,10 +183,21 @@ export async function upsertContent(
   let shouldGenerateArticle = false;
   let shouldGenerateImage = false;
 
+  // Bills are served from their structured brief, not from the long-form
+  // article. `article-detail.tsx` renders the brief whenever one exists and
+  // only falls back to `aiGeneratedArticle` (then to raw GPO text) when it does
+  // not — which is exactly the unreadable state this change removes. Generating
+  // both means paying for a wall of prose that nothing displays.
+  //
+  // The column and the `priorArticle` input stay: existing rows still hold
+  // articles worth using as framing context, and court cases and executive
+  // actions have no brief schema yet, so they still depend on it.
+  const generatesArticle = input.type !== "bill";
+
   let progressKind: "new" | "changed" | "unchanged";
   if (!existing) {
     shouldGenerateSummary = !sourceDescription && hasSummarySource;
-    shouldGenerateArticle = hasUsableText;
+    shouldGenerateArticle = generatesArticle && hasUsableText;
     shouldGenerateImage = hasUsableText;
     progressKind = "new";
     logger.info(`New ${label} detected`);
@@ -194,9 +205,9 @@ export async function upsertContent(
     shouldGenerateSummary = forceAIRegeneration
       ? !sourceDescription && hasSummarySource
       : !hasPersistedSummary && !sourceDescription && hasSummarySource;
-    shouldGenerateArticle = forceAIRegeneration
-      ? hasUsableText
-      : hasUsableText && !existing.hasArticle;
+    shouldGenerateArticle =
+      generatesArticle &&
+      (forceAIRegeneration ? hasUsableText : hasUsableText && !existing.hasArticle);
     shouldGenerateImage =
       (forceAIRegeneration || !existing.hasThumbnail) && hasUsableText;
     progressKind = "changed";
@@ -205,9 +216,9 @@ export async function upsertContent(
     shouldGenerateSummary = forceAIRegeneration
       ? !sourceDescription && hasSummarySource
       : !hasPersistedSummary && !sourceDescription && hasSummarySource;
-    shouldGenerateArticle = forceAIRegeneration
-      ? hasUsableText
-      : hasUsableText && !existing.hasArticle;
+    shouldGenerateArticle =
+      generatesArticle &&
+      (forceAIRegeneration ? hasUsableText : hasUsableText && !existing.hasArticle);
     shouldGenerateImage =
       (forceAIRegeneration || !existing.hasThumbnail) && hasUsableText;
     progressKind = "unchanged";

--- a/apps/scraper/src/utils/db/operations.ts
+++ b/apps/scraper/src/utils/db/operations.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { and, eq } from "@acme/db";
 import { db } from "@acme/db/client";
 import {
@@ -46,8 +48,14 @@ import {
   incrementImagesSearched,
   incrementNewEntries,
   incrementTotalProcessed,
+  incrementVideosGenerated,
 } from "./metrics.js";
-import { generateVideoForContent } from "./video-operations.js";
+import type { BuiltVideoRecord, DbExecutor } from "./video-operations.js";
+import {
+  buildVideoRecord,
+  generateVideoForContent,
+  persistVideoRecord,
+} from "./video-operations.js";
 
 const logger = createLogger("db");
 const forceAIRegeneration = process.env.SCRAPER_FORCE_AI_REGEN === "1";
@@ -286,6 +294,41 @@ export async function upsertContent(
       throw new Error(`AI returned an empty required summary for ${label}`);
     }
     shouldGenerateSummary = false;
+  }
+
+  // A bill we have never stored is assembled completely before anything is
+  // written. Everything below this point in the ordinary path writes the row
+  // first and enriches afterwards, which leaves the bill visible — titled,
+  // described, but with a grey placeholder where its header art belongs and raw
+  // GPO text under "Plain explainer" — for the two to four minutes its assets
+  // take to generate. For an existing bill that is the right trade, because the
+  // row is already public and refreshing it in place only improves it. For a
+  // new one it means publishing something unfinished, which is what this path
+  // exists to prevent.
+  //
+  // The id is minted here rather than by the database so the brief and the
+  // video can reference the bill before it exists, and all three rows land in
+  // one transaction.
+  if (!existing && input.type === "bill" && !budgetExhausted) {
+    const assembled = await assembleNewBill({
+      data: input.data,
+      contentHash: newContentHash,
+      description: preGeneratedDescription,
+      label,
+      claimBudget,
+    });
+
+    if (assembled.status !== "ready") {
+      // Nothing was written, so there is nothing to roll back. The bill keeps
+      // its place in the feed and the next run tries the whole thing again.
+      logger.warn(`${label}: ${assembled.reason} — not storing it this run`);
+      tickProgress({ newEntries: 0, unchanged: 0, changed: 0 });
+      return { status: "deferred", reason: assembled.reason };
+    }
+
+    incrementNewEntries();
+    tickProgress({ newEntries: 1, unchanged: 0, changed: 0 });
+    return { status: "written", id: assembled.id };
   }
 
   if (progressKind === "new") incrementNewEntries();
@@ -753,6 +796,254 @@ export async function upsertContentLens(
  * unchanged bills never re-pay — same caching contract as `upsertContentLens`.
  * AIRateLimitError propagates to the caller's rate-limit handler.
  */
+type AssembleResult =
+  | { status: "ready"; id: string }
+  | { status: "incomplete"; reason: string };
+
+/**
+ * What a brand-new bill must have before it is allowed into the database.
+ *
+ * Exported and pure so the rule is testable and hard to loosen by accident:
+ * every condition here corresponds to something a reader would otherwise see
+ * broken on the detail screen. Loosening one brings back the placeholder art
+ * and raw-GPO-text state this path exists to prevent.
+ *
+ * The dual lens is deliberately absent. It is additive, its research loop can
+ * legitimately return nothing, and the UI omits it cleanly — gating on it would
+ * suppress good bills for a reason no reader would ever notice.
+ */
+export function newBillReadiness(candidate: {
+  description?: string | null;
+  fullText?: string | null;
+  hasBrief: boolean;
+  headerArt: { imageData: Buffer | null; thumbnailUrl: string | null } | null;
+}): { ready: boolean; reason?: string } {
+  if (!candidate.description?.trim()) {
+    return { ready: false, reason: "no description could be produced" };
+  }
+  if (!isUsableSourceText(candidate.fullText)) {
+    return { ready: false, reason: "no usable bill text yet" };
+  }
+  if (!candidate.hasBrief) {
+    return { ready: false, reason: "brief generation failed" };
+  }
+  if (!candidate.headerArt) {
+    return { ready: false, reason: "header art generation failed" };
+  }
+  // Generated art or a scraped thumbnail both render; neither means the reader
+  // gets the grey placeholder.
+  if (!candidate.headerArt.imageData && !candidate.headerArt.thumbnailUrl) {
+    return { ready: false, reason: "no header art could be produced" };
+  }
+  return { ready: true };
+}
+
+/**
+ * Build every required asset for a brand-new bill, then write the bill, its
+ * header art and its brief in a single transaction.
+ *
+ * "Required" is deliberately narrow: a description, a structured brief, and
+ * header art. Those are what the detail screen renders — without them a reader
+ * gets a grey placeholder and a wall of raw GPO text, which is worse than the
+ * bill simply not being there yet. The dual lens is *not* required: it runs an
+ * agentic research loop that can legitimately come back empty, and the UI
+ * degrades cleanly without it, so gating on it would suppress good bills for a
+ * reason readers would never see.
+ *
+ * Nothing here writes until every required piece exists, so a failure at any
+ * point leaves the database exactly as it was. There is no partial row to clean
+ * up and no window in which a reader can see an unfinished bill.
+ */
+async function assembleNewBill(args: {
+  data: BillData;
+  contentHash: string;
+  description?: string;
+  label: string;
+  claimBudget: () => boolean;
+}): Promise<AssembleResult> {
+  const { data, contentHash, label } = args;
+  const description = args.description ?? data.description;
+
+  // Cheap preconditions first, so a bill that can never be completed this run
+  // does not spend budget or a generation call finding that out. The brief and
+  // art are stubbed as present here because they have not been attempted yet —
+  // the same rule runs again for real once they have.
+  const precheck = newBillReadiness({
+    description,
+    fullText: data.fullText,
+    hasBrief: true,
+    headerArt: { imageData: null, thumbnailUrl: "pending" },
+  });
+  if (!precheck.ready) {
+    return { status: "incomplete", reason: precheck.reason! };
+  }
+  // Narrowing for the compiler; `newBillReadiness` already rejected both.
+  if (!description || !data.fullText) {
+    return { status: "incomplete", reason: "missing description or text" };
+  }
+  if (!args.claimBudget()) {
+    return { status: "incomplete", reason: "run budget reached" };
+  }
+
+  const billId = randomUUID();
+
+  logger.start(`Assembling ${label} before storing it`);
+
+  const brief = await buildBillBriefRecord({
+    title: data.title,
+    billNumber: data.billNumber,
+    url: data.url,
+    fullText: data.fullText,
+    officialSummary: data.summary,
+    status: data.status,
+  });
+  if (!brief) {
+    return { status: "incomplete", reason: "brief generation failed" };
+  }
+
+  const video = await buildVideoRecord(
+    "bill",
+    data.title,
+    data.fullText,
+    contentHash,
+    data.sourceWebsite,
+  );
+
+  const readiness = newBillReadiness({
+    description,
+    fullText: data.fullText,
+    hasBrief: Boolean(brief),
+    headerArt: video,
+  });
+  if (!readiness.ready || !video) {
+    return {
+      status: "incomplete",
+      reason: readiness.reason ?? "header art generation failed",
+    };
+  }
+
+  // Every required asset now exists in memory. The single transaction below is
+  // the first and only write: either the bill, its art and its brief all become
+  // visible together, or none of them ever existed.
+  await db.transaction(async (tx) => {
+    await tx.insert(Bill).values({
+      ...data,
+      id: billId,
+      description: clampBillDescription(description),
+      contentHash,
+      versions: [],
+    });
+    await persistVideoRecord(tx, "bill", billId, video);
+    await persistBillBrief(tx, billId, contentHash, brief);
+  });
+
+  incrementVideosGenerated();
+  logger.success(`${label} stored complete (brief + header art)`);
+
+  // The lens comes after the commit, on purpose. It is additive rather than
+  // required, so it must not be able to hold back a bill that is otherwise
+  // complete — and its research loop is far slower than everything above, so
+  // running it inside the transaction would hold a connection open for minutes.
+  // A failure here leaves a complete bill with no lens, which `retroactive-
+  // lenses` fills in later.
+  try {
+    await upsertContentLens(
+      billId,
+      "bill",
+      contentHash,
+      data.title,
+      data.fullText,
+      "bill",
+      null,
+      args.claimBudget,
+    );
+  } catch (error) {
+    logger.warn(
+      `Dual lens failed for ${label} — the bill is stored and complete without it: ${
+        error instanceof Error ? error.message : error
+      }`,
+    );
+  }
+
+  return { status: "ready", id: billId };
+}
+
+/**
+ * A structured brief, generated but not yet stored.
+ *
+ * Split out for the same reason as the video record: a bill's assets are all
+ * produced before any row exists, so the bill can be written complete in one
+ * transaction rather than appearing and then filling in.
+ */
+export interface BuiltBillBrief {
+  brief: NonNullable<Awaited<ReturnType<typeof generateBillBrief>>> & {
+    generatedAt: string;
+    modelVersion: string;
+  };
+  modelVersion: string;
+}
+
+/** Generate a brief in memory. Returns null when generation fails. */
+export async function buildBillBriefRecord(args: {
+  title: string;
+  billNumber: string;
+  url: string;
+  fullText: string;
+  officialSummary?: string | null;
+  status?: string | null;
+  priorArticle?: string | null;
+}): Promise<BuiltBillBrief | null> {
+  const generated = await generateBillBrief({
+    title: args.title,
+    billNumber: args.billNumber,
+    url: args.url,
+    fullText: args.fullText,
+    officialSummary: args.officialSummary,
+    status: args.status,
+    priorArticle: args.priorArticle,
+  });
+  if (!generated) {
+    logger.warn(`Brief generation returned null for ${args.billNumber}`);
+    return null;
+  }
+
+  const modelVersion = getTextModelVersion();
+  return {
+    brief: { ...generated, generatedAt: new Date().toISOString(), modelVersion },
+    modelVersion,
+  };
+}
+
+/**
+ * Write a previously built brief. Takes an executor so it can run inside the
+ * same transaction as the bill row it describes.
+ */
+export async function persistBillBrief(
+  executor: DbExecutor,
+  contentId: string,
+  contentHash: string,
+  record: BuiltBillBrief,
+): Promise<void> {
+  await executor
+    .insert(ContentBrief)
+    .values({
+      contentId,
+      contentType: "bill",
+      contentHash,
+      brief: record.brief,
+      modelVersion: record.modelVersion,
+    })
+    .onConflictDoUpdate({
+      target: [ContentBrief.contentType, ContentBrief.contentId],
+      set: {
+        contentHash,
+        brief: record.brief,
+        modelVersion: record.modelVersion,
+        updatedAt: new Date(),
+      },
+    });
+}
+
 export async function upsertBillBrief(args: {
   contentId: string;
   contentHash: string;
@@ -796,44 +1087,10 @@ export async function upsertBillBrief(args: {
     return false;
   }
 
-  const generated = await generateBillBrief({
-    title: args.title,
-    billNumber: args.billNumber,
-    url: args.url,
-    fullText: args.fullText,
-    officialSummary: args.officialSummary,
-    status: args.status,
-    priorArticle: args.priorArticle,
-  });
-  if (!generated) {
-    logger.warn(`Brief generation returned null for ${args.billNumber}`);
-    return false;
-  }
+  const record = await buildBillBriefRecord(args);
+  if (!record) return false;
 
-  const modelVersion = getTextModelVersion();
-  const brief = {
-    ...generated,
-    generatedAt: new Date().toISOString(),
-    modelVersion,
-  };
-  await db
-    .insert(ContentBrief)
-    .values({
-      contentId: args.contentId,
-      contentType: "bill",
-      contentHash: args.contentHash,
-      brief,
-      modelVersion,
-    })
-    .onConflictDoUpdate({
-      target: [ContentBrief.contentType, ContentBrief.contentId],
-      set: {
-        contentHash: args.contentHash,
-        brief,
-        modelVersion,
-        updatedAt: new Date(),
-      },
-    });
+  await persistBillBrief(db, args.contentId, args.contentHash, record);
 
   logger.success(`Cached brief for ${args.billNumber}`);
   return true;

--- a/apps/scraper/src/utils/db/video-operations.ts
+++ b/apps/scraper/src/utils/db/video-operations.ts
@@ -65,6 +65,149 @@ export interface GenerateVideoResult {
 }
 
 /**
+ * A video row's worth of content, produced without touching the database.
+ *
+ * Header art is the slowest asset to generate and the most visible when it is
+ * missing — a grey placeholder occupying the top third of the detail screen.
+ * Separating "make it" from "store it" lets a caller finish every asset before
+ * any row exists, so a bill is never briefly visible without its art.
+ */
+export interface BuiltVideoRecord {
+  title: string;
+  description: string;
+  imageData: Buffer | null;
+  imageMimeType: string | null;
+  thumbnailUrl: string | null;
+  author: string;
+  engagementMetrics: { likes: number; comments: number; shares: number };
+  sourceContentHash: string;
+}
+
+/**
+ * Anything that can run an insert — the pool, or a transaction handle.
+ * Structural so a caller can pass `db` or a `tx` without this module needing to
+ * know which.
+ */
+export type DbExecutor = Pick<typeof db, "insert">;
+
+/**
+ * Generate marketing copy and header art in memory.
+ *
+ * Returns `null` only when copy generation fails outright; a missing image is
+ * represented by `imageData: null` rather than a failure, because a scraped
+ * `thumbnailUrl` is an acceptable substitute and the caller decides whether
+ * that is good enough.
+ */
+export async function buildVideoRecord(
+  contentType: "bill" | "government_content" | "court_case",
+  title: string,
+  fullText: string,
+  contentHash: string,
+  author: string,
+  thumbnailUrl?: string | null,
+  hasExistingImage = false,
+): Promise<BuiltVideoRecord | null> {
+  const marketingCopy = await generateMarketingCopy(
+    title,
+    fullText,
+    contentType,
+  );
+  if (!marketingCopy) return null;
+
+  let imageData: Buffer | null = null;
+  let imageMimeType: string | null = null;
+  let generatedImage = await generateImage(marketingCopy.imagePrompt);
+
+  if (!generatedImage && !thumbnailUrl && !hasExistingImage) {
+    const safeFallbackPrompt =
+      contentType === "court_case"
+        ? "A richly illustrated civic tableau: a monumental courthouse transformed into a balancing scale, with expressive citizens, legal folders, and story clues arranged across the steps in a bold, slightly surreal composition."
+        : contentType === "bill"
+          ? "A richly illustrated civic machine built around the United States Capitol, with gears, expressive citizens, symbolic objects, and layered policy clues in a colorful, witty, slightly surreal composition."
+          : "A richly illustrated civic tableau where a government building opens into a miniature world of expressive people and story-specific public-life details, colorful, layered, witty, and slightly surreal.";
+    logger.warn(
+      `Primary image unavailable for ${contentType}; trying an illustrated fallback`,
+    );
+    generatedImage = await generateImage(safeFallbackPrompt);
+  }
+
+  if (generatedImage) {
+    imageData = await convertToJpeg(generatedImage.data);
+    imageMimeType = "image/jpeg";
+  }
+
+  return {
+    // Hard-truncate to the DB constraint (varchar 100) as a safety net in case
+    // the AI schema validation ever drifts from the DB schema again.
+    title: marketingCopy.title.substring(0, 100),
+    description: marketingCopy.description,
+    imageData,
+    imageMimeType,
+    thumbnailUrl: thumbnailUrl ?? null,
+    author,
+    engagementMetrics: {
+      likes: Math.floor(Math.random() * 50000) + 1000,
+      comments: Math.floor(Math.random() * 2000) + 50,
+      shares: Math.floor(Math.random() * 1000) + 10,
+    },
+    sourceContentHash: contentHash,
+  };
+}
+
+/**
+ * Write a previously built video record. Takes an executor so it can run inside
+ * the same transaction as the content row it belongs to.
+ */
+export async function persistVideoRecord(
+  executor: DbExecutor,
+  contentType: "bill" | "government_content" | "court_case",
+  contentId: string,
+  record: BuiltVideoRecord,
+  options: { preserveCopy?: boolean } = {},
+): Promise<void> {
+  // Never erase a working image when a replacement provider fails.
+  const replacementImage = record.imageData
+    ? {
+        imageData: record.imageData,
+        imageMimeType: record.imageMimeType,
+        imageWidth: 1024,
+        imageHeight: 1024,
+      }
+    : record.thumbnailUrl
+      ? { thumbnailUrl: record.thumbnailUrl }
+      : {};
+
+  await executor
+    .insert(Video)
+    .values({
+      contentType,
+      contentId,
+      title: record.title,
+      description: record.description,
+      imageData: record.imageData,
+      imageMimeType: record.imageMimeType,
+      imageWidth: record.imageData ? 1024 : null,
+      imageHeight: record.imageData ? 1024 : null,
+      thumbnailUrl: record.thumbnailUrl ?? undefined,
+      author: record.author,
+      engagementMetrics: record.engagementMetrics,
+      sourceContentHash: record.sourceContentHash,
+    })
+    .onConflictDoUpdate({
+      target: [Video.contentType, Video.contentId],
+      set: {
+        ...(!options.preserveCopy && {
+          title: record.title,
+          description: record.description,
+        }),
+        ...replacementImage,
+        sourceContentHash: record.sourceContentHash,
+        updatedAt: new Date(),
+      },
+    });
+}
+
+/**
  * Generate or update video content for a source item
  * @param contentType - Type of content (bill, government_content, court_case)
  * @param contentId - UUID of the source content
@@ -111,93 +254,32 @@ export async function generateVideoForContent(
 
   logger.start(`Generating video for ${contentType}:${contentId}`);
 
-  // Generate marketing copy
-  const marketingCopy = await generateMarketingCopy(
+  const record = await buildVideoRecord(
+    contentType,
     title,
     fullText,
-    contentType,
+    contentHash,
+    author,
+    thumbnailUrl,
+    existing?.hasImage ?? false,
   );
 
-  // Generate and convert image
-  let imageData: Buffer | null = null;
-  let imageMimeType: string | null = null;
-  let generatedImage = await generateImage(marketingCopy.imagePrompt);
-  if (!generatedImage && !thumbnailUrl && !existing?.hasImage) {
-    const safeFallbackPrompt =
-      contentType === "court_case"
-        ? "A richly illustrated civic tableau: a monumental courthouse transformed into a balancing scale, with expressive citizens, legal folders, and story clues arranged across the steps in a bold, slightly surreal composition."
-        : contentType === "bill"
-          ? "A richly illustrated civic machine built around the United States Capitol, with gears, expressive citizens, symbolic objects, and layered policy clues in a colorful, witty, slightly surreal composition."
-          : "A richly illustrated civic tableau where a government building opens into a miniature world of expressive people and story-specific public-life details, colorful, layered, witty, and slightly surreal.";
-    logger.warn(
-      `Primary image unavailable for ${contentType}:${contentId}; trying an illustrated fallback`,
-    );
-    generatedImage = await generateImage(safeFallbackPrompt);
+  if (!record) {
+    logger.warn(`Marketing copy unavailable for ${contentType}:${contentId}`);
+    incrementVideosSkipped();
+    return { regenerated: false, hasImage: existing?.hasImage ?? false };
   }
-  if (generatedImage) {
-    imageData = await convertToJpeg(generatedImage.data);
-    imageMimeType = "image/jpeg";
-  }
-
-  // Random engagement metrics (same as current video.ts)
-  const engagementMetrics = {
-    likes: Math.floor(Math.random() * 50000) + 1000,
-    comments: Math.floor(Math.random() * 2000) + 50,
-    shares: Math.floor(Math.random() * 1000) + 10,
-  };
-
-  // Upsert video with hybrid image support
-  // Hard-truncate title to DB constraint (varchar 100) as a safety net in case
-  // the AI schema validation ever drifts from the DB schema again
-  const safeTitle = marketingCopy.title.substring(0, 100);
 
   try {
-    const replacementImage = imageData
-      ? {
-          imageData,
-          imageMimeType,
-          imageWidth: 1024,
-          imageHeight: 1024,
-        }
-      : thumbnailUrl
-        ? { thumbnailUrl }
-        : {};
-
-    await db
-      .insert(Video)
-      .values({
-        contentType,
-        contentId,
-        title: safeTitle,
-        description: marketingCopy.description,
-        imageData,
-        imageMimeType,
-        imageWidth: imageData ? 1024 : null,
-        imageHeight: imageData ? 1024 : null,
-        thumbnailUrl: thumbnailUrl ?? undefined, // Add URL-based thumbnail support
-        author,
-        engagementMetrics,
-        sourceContentHash: contentHash,
-      })
-      .onConflictDoUpdate({
-        target: [Video.contentType, Video.contentId],
-        set: {
-          ...(!options.preserveCopy && {
-            title: safeTitle,
-            description: marketingCopy.description,
-          }),
-          // Never erase a working image when a replacement provider fails.
-          ...replacementImage,
-          sourceContentHash: contentHash,
-          updatedAt: new Date(),
-        },
-      });
+    await persistVideoRecord(db, contentType, contentId, record, options);
 
     incrementVideosGenerated();
     logger.success(`Video generated for ${contentType}:${contentId}`);
     return {
       regenerated: true,
-      hasImage: Boolean(imageData || thumbnailUrl || existing?.hasImage),
+      hasImage: Boolean(
+        record.imageData || record.thumbnailUrl || existing?.hasImage,
+      ),
     };
   } catch (error) {
     // Build a sanitized error message — the raw DB error embeds binary image

--- a/apps/scraper/src/utils/new-item-limit.ts
+++ b/apps/scraper/src/utils/new-item-limit.ts
@@ -1,10 +1,14 @@
 /**
- * Caps how many brand-new items a single scraper run will fully process
- * (AI summary/article/image generation). Items beyond the cap are still saved
- * with their raw content — the scraper's incremental cursor advances past
- * everything it fetched, so an item that is not persisted here is lost rather
- * than deferred. They roll over as "backfill" work for the retroactive
- * scripts (`backfill-bill-descriptions`, `retroactive-briefs`, ...).
+ * Caps how many items a single scraper run will generate for.
+ *
+ * One item draws at most one slot however many assets it produces, and only
+ * when something is actually generated — a fully cached item costs nothing.
+ *
+ * Note this is a cap on *ingestion*, not only on spend. An item that cannot be
+ * completed within the budget is not stored at all; it is reported `deferred`
+ * so the cursor holds and the next run attempts the whole thing again. Raising
+ * or lowering this therefore changes how fast the database keeps up with the
+ * source, not just what a run costs.
  */
 
 export interface NewItemLimiter {


### PR DESCRIPTION
> at no point in time should a user be able to see an unfinished bill

## The problem

The row was written first and enriched afterwards. For the two to four minutes its assets took to generate, a new bill sat at the top of Browse — titled and described, with a grey `bill · header art` placeholder occupying the top third of the detail screen and raw GPO text under "Plain explainer":

```
[Congressional Bills 119th Congress]
[From the U.S. Government Publishing Office]
[S. 2955 Introduced in Senate (IS)] <DOC> 119th CONGRESS 1st Session...
```

#243 closed the case where budget ran out (the bill is no longer stored at all) and the case where enrichment threw (the row is rolled back). It did not close the ordinary success path, where the row is simply visible before its assets exist. Header art was additionally exempt by design — its failure was caught, logged as "content was saved successfully", and the item still reported `written`.

## The change

A brand-new bill is assembled entirely in memory, then written once:

```
description → structured brief → header art
                                      ↓
              ONE transaction: bill + video + content_brief
```

Either all three become visible together or none of them ever existed. The id is minted with `randomUUID` rather than by the database, so the brief and the art can reference the bill before it exists.

To make that possible, generation is separated from persistence — `buildVideoRecord` / `buildBillBriefRecord` produce records without touching the database, and `persistVideoRecord` / `persistBillBrief` take an executor so they can run inside the transaction. The existing upsert functions compose both halves, so there is still one code path.

**Only new bills take this route.** An existing row is already public, so refreshing it in place only improves it, and holding a transaction open for the minutes enrichment takes would cost a connection for nothing.

## What counts as complete

Required: description, structured brief, header art. Each corresponds to something a reader would otherwise see broken.

The **dual lens is deliberately not required** and runs after the commit. Its research loop can legitimately return nothing, and the UI omits it cleanly — gating on it would suppress good bills for a reason no reader would ever notice.

`newBillReadiness` is exported and pure so the rule is testable and hard to loosen by accident.

## Bills no longer generate the legacy article

`article-detail.tsx` renders the brief whenever one exists and only falls back to `aiGeneratedArticle` — then to raw text — when it does not. Now that a bill cannot be stored without a brief, the article was being generated, paid for and never displayed. Removing it drops one LLM call per bill from every run.

The column and the `priorArticle` input stay: existing rows still hold articles worth using as framing context, and court cases and executive actions have no brief schema yet.

**Worth knowing:** the brief generator took the article as an input, described in its prompt as prior analysis whose judgments to reuse. Briefs for new bills are now built from the official text and the CRS summary alone. That is a change in brief inputs, not just a deletion — flagging it rather than burying it.

## Verification

Run against a local database with `--recent 6` and a budget of 2:

```
[db] ◐ Assembling bill H.R. 2332 before storing it
[db] ✔ bill H.R. 2332 stored complete (brief + header art)
[db] ℹ bill S. 1414: run budget reached before it could be enriched — not storing it
[db] ℹ bill H.R. 3108: run budget reached before it could be enriched — not storing it
   Total Processed 6 · New Entries 1 · AI Articles Generated 0
```

The stored bill: `art=1 brief=1 lens=1`, no legacy article. The four refused bills left no rows behind. Afterwards every bill in the database has both art and a brief.

57 scraper tests, plus lint, format and typecheck across the workspace.

## Also

Corrects the `new-item-limit.ts` header, which still claimed over-budget items are saved with their raw content and described a cursor that advances past everything fetched. Neither has been true since #243, and the number now caps ingestion rather than only spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)