### PR TITLE
Teach the reprocessing tools about structured briefs

### DIFF
--- a/apps/scraper/src/reprocess-content.ts
+++ b/apps/scraper/src/reprocess-content.ts
@@ -4,7 +4,13 @@ import { hideBin } from "yargs/helpers";
 
 import { and, asc, eq, gt } from "@acme/db";
 import { db } from "@acme/db/client";
-import { Bill, CourtCase, GovernmentContent, Video } from "@acme/db/schema";
+import {
+  Bill,
+  ContentBrief,
+  CourtCase,
+  GovernmentContent,
+  Video,
+} from "@acme/db/schema";
 
 import type { ReprocessMode } from "./utils/reprocessing-policy.js";
 import { databaseTarget, databaseTargetMessage } from "./env.js";
@@ -15,7 +21,7 @@ import {
 } from "./utils/ai/text-generation.js";
 import { getThumbnailImage } from "./utils/api/google-images.js";
 import { getCostSummary, resetCosts } from "./utils/costs.js";
-import { upsertContentLens } from "./utils/db/operations.js";
+import { upsertBillBrief, upsertContentLens } from "./utils/db/operations.js";
 import { generateVideoForContent } from "./utils/db/video-operations.js";
 import { createContentHash } from "./utils/hash.js";
 import {
@@ -29,6 +35,7 @@ import {
   isUsableAIArticle,
   isUsableSourceText,
   needsReprocessing,
+  requiresBrief,
 } from "./utils/reprocessing-policy.js";
 import { refreshSourceText } from "./utils/source-refresh.js";
 
@@ -51,6 +58,11 @@ interface ContentItem {
   videoId: string | null;
   videoImageData: Buffer | null;
   videoThumbnailUrl: string | null;
+  /** Structured brief presence. Always false for types that have no brief. */
+  hasBrief: boolean;
+  billNumber: string | null;
+  officialSummary: string | null;
+  status: string | null;
 }
 
 interface ProcessResult {
@@ -62,8 +74,10 @@ interface ProcessResult {
 
 function rowState(item: ContentItem) {
   return {
+    contentType: item.type,
     fullText: item.fullText,
     aiGeneratedArticle: item.aiGeneratedArticle,
+    hasBrief: item.hasBrief,
     videoId: item.videoId,
     videoImageData: item.videoImageData,
     videoThumbnailUrl: item.videoThumbnailUrl,
@@ -88,20 +102,32 @@ async function loadContentItems(
         videoId: Video.id,
         videoImageData: Video.imageData,
         videoThumbnailUrl: Video.thumbnailUrl,
+        briefId: ContentBrief.id,
+        billNumber: Bill.billNumber,
+        officialSummary: Bill.summary,
+        status: Bill.status,
       })
       .from(Bill)
       .leftJoin(
         Video,
         and(eq(Video.contentType, "bill"), eq(Video.contentId, Bill.id)),
       )
+      .leftJoin(
+        ContentBrief,
+        and(
+          eq(ContentBrief.contentType, "bill"),
+          eq(ContentBrief.contentId, Bill.id),
+        ),
+      )
       .orderBy(asc(Bill.id));
     const rows = afterId
       ? await query.where(gt(Bill.id, afterId))
       : await query;
-    return rows.map((row) => ({
+    return rows.map(({ briefId, ...row }) => ({
       ...row,
       type,
       articleType: "bill",
+      hasBrief: briefId !== null,
     }));
   }
 
@@ -133,7 +159,14 @@ async function loadContentItems(
     const rows = afterId
       ? await query.where(gt(GovernmentContent.id, afterId))
       : await query;
-    return rows.map((row) => ({ ...row, type }));
+    return rows.map((row) => ({
+      ...row,
+      type,
+      hasBrief: false,
+      billNumber: null,
+      officialSummary: null,
+      status: null,
+    }));
   }
 
   const query = db
@@ -166,6 +199,10 @@ async function loadContentItems(
     ...row,
     type,
     articleType: "court case",
+    hasBrief: false,
+    billNumber: null,
+    officialSummary: null,
+    status: null,
   }));
 }
 
@@ -235,9 +272,18 @@ async function processItem(
   const errors: string[] = [];
   let replacementArticle: string | undefined;
   let replacementThumbnail: string | undefined;
+  // Bills are read from their structured brief and no longer generate an
+  // article, so producing one here would be paid-for content nothing displays —
+  // and under `missing` it would recur on every run, because the bill would
+  // never satisfy an article check it is not meant to satisfy.
   const shouldGenerateArticle =
     assets === "all" &&
+    !requiresBrief(item.type) &&
     (mode === "replace" || !isUsableAIArticle(item.aiGeneratedArticle));
+  const shouldGenerateBrief =
+    assets === "all" &&
+    requiresBrief(item.type) &&
+    (mode === "replace" || !item.hasBrief);
   const imageSearchReady = Boolean(
     process.env.GOOGLE_API_KEY && process.env.GOOGLE_SEARCH_ENGINE_ID,
   );
@@ -301,6 +347,32 @@ async function processItem(
   });
 
   const effectiveArticle = replacementArticle ?? item.aiGeneratedArticle;
+
+  // The structured brief. Previously absent from this tool entirely, which is
+  // why a "fill in what is missing" pass could leave a bill with art and an
+  // article and still nothing the app wants to render.
+  let briefPresent = item.hasBrief;
+  if (shouldGenerateBrief && item.billNumber) {
+    try {
+      briefPresent = await upsertBillBrief({
+        contentId: item.id,
+        contentHash,
+        title: item.title,
+        billNumber: item.billNumber,
+        url: item.url,
+        fullText,
+        officialSummary: item.officialSummary,
+        status: item.status,
+        priorArticle: effectiveArticle,
+      });
+      if (!briefPresent) errors.push("brief generation returned nothing");
+    } catch (error) {
+      errors.push(
+        `Brief: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
   if (assets === "all") {
     try {
       const lensGenerated = await upsertContentLens(
@@ -341,12 +413,15 @@ async function processItem(
     errors.push(error instanceof Error ? error.message : String(error));
   }
 
-  const articleIsUsable = isUsableAIArticle(effectiveArticle);
+  // A bill counts as complete on its brief; everything else on its article.
+  const longFormIsUsable = requiresBrief(item.type)
+    ? briefPresent
+    : isUsableAIArticle(effectiveArticle);
   return {
     id: item.id,
     type: item.type,
     status:
-      articleIsUsable && videoHasImage
+      longFormIsUsable && videoHasImage
         ? errors.length === 0
           ? "updated"
           : "partial"

--- a/apps/scraper/src/utils/reprocessing-policy.test.ts
+++ b/apps/scraper/src/utils/reprocessing-policy.test.ts
@@ -19,11 +19,21 @@ ${"Supporters and critics disagree. ".repeat(20)}
 `;
 
 const completeState = {
+  contentType: "court_case" as const,
   fullText: "A normal source sentence with enough context. ".repeat(20),
   aiGeneratedArticle: article,
+  hasBrief: false,
   videoId: "video-id",
   videoImageData: Buffer.from("image"),
   videoThumbnailUrl: null,
+};
+
+/** A bill stored the way the scraper now stores them: brief, no article. */
+const completeBill = {
+  ...completeState,
+  contentType: "bill" as const,
+  aiGeneratedArticle: null,
+  hasBrief: true,
 };
 
 void test("source text rejects short and boilerplate-heavy input", () => {
@@ -52,6 +62,59 @@ void test("missing mode selects incomplete derived assets only", () => {
   assert.equal(needsReprocessing(completeState, "replace"), true);
   assert.equal(
     needsReprocessing({ ...completeState, fullText: null }, "missing"),
+    true,
+  );
+});
+
+void test("a bill is judged on its brief, not on the retired article", () => {
+  // The trap this guards: bills no longer generate an article, so requiring one
+  // would mark every correctly-stored bill incomplete and regenerate the exact
+  // artifact that was deliberately removed — on every run, forever.
+  assert.equal(needsReprocessing(completeBill, "missing"), false);
+  assert.equal(
+    needsReprocessing({ ...completeBill, hasBrief: false }, "missing"),
+    true,
+  );
+});
+
+void test("a bill with a legacy article but no brief is still incomplete", () => {
+  // Describes the 794 bills in production carrying an article and no brief:
+  // they render as a wall of prose, which is the state being drained.
+  assert.equal(
+    needsReprocessing(
+      { ...completeBill, aiGeneratedArticle: article, hasBrief: false },
+      "missing",
+    ),
+    true,
+  );
+});
+
+void test("non-bill types still require an article, having no brief schema", () => {
+  for (const contentType of ["government_content", "court_case"] as const) {
+    assert.equal(
+      needsReprocessing({ ...completeState, contentType }, "missing"),
+      false,
+    );
+    assert.equal(
+      needsReprocessing(
+        { ...completeState, contentType, aiGeneratedArticle: null },
+        "missing",
+      ),
+      true,
+      `${contentType} should still need its article`,
+    );
+  }
+});
+
+void test("missing source text or header art outranks the long-form check", () => {
+  // Both apply to every type, so a bill with a perfect brief still needs work
+  // if its art is gone.
+  assert.equal(
+    needsReprocessing({ ...completeBill, videoImageData: null }, "missing"),
+    true,
+  );
+  assert.equal(
+    needsReprocessing({ ...completeBill, fullText: null }, "missing"),
     true,
   );
 });

--- a/apps/scraper/src/utils/reprocessing-policy.ts
+++ b/apps/scraper/src/utils/reprocessing-policy.ts
@@ -1,8 +1,13 @@
 export type ReprocessMode = "missing" | "replace";
 
+export type ReprocessContentType = "bill" | "government_content" | "court_case";
+
 export interface ReprocessingState {
+  contentType: ReprocessContentType;
   fullText: string | null;
   aiGeneratedArticle: string | null;
+  /** Whether a structured brief exists. Bills only — see `needsReprocessing`. */
+  hasBrief: boolean;
   videoId: string | null;
   videoImageData: Buffer | null;
   videoThumbnailUrl: string | null;
@@ -62,16 +67,32 @@ export function hasVideoImage(state: ReprocessingState): boolean {
   return Boolean(state.videoImageData || state.videoThumbnailUrl);
 }
 
+/**
+ * Which long-form asset a content type is actually read from.
+ *
+ * Bills render from their structured brief; `article-detail.tsx` only falls
+ * back to `aiGeneratedArticle` when no brief exists. Since bills no longer
+ * generate an article at all, judging one "incomplete" for lacking an article
+ * would select every correctly-stored bill and regenerate the artifact we
+ * deliberately stopped producing.
+ *
+ * Court cases and executive actions have no brief schema yet, so for them the
+ * article is still the only long-form content and remains required.
+ */
+export function requiresBrief(contentType: ReprocessContentType): boolean {
+  return contentType === "bill";
+}
+
 export function needsReprocessing(
   state: ReprocessingState,
   mode: ReprocessMode,
 ): boolean {
   if (mode === "replace") return true;
 
-  return (
-    !isUsableSourceText(state.fullText) ||
-    !isUsableAIArticle(state.aiGeneratedArticle) ||
-    !state.videoId ||
-    !hasVideoImage(state)
-  );
+  if (!isUsableSourceText(state.fullText)) return true;
+  if (!state.videoId || !hasVideoImage(state)) return true;
+
+  return requiresBrief(state.contentType)
+    ? !state.hasBrief
+    : !isUsableAIArticle(state.aiGeneratedArticle);
 }

--- a/apps/supervisor/src/config.ts
+++ b/apps/supervisor/src/config.ts
@@ -75,10 +75,15 @@ export const jobs: readonly JobDefinition[] = [
     id: "retro-briefs",
     description: "Generate structured briefs for content missing one",
     script: "retroactive-briefs.js",
-    args: ["--limit", "200", "--concurrency", "4"],
+    // The limit is a ceiling on candidates, not a target: the script selects
+    // only bills whose brief is missing or stale, so a generous number costs
+    // nothing once the backlog is drained. It was 200 against a backlog of 794,
+    // which meant four manual triggers to finish one job — and no record of how
+    // many passes were left.
+    args: ["--limit", "1000", "--concurrency", "4"],
     schedule: { kind: "manual" },
     priority: 20,
-    timeoutMinutes: 6 * 60,
+    timeoutMinutes: 12 * 60,
   },
   {
     id: "retro-lenses",


### PR DESCRIPTION
`reprocess-content` had **no brief handling at all**. Its completeness policy predates structured briefs and inspects only source text, the legacy article, and the video row.

Two consequences, one already observed and one now armed:

**Observed.** Asked to fill in incomplete bills, it selected **56** rows while **794** had no brief. Every bill it touched got header art and a freshly generated legacy article, and still nothing the app wants to render — `article-detail.tsx` renders the brief when one exists and only falls back to the article, then to raw GPO text, when it does not.

**Armed.** Now that bills no longer generate an article (#252), requiring one would mark every correctly-stored bill incomplete and regenerate the artifact that was deliberately removed — on every run, forever.

## The change

Completeness is judged per content type:

| type | long-form requirement |
| --- | --- |
| `bill` | structured brief |
| `government_content` | article (no brief schema yet) |
| `court_case` | article (no brief schema yet) |

Source text and header art remain required for all three, and outrank the long-form check.

`reprocess-content` now generates briefs, and skips articles for bills.

## Verification

Read-only against production (`--mode missing`, no `--apply`):

```
Mode                     missing
Selected rows            794
Writes                   disabled (inventory only)
```

794 is exactly the set of bills with no brief — up from 56 under the old policy.

61 scraper tests, including four new ones on the policy. The important one asserts a bill with a legacy article and no brief is still incomplete, and that a bill with a brief and no article is complete — the two cases that were backwards.

## Also

`retro-briefs` had `--limit 200` against a backlog of 794, so draining it meant four manual triggers with nothing recording how many passes remained. The limit is a ceiling on candidates rather than a target — the script selects only missing or stale briefs — so raising it to 1000 costs nothing once drained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)