### PR TITLE
Time jobs out on silence, not on elapsed time

### DIFF
--- a/apps/supervisor/src/config.test.ts
+++ b/apps/supervisor/src/config.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findJob, jobs } from "./config.js";
+
+void test("job ids are unique", () => {
+  const ids = jobs.map((job) => job.id);
+  assert.equal(new Set(ids).size, ids.length);
+});
+
+void test("every job is reachable by id", () => {
+  for (const job of jobs) {
+    assert.equal(findJob(job.id)?.id, job.id);
+  }
+  assert.equal(findJob("no-such-job"), undefined);
+});
+
+void test("limits are generous enough not to kill healthy work", () => {
+  // The first version of this config used wall-clock timeouts picked by guess,
+  // and one of them (12h for a 15.4h backfill) would have killed a healthy run
+  // at 78% complete. The idle limit is the safeguard now, so it has to be long
+  // enough that ordinary slowness — a large-context generation, a retried
+  // image — never looks like a hang.
+  for (const job of jobs) {
+    assert.ok(
+      job.idleTimeoutMinutes >= 30,
+      `${job.id}: idle limit ${job.idleTimeoutMinutes}m is short enough to kill slow but healthy work`,
+    );
+    assert.ok(
+      job.maxRuntimeHours >= 12,
+      `${job.id}: absolute limit ${job.maxRuntimeHours}h is not a backstop, it is a deadline`,
+    );
+    // The backstop must not be able to fire before the idle limit does.
+    assert.ok(
+      job.maxRuntimeHours * 60 > job.idleTimeoutMinutes,
+      `${job.id}: absolute limit fires before the idle limit could`,
+    );
+  }
+});
+
+void test("scheduled jobs outrank the manual backfills", () => {
+  const scheduled = jobs.filter((job) => job.schedule.kind !== "manual");
+  const manual = jobs.filter((job) => job.schedule.kind === "manual");
+  const worstScheduled = Math.max(...scheduled.map((job) => job.priority));
+  const bestManual = Math.min(...manual.map((job) => job.priority));
+
+  // A multi-hour archive drain must never be able to queue ahead of the day's
+  // legislation.
+  assert.ok(
+    worstScheduled < bestManual,
+    "a manual backfill can outrank a scheduled run",
+  );
+});

--- a/apps/supervisor/src/config.ts
+++ b/apps/supervisor/src/config.ts
@@ -21,7 +21,8 @@ export const jobs: readonly JobDefinition[] = [
     // whose text was replaced by a substitute amendment.
     env: { SCRAPER_MAX_NEW_ITEMS_PER_RUN: "25" },
     priority: 0,
-    timeoutMinutes: 6 * 60,
+    idleTimeoutMinutes: 60,
+    maxRuntimeHours: 24,
   },
   // The other three registered scrapers. These used to ride along in a weekly
   // `main.js all` run; they are listed individually so that dropping the `all`
@@ -37,7 +38,8 @@ export const jobs: readonly JobDefinition[] = [
     args: ["federalregister", "--concurrency", "2"],
     schedule: { kind: "weekly", weekday: 0, hour: 3, minute: 15 },
     priority: 10,
-    timeoutMinutes: 6 * 60,
+    idleTimeoutMinutes: 60,
+    maxRuntimeHours: 24,
   },
   {
     id: "scc-cvig-weekly",
@@ -46,7 +48,8 @@ export const jobs: readonly JobDefinition[] = [
     args: ["scc-cvig", "--concurrency", "2"],
     schedule: { kind: "weekly", weekday: 0, hour: 3, minute: 15 },
     priority: 11,
-    timeoutMinutes: 4 * 60,
+    idleTimeoutMinutes: 60,
+    maxRuntimeHours: 24,
   },
   {
     id: "ca-sos-weekly",
@@ -55,7 +58,8 @@ export const jobs: readonly JobDefinition[] = [
     args: ["ca-sos-statements", "--concurrency", "2"],
     schedule: { kind: "weekly", weekday: 0, hour: 3, minute: 15 },
     priority: 12,
-    timeoutMinutes: 4 * 60,
+    idleTimeoutMinutes: 60,
+    maxRuntimeHours: 24,
   },
 
   // Everything below is manual: it runs only when someone drops a request file,
@@ -83,7 +87,8 @@ export const jobs: readonly JobDefinition[] = [
     args: ["--limit", "1000", "--concurrency", "4"],
     schedule: { kind: "manual" },
     priority: 20,
-    timeoutMinutes: 12 * 60,
+    idleTimeoutMinutes: 60,
+    maxRuntimeHours: 72,
   },
   {
     id: "retro-lenses",
@@ -92,7 +97,8 @@ export const jobs: readonly JobDefinition[] = [
     args: ["--type", "all", "--limit", "200", "--concurrency", "4"],
     schedule: { kind: "manual" },
     priority: 21,
-    timeoutMinutes: 6 * 60,
+    idleTimeoutMinutes: 60,
+    maxRuntimeHours: 72,
   },
   {
     id: "retro-videos",
@@ -101,7 +107,8 @@ export const jobs: readonly JobDefinition[] = [
     args: ["--type", "bill"],
     schedule: { kind: "manual" },
     priority: 30,
-    timeoutMinutes: 6 * 60,
+    idleTimeoutMinutes: 60,
+    maxRuntimeHours: 48,
   },
   {
     id: "reprocess-bare",
@@ -129,7 +136,8 @@ export const jobs: readonly JobDefinition[] = [
     // so it wants a human deciding when it runs.
     schedule: { kind: "manual" },
     priority: 31,
-    timeoutMinutes: 8 * 60,
+    idleTimeoutMinutes: 60,
+    maxRuntimeHours: 72,
   },
 ];
 

--- a/apps/supervisor/src/run.ts
+++ b/apps/supervisor/src/run.ts
@@ -42,6 +42,33 @@ export async function runJob(
     },
   );
 
+  let timedOut = false;
+
+  const terminate = (why: string) => {
+    timedOut = true;
+    logger.error(`[${job.id}] ${why}, terminating`);
+    child.kill("SIGTERM");
+    // A job that ignores SIGTERM still has to go, or it wedges the queue.
+    setTimeout(() => child.kill("SIGKILL"), 30_000).unref();
+  };
+
+  // Progress, not elapsed time, is what distinguishes a long job from a stuck
+  // one. Every line of output resets the clock, so a run that is working stays
+  // alive however long it takes, and one that has genuinely hung is still cut
+  // loose rather than blocking the queue behind it forever.
+  let idleTimer: NodeJS.Timeout | undefined;
+  const noteProgress = () => {
+    clearTimeout(idleTimer);
+    idleTimer = setTimeout(
+      () =>
+        terminate(
+          `produced no output for ${job.idleTimeoutMinutes}m and looks wedged`,
+        ),
+      job.idleTimeoutMinutes * 60_000,
+    );
+  };
+  noteProgress();
+
   // Prefix every line so a shared log stays readable when jobs run back to
   // back, and so grepping for one job's history is possible.
   //
@@ -51,24 +78,20 @@ export async function runJob(
   // of padded blocks. The supervisor's own messages still use consola.
   const pipe = (stream: NodeJS.ReadableStream, sink: NodeJS.WriteStream) => {
     const lines = createInterface({ input: stream });
-    lines.on("line", (line) => sink.write(`[${job.id}] ${line}\n`));
+    lines.on("line", (line) => {
+      noteProgress();
+      sink.write(`[${job.id}] ${line}\n`);
+    });
   };
   if (child.stdout) pipe(child.stdout, process.stdout);
   if (child.stderr) pipe(child.stderr, process.stderr);
 
-  let timedOut = false;
-
-  const timeout = setTimeout(
-    () => {
-      timedOut = true;
-      logger.error(
-        `[${job.id}] exceeded ${job.timeoutMinutes}m timeout, terminating`,
-      );
-      child.kill("SIGTERM");
-      // A job that ignores SIGTERM still has to go, or it wedges the queue.
-      setTimeout(() => child.kill("SIGKILL"), 30_000).unref();
-    },
-    job.timeoutMinutes * 60_000,
+  const hardStop = setTimeout(
+    () =>
+      terminate(
+        `exceeded the ${job.maxRuntimeHours}h absolute limit while still producing output`,
+      ),
+    job.maxRuntimeHours * 3_600_000,
   );
 
   const onAbort = () => {
@@ -88,7 +111,8 @@ export async function runJob(
     });
     return { exitCode, timedOut, durationMs: Date.now() - startedAt };
   } finally {
-    clearTimeout(timeout);
+    clearTimeout(idleTimer);
+    clearTimeout(hardStop);
     signal.removeEventListener("abort", onAbort);
   }
 }

--- a/apps/supervisor/src/schedule.test.ts
+++ b/apps/supervisor/src/schedule.test.ts
@@ -17,7 +17,8 @@ const weeklyJob: JobDefinition = {
   args: [],
   schedule: { kind: "weekly", weekday: 0, hour: 3, minute: 15 },
   priority: 0,
-  timeoutMinutes: 60,
+  idleTimeoutMinutes: 60,
+  maxRuntimeHours: 24,
 };
 
 const intervalJob: JobDefinition = {
@@ -27,7 +28,8 @@ const intervalJob: JobDefinition = {
   args: [],
   schedule: { kind: "interval", everyMinutes: 5 },
   priority: 10,
-  timeoutMinutes: 60,
+  idleTimeoutMinutes: 60,
+  maxRuntimeHours: 24,
 };
 
 const clean: JobState = { consecutiveFailures: 0 };

--- a/apps/supervisor/src/types.ts
+++ b/apps/supervisor/src/types.ts
@@ -44,8 +44,29 @@ export interface JobDefinition {
    * multi-hour archive drain.
    */
   readonly priority: number;
-  /** Hard ceiling on a single run. Exceeding it is a failure, not a success. */
-  readonly timeoutMinutes: number;
+  /**
+   * How long a job may produce **no output at all** before it is considered
+   * wedged and terminated.
+   *
+   * This is deliberately not a cap on total runtime. A backfill that legitimately
+   * runs for fifteen hours is not stuck — it is working — and a wall-clock limit
+   * cannot tell the two apart. The first version of this used one, and came
+   * within hours of killing a healthy 794-item drain at 78% complete purely
+   * because someone (me) guessed "12 hours" before ever running the job.
+   *
+   * Silence is the honest signal. Every job here narrates per item, so an hour
+   * without a single line means something has genuinely hung — a provider call
+   * with no timeout of its own, a stalled socket, a deadlock.
+   */
+  readonly idleTimeoutMinutes: number;
+
+  /**
+   * Absolute backstop, in hours. Only exists to catch a job that spins forever
+   * while still producing output — a retry loop logging failures would never
+   * trip the idle timer. Set generously: this should never be what stops a
+   * healthy run.
+   */
+  readonly maxRuntimeHours: number;
 }
 
 export interface JobState {


### PR DESCRIPTION
The per-job wall-clock limits in the supervisor were numbers I guessed before ever running any of these jobs. One was wrong in the way that matters.

`retro-briefs` was capped at 12h. Measured against production it runs at **0.9 briefs/min**, so draining the 794-bill backlog takes **15.4h** — the cap would have killed a healthy run at roughly 78% complete and recorded it as a failure.

## Elapsed time is the wrong signal

A backfill running for fifteen hours is not stuck, it is working. A wall-clock limit cannot tell those apart, so it either kills good work or is set so high it never catches a real hang.

**Silence can tell them apart.** Every job here narrates per item, so an hour with no output means something has genuinely hung — a provider call with no timeout of its own, a stalled socket, a deadlock. Each line of output now resets the clock.

A generous absolute backstop stays, but only to catch a job spinning forever *while still logging* — a retry loop would never trip the idle timer.

```
                     idle   absolute
congress-daily        60m       24h
federalregister-weekly 60m      24h
scc-cvig-weekly       60m       24h
ca-sos-weekly         60m       24h
retro-briefs          60m       72h
retro-lenses          60m       72h
retro-videos          60m       48h
reprocess-bare        60m       72h
```

## Verification

Both shapes run against the supervisor with the idle limit shortened to ten seconds:

```
=== CHATTY job (24s of output, 10s idle limit) — should SURVIVE ===
[retro-briefs] chatty: done
✔ "retro-briefs" finished in 0.4m

=== SILENT job — should be KILLED as wedged ===
[retro-lenses] silent: starting then hanging
 ERROR  [retro-lenses] produced no output for 0.17m and looks wedged, terminating
 ERROR  "retro-lenses" failed (exit 128, timed out)
```

Under the previous design the chatty job would have been killed at ten seconds.

## Also

Adds a config test asserting the limits stay generous — idle at least 30m, absolute at least 12h, and the backstop unable to fire before the idle limit — plus that no manual backfill can outrank a scheduled run.

## Not addressed

There is still no feedback loop telling you a limit is badly sized until it fires. The supervisor records `durationMs` per run but never compares it to the budget. Less urgent now that the limit tracks progress rather than duration, but worth adding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)