### PR TITLE
Add a supervisor job for bills stored without a description

### DIFF
--- a/apps/supervisor/src/config.ts
+++ b/apps/supervisor/src/config.ts
@@ -76,6 +76,25 @@ export const jobs: readonly JobDefinition[] = [
   // that in is a deliberate, supervised spend, not something a scheduler starts
   // on its own at 3am.
   {
+    id: "backfill-descriptions",
+    description: "Fill in the card gist for bills stored without one",
+    script: "backfill-bill-descriptions.js",
+    // Prefers a real congress.gov summary if one has been published since the
+    // bill was stored, and only falls back to generating one — so most of this
+    // is fetching, not inference, and it is the cheapest of the backfills.
+    //
+    // Exists for rows written before a bill had to be complete to be stored at
+    // all. Nothing produces description-less bills any more; this drains the
+    // ones that already exist.
+    args: ["--concurrency", "4", "--apply", "--yes"],
+    schedule: { kind: "manual" },
+    // Ahead of the other backfills: a blank gist is the most visible defect of
+    // the three, and the cheapest to repair.
+    priority: 19,
+    idleTimeoutMinutes: 60,
+    maxRuntimeHours: 24,
+  },
+  {
     id: "retro-briefs",
     description: "Generate structured briefs for content missing one",
     script: "retroactive-briefs.js",


### PR DESCRIPTION
54 bills in production have a `NULL` description, and most have no CRS summary either — so `description ?? summary` in the content API yields nothing and the card renders as a bare title.

```
total bills            832
null description        54
added today             76
added today, no desc    54   ← the same rows
```

## Why they exist

All 54 come from today's `congress-daily` run, which executed at 19:24 on an image predating #243. Past-budget bills were still stored raw then, and "raw" meant no description, no article and no art.

**This cannot recur.** Under #243 a past-budget new bill is not stored at all, and under #252 a bill without a description is never written. These rows are a fossil of a code path that no longer exists — their header art was already repaired by `retro-videos`.

## The fix

`backfill-bill-descriptions` already does exactly this and was simply never wired into the supervisor. It prefers a real congress.gov summary where one has since been published and only falls back to generating one, so most of the work is fetching rather than inference — the cheapest of the backfills.

Ordered at priority 19, ahead of the other manual backfills: a blank gist is the most visible of the three remaining defects and the cheapest to repair.

```sh
ssh big-mac 'touch ~/.local/state/billion/requests/backfill-descriptions'
```

23 supervisor tests pass, including the config guards on limits and priority ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)