### PR TITLE
Configure EAS Update and prompt users to restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,36 @@ jobs:
       - name: Bundle Android
         run: cd apps/expo && npx expo export --platform android --output-dir dist
 
+  # Publish only after the same checks that gate production, plus successful
+  # native bundles. The fingerprint runtime policy prevents an update that
+  # changes native code or config from reaching an incompatible installed app.
+  eas-update:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [lint, format, typecheck, test, bundle-expo]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup
+        uses: ./tooling/github/setup
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Publish production update
+        working-directory: apps/expo
+        run: |
+          eas update \
+            --channel production \
+            --environment production \
+            --message "main@${GITHUB_SHA}" \
+            --non-interactive
+
   # Publishes the image the scrapers actually run in production.
   #
   # This lives in `ci.yml` rather than its own workflow so it can `needs:` the

--- a/apps/expo/app.config.base.json
+++ b/apps/expo/app.config.base.json
@@ -6,7 +6,12 @@
   "orientation": "portrait",
   "icon": "./assets/billion-logo.png",
   "userInterfaceStyle": "dark",
+  "runtimeVersion": {
+    "policy": "fingerprint"
+  },
   "updates": {
+    "url": "https://u.expo.dev/c38bc8f8-f82c-4a45-b819-d62bd366ac8b",
+    "checkAutomatically": "ON_LOAD",
     "fallbackToCacheTimeout": 0
   },
   "assetBundlePatterns": ["**/*"],

--- a/apps/expo/eas.json
+++ b/apps/expo/eas.json
@@ -14,11 +14,13 @@
     },
     "development": {
       "extends": "base",
+      "channel": "development",
       "developmentClient": true,
       "distribution": "internal"
     },
     "preview": {
       "extends": "base",
+      "channel": "preview",
       "distribution": "internal",
       "ios": {
         "simulator": true
@@ -26,6 +28,7 @@
     },
     "production": {
       "extends": "base",
+      "channel": "production",
       "autoIncrement": true
     }
   },

--- a/apps/expo/src/app/_layout.tsx
+++ b/apps/expo/src/app/_layout.tsx
@@ -32,6 +32,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { PostHogProvider } from "posthog-react-native";
 
 import { createRouteErrorBoundary } from "~/components/RouteErrorBoundary";
+import { UpdatePrompt } from "~/components/UpdatePrompt";
 import { posthog } from "~/config/posthog";
 import { useTheme } from "~/styles";
 import { queryClient } from "~/utils/api";
@@ -136,6 +137,7 @@ export default function RootLayout() {
         }}
       >
         <PostHogAuthSync />
+        <UpdatePrompt />
         <GestureHandlerRootView style={{ flex: 1 }}>
           <Stack
             screenOptions={{

--- a/apps/expo/src/components/UpdatePrompt.tsx
+++ b/apps/expo/src/components/UpdatePrompt.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from "react";
+import { Alert } from "react-native";
+import * as Updates from "expo-updates";
+
+async function restartWithUpdate() {
+  try {
+    await Updates.reloadAsync();
+  } catch (error) {
+    console.warn("Unable to restart with the downloaded update:", error);
+    Alert.alert(
+      "Unable to restart",
+      "Close and reopen Billion to finish installing the update.",
+    );
+  }
+}
+
+export function UpdatePrompt() {
+  const { downloadedUpdate, isUpdatePending } = Updates.useUpdates();
+  const promptedUpdateId = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!isUpdatePending) return;
+
+    const updateId = downloadedUpdate?.updateId ?? "pending";
+    if (promptedUpdateId.current === updateId) return;
+    promptedUpdateId.current = updateId;
+
+    Alert.alert(
+      "A new version is available",
+      "Restart Billion to get the latest improvements.",
+      [
+        { text: "Later", style: "cancel" },
+        {
+          text: "Restart now",
+          onPress: () => void restartWithUpdate(),
+        },
+      ],
+    );
+  }, [downloadedUpdate?.updateId, isUpdatePending]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- configure the Expo app with the existing EAS Update project URL and a fingerprint runtime policy
- assign development, preview, and production update channels to their EAS build profiles
- publish production updates from `main` only after lint, format, typecheck, test, and native bundle checks pass
- show “A new version is available” after a compatible update downloads, with Later and Restart now actions

## Why

`expo-updates` was installed but had no update URL, runtime compatibility policy, channel wiring, or publish path. Installed builds therefore had no way to receive JS-only changes without another App Store submission.

The fingerprint policy makes automated publishing safe across the native boundary: JS-only changes keep the installed binary's runtime fingerprint, while native dependency or configuration changes generate a different fingerprint and cannot load on that binary.

## Deployment note

This PR changes native update configuration, so enabling OTA updates requires one new production build and TestFlight/App Store release after merge. Once users have that build, compatible JS-only changes merged to `main` will publish automatically. Native changes still require a new build.

The workflow reuses the existing `EXPO_TOKEN` secret and the EAS `production` environment.

## Validation

- `pnpm --filter @acme/expo typecheck`
- `pnpm --filter @acme/expo lint`
- `pnpm --filter @acme/expo format`
- Prettier check for all changed files
- parsed `.github/workflows/ci.yml` as YAML
- resolved the public Expo config and generated the iOS runtime fingerprint
- exported production bundles for iOS and Android

Closes #262
