### PR TITLE
feat: add notification admin console

### DIFF
--- a/apps/nextjs/src/app/admin/notifications/actions.ts
+++ b/apps/nextjs/src/app/admin/notifications/actions.ts
@@ -1,0 +1,106 @@
+"use server";
+
+import { randomUUID } from "node:crypto";
+import { revalidatePath } from "next/cache";
+import { z } from "zod/v4";
+
+import { eq } from "@acme/db";
+import { db } from "@acme/db/client";
+import { Bill } from "@acme/db/schema";
+
+import { requireNotificationAdmin } from "~/auth/admin";
+import {
+  checkNotificationReceipts,
+  sendBreakingAlert,
+} from "~/server/notifications";
+
+export interface AdminActionState {
+  status: "idle" | "success" | "error";
+  message?: string;
+  resetKey?: string;
+}
+
+const AdminAlertSchema = z.object({
+  contentId: z.uuid(),
+  title: z.string().trim().min(1).max(100),
+  body: z.string().trim().min(1).max(240),
+  confirmation: z.literal("confirmed"),
+});
+
+export async function sendAdminAlert(
+  _previous: AdminActionState,
+  formData: FormData,
+): Promise<AdminActionState> {
+  try {
+    const operator = await requireNotificationAdmin();
+    const parsed = AdminAlertSchema.safeParse({
+      contentId: formData.get("contentId"),
+      title: formData.get("title"),
+      body: formData.get("body"),
+      confirmation: formData.get("confirmation"),
+    });
+    if (!parsed.success) {
+      return {
+        status: "error",
+        message:
+          parsed.error.issues[0]?.message ??
+          "Choose a bill and confirm the send.",
+      };
+    }
+
+    const [bill] = await db
+      .select({ id: Bill.id })
+      .from(Bill)
+      .where(eq(Bill.id, parsed.data.contentId))
+      .limit(1);
+    if (!bill) {
+      return { status: "error", message: "That bill no longer exists." };
+    }
+
+    const result = await sendBreakingAlert({
+      title: parsed.data.title,
+      body: parsed.data.body,
+      contentId: bill.id,
+      route: `/article-detail?id=${bill.id}`,
+      idempotencyKey: `admin:${bill.id}:${randomUUID()}`,
+      operatorUserId: operator.id,
+      operatorEmail: operator.email,
+    });
+
+    revalidatePath("/admin/notifications");
+    const recipients = "recipients" in result ? result.recipients : 0;
+    return {
+      status: "success",
+      message: `Alert sent to ${recipients} opted-in device${recipients === 1 ? "" : "s"}.`,
+      resetKey: result.alertId,
+    };
+  } catch (error) {
+    console.error("admin notification send failed", error);
+    return {
+      status: "error",
+      message:
+        error instanceof Error ? error.message : "Could not send the alert.",
+    };
+  }
+}
+
+export async function refreshAdminReceipts(
+  _previous: AdminActionState,
+): Promise<AdminActionState> {
+  try {
+    await requireNotificationAdmin();
+    const result = await checkNotificationReceipts();
+    revalidatePath("/admin/notifications");
+    return {
+      status: "success",
+      message: `Checked ${result.checked} receipt${result.checked === 1 ? "" : "s"}; ${result.pending} still pending.`,
+    };
+  } catch (error) {
+    console.error("admin receipt check failed", error);
+    return {
+      status: "error",
+      message:
+        error instanceof Error ? error.message : "Could not check receipts.",
+    };
+  }
+}

--- a/apps/nextjs/src/app/admin/notifications/notification-console.tsx
+++ b/apps/nextjs/src/app/admin/notifications/notification-console.tsx
@@ -1,0 +1,237 @@
+"use client";
+
+import { useActionState, useMemo, useState } from "react";
+import { useFormStatus } from "react-dom";
+
+import { Button } from "@acme/ui/button";
+import { Input } from "@acme/ui/input";
+import { Label } from "@acme/ui/label";
+
+import type { AdminActionState } from "./actions";
+import { refreshAdminReceipts, sendAdminAlert } from "./actions";
+
+interface BillOption {
+  id: string;
+  billNumber: string;
+  title: string;
+}
+
+const initialState: AdminActionState = { status: "idle" };
+
+function SubmitButton({ recipients }: { recipients: number }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button
+      type="submit"
+      variant="destructive"
+      className="w-full sm:w-auto"
+      disabled={pending}
+    >
+      {pending
+        ? "Sending…"
+        : `Send now to ${recipients} device${recipients === 1 ? "" : "s"}`}
+    </Button>
+  );
+}
+
+function ReceiptButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" variant="outline" size="sm" disabled={pending}>
+      {pending ? "Checking…" : "Check receipts"}
+    </Button>
+  );
+}
+
+function ActionMessage({ state }: { state: AdminActionState }) {
+  if (!state.message) return null;
+  return (
+    <p
+      role="status"
+      className={
+        state.status === "error"
+          ? "text-destructive text-sm"
+          : "text-sm text-emerald-400"
+      }
+    >
+      {state.message}
+    </p>
+  );
+}
+
+export function NotificationComposer({
+  bills,
+  recipients,
+}: {
+  bills: BillOption[];
+  recipients: number;
+}) {
+  const [state, action] = useActionState(sendAdminAlert, initialState);
+  const [query, setQuery] = useState("");
+  const [selectedId, setSelectedId] = useState(bills[0]?.id ?? "");
+  const [title, setTitle] = useState("BREAKING");
+  const [body, setBody] = useState("");
+  const filteredBills = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return bills;
+    return bills.filter((bill) =>
+      `${bill.billNumber} ${bill.title}`.toLowerCase().includes(normalized),
+    );
+  }, [bills, query]);
+  const selectedBill = bills.find((bill) => bill.id === selectedId);
+
+  return (
+    <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_22rem]">
+      <form
+        key={state.resetKey ?? "composer"}
+        action={action}
+        className="border-border bg-card/60 space-y-5 rounded-2xl border p-5 shadow-xl shadow-black/10 sm:p-7"
+      >
+        <div>
+          <p className="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
+            Compose
+          </p>
+          <h2 className="mt-2 text-2xl">Breaking bill alert</h2>
+        </div>
+
+        <div className="space-y-2">
+          <Label htmlFor="bill-search">Find a bill</Label>
+          <Input
+            id="bill-search"
+            type="search"
+            placeholder="Search by bill number or title"
+            value={query}
+            onChange={(event) => {
+              const nextQuery = event.target.value;
+              setQuery(nextQuery);
+              const normalized = nextQuery.trim().toLowerCase();
+              const firstMatch = bills.find((bill) =>
+                `${bill.billNumber} ${bill.title}`
+                  .toLowerCase()
+                  .includes(normalized),
+              );
+              if (firstMatch) setSelectedId(firstMatch.id);
+            }}
+          />
+          <select
+            id="contentId"
+            name="contentId"
+            required
+            value={selectedId}
+            onChange={(event) => setSelectedId(event.target.value)}
+            className="border-input bg-input/30 focus-visible:border-ring focus-visible:ring-ring/50 min-h-11 w-full rounded-md border px-3 text-sm outline-none focus-visible:ring-[3px]"
+          >
+            {filteredBills.length === 0 ? (
+              <option value="">No matching bills</option>
+            ) : null}
+            {filteredBills.map((bill) => (
+              <option key={bill.id} value={bill.id}>
+                {bill.billNumber} — {bill.title}
+              </option>
+            ))}
+          </select>
+          <p className="text-muted-foreground text-xs">
+            Opening the push routes directly to this bill in the app.
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-4">
+            <Label htmlFor="title">Push title</Label>
+            <span className="text-muted-foreground font-mono text-xs">
+              {title.length}/100
+            </span>
+          </div>
+          <Input
+            id="title"
+            name="title"
+            required
+            maxLength={100}
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <div className="flex items-center justify-between gap-4">
+            <Label htmlFor="body">Message</Label>
+            <span className="text-muted-foreground font-mono text-xs">
+              {body.length}/240
+            </span>
+          </div>
+          <textarea
+            id="body"
+            name="body"
+            required
+            maxLength={240}
+            rows={4}
+            placeholder="What changed, and why does it matter?"
+            value={body}
+            onChange={(event) => setBody(event.target.value)}
+            className="border-input bg-input/30 placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 w-full resize-y rounded-md border px-3 py-2 text-sm outline-none focus-visible:ring-[3px]"
+          />
+        </div>
+
+        <label className="border-border bg-background/40 flex cursor-pointer gap-3 rounded-xl border p-4">
+          <input
+            type="checkbox"
+            name="confirmation"
+            value="confirmed"
+            required
+            className="mt-1 size-4 accent-red-500"
+          />
+          <span className="text-sm leading-6">
+            I reviewed this alert and understand it will immediately notify{" "}
+            <strong>
+              {recipients} opted-in device{recipients === 1 ? "" : "s"}
+            </strong>
+            .
+          </span>
+        </label>
+
+        <div className="flex flex-wrap items-center gap-4">
+          <SubmitButton recipients={recipients} />
+          <ActionMessage state={state} />
+        </div>
+      </form>
+
+      <aside className="space-y-4">
+        <div className="border-border bg-card rounded-[2rem] border p-4 shadow-2xl shadow-black/20">
+          <div className="rounded-[1.5rem] bg-black p-4">
+            <div className="mb-3 flex items-center justify-between text-[11px] text-white/55">
+              <span>Billion</span>
+              <span>now</span>
+            </div>
+            <p className="text-sm font-semibold text-white">
+              {title || "Push title"}
+            </p>
+            <p className="mt-1 text-sm leading-5 text-white/75">
+              {body || "Your alert copy will appear here."}
+            </p>
+          </div>
+        </div>
+        <div className="border-border bg-card/60 rounded-2xl border p-5">
+          <p className="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
+            Destination
+          </p>
+          <p className="mt-2 text-sm font-semibold">
+            {selectedBill?.billNumber ?? "Choose a bill"}
+          </p>
+          <p className="text-muted-foreground mt-1 line-clamp-3 text-sm">
+            {selectedBill?.title ?? "The selected bill title will appear here."}
+          </p>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+export function ReceiptRefresh() {
+  const [state, action] = useActionState(refreshAdminReceipts, initialState);
+  return (
+    <form action={action} className="flex flex-wrap items-center gap-3">
+      <ReceiptButton />
+      <ActionMessage state={state} />
+    </form>
+  );
+}

--- a/apps/nextjs/src/app/admin/notifications/page.tsx
+++ b/apps/nextjs/src/app/admin/notifications/page.tsx
@@ -1,0 +1,246 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import { desc, inArray, sql } from "@acme/db";
+import { db } from "@acme/db/client";
+import {
+  Bill,
+  NotificationAlert,
+  NotificationDelivery,
+  PushDevice,
+} from "@acme/db/schema";
+import { Button } from "@acme/ui/button";
+
+import { getNotificationAdminAccess } from "~/auth/admin";
+import { auth } from "~/auth/server";
+import { NotificationComposer, ReceiptRefresh } from "./notification-console";
+
+export const dynamic = "force-dynamic";
+
+async function getDashboardData() {
+  const [bills, alerts, recipientRows] = await Promise.all([
+    db
+      .select({
+        id: Bill.id,
+        billNumber: Bill.billNumber,
+        title: Bill.title,
+      })
+      .from(Bill)
+      .orderBy(desc(Bill.sourceUpdatedAt), desc(Bill.createdAt))
+      .limit(100),
+    db
+      .select()
+      .from(NotificationAlert)
+      .orderBy(desc(NotificationAlert.createdAt))
+      .limit(20),
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(PushDevice)
+      .where(
+        sql`${PushDevice.enabled} = true and ${PushDevice.breakingNews} = true`,
+      ),
+  ]);
+
+  const alertIds = alerts.map((alert) => alert.id);
+  const deliveries =
+    alertIds.length === 0
+      ? []
+      : await db
+          .select({
+            alertId: NotificationDelivery.alertId,
+            status: NotificationDelivery.status,
+          })
+          .from(NotificationDelivery)
+          .where(inArray(NotificationDelivery.alertId, alertIds));
+
+  return {
+    bills,
+    alerts: alerts.map((alert) => {
+      const statuses = deliveries.filter(
+        (delivery) => delivery.alertId === alert.id,
+      );
+      const count = (status: string) =>
+        statuses.filter((delivery) => delivery.status === status).length;
+      return {
+        ...alert,
+        queued: count("queued"),
+        ticketed: count("ticketed"),
+        delivered: count("delivered"),
+        failed: count("failed"),
+        total: statuses.length,
+      };
+    }),
+    recipients: recipientRows[0]?.count ?? 0,
+  };
+}
+
+function formatDate(date: Date | null) {
+  if (!date) return "Not sent";
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export default async function NotificationAdminPage() {
+  const access = await getNotificationAdminAccess();
+
+  if (!access.session) {
+    const signInAction = async () => {
+      "use server";
+      const result = await auth.api.signInSocial({
+        body: {
+          provider: "discord",
+          callbackURL: "/admin/notifications",
+        },
+      });
+      if (!result.url) throw new Error("Could not start Discord sign-in.");
+      redirect(result.url);
+    };
+
+    return (
+      <main className="mx-auto flex min-h-screen max-w-lg items-center px-6">
+        <div className="border-border bg-card w-full rounded-2xl border p-8 text-center">
+          <p className="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
+            Internal
+          </p>
+          <h1 className="mt-3 text-3xl">Notification console</h1>
+          <p className="text-muted-foreground mt-3">
+            Sign in with an authorized Billion account to continue.
+          </p>
+          <form action={signInAction} className="mt-6">
+            <Button type="submit">Sign in with Discord</Button>
+          </form>
+        </div>
+      </main>
+    );
+  }
+
+  if (!access.configured || !access.authorized) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-lg items-center px-6">
+        <div className="border-border bg-card w-full rounded-2xl border p-8">
+          <p className="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
+            Access denied
+          </p>
+          <h1 className="mt-3 text-3xl">Notification console</h1>
+          <p className="text-muted-foreground mt-3">
+            {access.configured
+              ? `${access.session.user.email} is not on the notification admin allowlist.`
+              : "Set BILLION_ADMIN_EMAILS to a comma-separated list of authorized account emails."}
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const data = await getDashboardData();
+  const signOutAction = async () => {
+    "use server";
+    await auth.api.signOut({ headers: await headers() });
+    redirect("/admin/notifications");
+  };
+
+  return (
+    <main className="min-h-screen bg-[radial-gradient(circle_at_top_left,rgba(220,38,38,0.14),transparent_32rem)]">
+      <div className="mx-auto max-w-7xl px-5 py-10 sm:px-8">
+        <header className="mb-10 flex flex-wrap items-end justify-between gap-5">
+          <div>
+            <p className="text-xs font-semibold tracking-[0.2em] text-red-400 uppercase">
+              Billion newsroom
+            </p>
+            <h1 className="mt-2 text-4xl sm:text-5xl">Notification console</h1>
+            <p className="text-muted-foreground mt-3 max-w-2xl">
+              Review and send breaking bill alerts to readers who explicitly
+              opted in.
+            </p>
+          </div>
+          <form action={signOutAction}>
+            <Button type="submit" variant="ghost" size="sm">
+              Sign out {access.session.user.name}
+            </Button>
+          </form>
+        </header>
+
+        <section aria-labelledby="compose-heading">
+          <h2 id="compose-heading" className="sr-only">
+            Compose an alert
+          </h2>
+          <NotificationComposer
+            bills={data.bills}
+            recipients={data.recipients}
+          />
+        </section>
+
+        <section className="mt-12" aria-labelledby="history-heading">
+          <div className="mb-5 flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <p className="text-muted-foreground text-xs font-semibold tracking-[0.18em] uppercase">
+                Audit trail
+              </p>
+              <h2 id="history-heading" className="mt-2 text-3xl">
+                Recent alerts
+              </h2>
+            </div>
+            <ReceiptRefresh />
+          </div>
+
+          <div className="border-border overflow-x-auto rounded-2xl border">
+            <table className="w-full min-w-[860px] text-left text-sm">
+              <thead className="bg-muted/50 text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-3 font-medium">Alert</th>
+                  <th className="px-4 py-3 font-medium">Operator</th>
+                  <th className="px-4 py-3 font-medium">Sent</th>
+                  <th className="px-4 py-3 font-medium">Delivery</th>
+                  <th className="px-4 py-3 font-medium">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-border divide-y">
+                {data.alerts.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="text-muted-foreground px-4 py-10 text-center"
+                    >
+                      No alerts have been sent yet.
+                    </td>
+                  </tr>
+                ) : (
+                  data.alerts.map((alert) => (
+                    <tr key={alert.id} className="bg-card/40 align-top">
+                      <td className="max-w-md px-4 py-4">
+                        <p className="font-semibold">{alert.title}</p>
+                        <p className="text-muted-foreground mt-1 line-clamp-2">
+                          {alert.body}
+                        </p>
+                      </td>
+                      <td className="text-muted-foreground px-4 py-4">
+                        {alert.operatorEmail ?? "API operator"}
+                      </td>
+                      <td className="text-muted-foreground px-4 py-4 whitespace-nowrap">
+                        {formatDate(alert.sentAt)}
+                      </td>
+                      <td className="px-4 py-4 whitespace-nowrap">
+                        <p>{alert.delivered} delivered</p>
+                        <p className="text-muted-foreground">
+                          {alert.ticketed + alert.queued} pending ·{" "}
+                          {alert.failed} failed · {alert.total} total
+                        </p>
+                      </td>
+                      <td className="px-4 py-4">
+                        <span className="bg-muted rounded-full px-2.5 py-1 text-xs font-semibold uppercase">
+                          {alert.status}
+                        </span>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/apps/nextjs/src/app/api/notifications/breaking/route.ts
+++ b/apps/nextjs/src/app/api/notifications/breaking/route.ts
@@ -1,29 +1,12 @@
 import { NextResponse } from "next/server";
-import { z } from "zod/v4";
 
-import { sendExpoPushMessages } from "@acme/api/lib/expo-push";
-import { and, eq } from "@acme/db";
-import { db } from "@acme/db/client";
-import {
-  NotificationAlert,
-  NotificationDelivery,
-  PushDevice,
-} from "@acme/db/schema";
-
+import { BreakingAlertSchema, sendBreakingAlert } from "~/server/notifications";
 import {
   isNotificationOperatorAuthorized,
   isNotificationServiceConfigured,
 } from "../_lib/authorize";
 
 export const runtime = "nodejs";
-
-const BreakingAlertSchema = z.object({
-  title: z.string().trim().min(1).max(100).default("BREAKING"),
-  body: z.string().trim().min(1).max(240),
-  contentId: z.uuid().optional(),
-  route: z.string().trim().startsWith("/").max(500),
-  idempotencyKey: z.string().trim().min(8).max(160),
-});
 
 export async function POST(request: Request) {
   if (!isNotificationServiceConfigured()) {
@@ -46,157 +29,12 @@ export async function POST(request: Request) {
     );
   }
 
-  const input = parsed.data;
-  const [created] = await db
-    .insert(NotificationAlert)
-    .values(input)
-    .onConflictDoNothing({ target: NotificationAlert.idempotencyKey })
-    .returning();
-
-  const alert =
-    created ??
-    (
-      await db
-        .select()
-        .from(NotificationAlert)
-        .where(eq(NotificationAlert.idempotencyKey, input.idempotencyKey))
-        .limit(1)
-    )[0];
-
-  if (!alert) {
-    return NextResponse.json(
-      { error: "Could not create alert" },
-      { status: 500 },
-    );
-  }
-  if (!created) {
-    return NextResponse.json({
-      ok: true,
-      duplicate: true,
-      alertId: alert.id,
-      status: alert.status,
-    });
-  }
-
-  const devices = await db
-    .select({
-      id: PushDevice.id,
-      expoPushToken: PushDevice.expoPushToken,
-    })
-    .from(PushDevice)
-    .where(
-      and(eq(PushDevice.enabled, true), eq(PushDevice.breakingNews, true)),
-    );
-
-  if (devices.length === 0) {
-    await db
-      .update(NotificationAlert)
-      .set({ status: "sent", sentAt: new Date() })
-      .where(eq(NotificationAlert.id, alert.id));
-    return NextResponse.json({
-      ok: true,
-      alertId: alert.id,
-      recipients: 0,
-    });
-  }
-
-  await db.insert(NotificationDelivery).values(
-    devices.map((device) => ({
-      alertId: alert.id,
-      deviceId: device.id,
-    })),
-  );
-  await db
-    .update(NotificationAlert)
-    .set({ status: "sending" })
-    .where(eq(NotificationAlert.id, alert.id));
-
   try {
-    const tickets = await sendExpoPushMessages(
-      devices.map((device) => ({
-        to: device.expoPushToken,
-        title: input.title,
-        body: input.body,
-        sound: "default",
-        priority: "high",
-        channelId: "breaking-news",
-        data: {
-          type: "bill",
-          alertId: alert.id,
-          contentId: input.contentId,
-          route: input.route,
-        },
-      })),
-    );
-
-    const deviceByToken = new Map(
-      devices.map((device) => [device.expoPushToken, device]),
-    );
-    let accepted = 0;
-
-    for (const result of tickets) {
-      const device = deviceByToken.get(result.token);
-      if (!device) continue;
-
-      if (result.ticket.status === "ok") {
-        accepted += 1;
-        await db
-          .update(NotificationDelivery)
-          .set({
-            expoTicketId: result.ticket.id,
-            status: "ticketed",
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(NotificationDelivery.alertId, alert.id),
-              eq(NotificationDelivery.deviceId, device.id),
-            ),
-          );
-      } else {
-        await db
-          .update(NotificationDelivery)
-          .set({
-            status: "failed",
-            error: result.ticket.message,
-            updatedAt: new Date(),
-          })
-          .where(
-            and(
-              eq(NotificationDelivery.alertId, alert.id),
-              eq(NotificationDelivery.deviceId, device.id),
-            ),
-          );
-
-        if (result.ticket.details?.error === "DeviceNotRegistered") {
-          await db
-            .update(PushDevice)
-            .set({ enabled: false, updatedAt: new Date() })
-            .where(eq(PushDevice.id, device.id));
-        }
-      }
-    }
-
-    await db
-      .update(NotificationAlert)
-      .set({ status: "sent", sentAt: new Date() })
-      .where(eq(NotificationAlert.id, alert.id));
-
-    return NextResponse.json({
-      ok: true,
-      alertId: alert.id,
-      recipients: devices.length,
-      accepted,
-      rejected: devices.length - accepted,
-    });
+    return NextResponse.json(await sendBreakingAlert(parsed.data));
   } catch (error) {
-    await db
-      .update(NotificationAlert)
-      .set({ status: "failed" })
-      .where(eq(NotificationAlert.id, alert.id));
     console.error("breaking notification send failed", error);
     return NextResponse.json(
-      { error: "Could not send alert", alertId: alert.id },
+      { error: "Could not send alert" },
       { status: 502 },
     );
   }

--- a/apps/nextjs/src/app/api/notifications/receipts/route.ts
+++ b/apps/nextjs/src/app/api/notifications/receipts/route.ts
@@ -1,10 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { getExpoPushReceipts } from "@acme/api/lib/expo-push";
-import { and, eq, isNotNull } from "@acme/db";
-import { db } from "@acme/db/client";
-import { NotificationDelivery, PushDevice } from "@acme/db/schema";
-
+import { checkNotificationReceipts } from "~/server/notifications";
 import {
   isNotificationOperatorAuthorized,
   isNotificationServiceConfigured,
@@ -23,72 +19,8 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const deliveries = await db
-    .select({
-      id: NotificationDelivery.id,
-      deviceId: NotificationDelivery.deviceId,
-      expoTicketId: NotificationDelivery.expoTicketId,
-    })
-    .from(NotificationDelivery)
-    .where(
-      and(
-        eq(NotificationDelivery.status, "ticketed"),
-        isNotNull(NotificationDelivery.expoTicketId),
-      ),
-    );
-
-  const ticketIds = deliveries
-    .map((delivery) => delivery.expoTicketId)
-    .filter((id): id is string => Boolean(id));
-
-  if (ticketIds.length === 0) {
-    return NextResponse.json({ ok: true, checked: 0, pending: 0 });
-  }
-
   try {
-    const receipts = await getExpoPushReceipts(ticketIds);
-    let delivered = 0;
-    let failed = 0;
-
-    for (const delivery of deliveries) {
-      const ticketId = delivery.expoTicketId;
-      if (!ticketId) continue;
-      const receipt = receipts[ticketId];
-      if (!receipt) continue;
-
-      if (receipt.status === "ok") {
-        delivered += 1;
-        await db
-          .update(NotificationDelivery)
-          .set({ status: "delivered", error: null, updatedAt: new Date() })
-          .where(eq(NotificationDelivery.id, delivery.id));
-      } else {
-        failed += 1;
-        await db
-          .update(NotificationDelivery)
-          .set({
-            status: "failed",
-            error: receipt.message,
-            updatedAt: new Date(),
-          })
-          .where(eq(NotificationDelivery.id, delivery.id));
-
-        if (receipt.details?.error === "DeviceNotRegistered") {
-          await db
-            .update(PushDevice)
-            .set({ enabled: false, updatedAt: new Date() })
-            .where(eq(PushDevice.id, delivery.deviceId));
-        }
-      }
-    }
-
-    return NextResponse.json({
-      ok: true,
-      checked: delivered + failed,
-      delivered,
-      failed,
-      pending: ticketIds.length - delivered - failed,
-    });
+    return NextResponse.json(await checkNotificationReceipts());
   } catch (error) {
     console.error("notification receipt check failed", error);
     return NextResponse.json(

--- a/apps/nextjs/src/auth/admin.ts
+++ b/apps/nextjs/src/auth/admin.ts
@@ -1,0 +1,36 @@
+import "server-only";
+
+import { env } from "~/env";
+import { getSession } from "./server";
+
+const adminEmails = () =>
+  new Set(
+    (env.BILLION_ADMIN_EMAILS ?? "")
+      .split(",")
+      .map((email) => email.trim().toLowerCase())
+      .filter(Boolean),
+  );
+
+export async function getNotificationAdminAccess() {
+  const session = await getSession();
+  const configured = Boolean(env.BILLION_ADMIN_EMAILS);
+  const authorized =
+    Boolean(session) &&
+    adminEmails().has(session?.user.email.trim().toLowerCase() ?? "");
+
+  return { session, configured, authorized };
+}
+
+export async function requireNotificationAdmin() {
+  const access = await getNotificationAdminAccess();
+  if (!access.session) {
+    throw new Error("Sign in to manage notifications.");
+  }
+  if (!access.configured) {
+    throw new Error("The notification admin allowlist is not configured.");
+  }
+  if (!access.authorized) {
+    throw new Error("Your account is not authorized to manage notifications.");
+  }
+  return access.session.user;
+}

--- a/apps/nextjs/src/env.ts
+++ b/apps/nextjs/src/env.ts
@@ -31,6 +31,7 @@ export const env = createEnv({
       envSchemas.RESEND_TESTFLIGHT_BATCH_SEGMENT_ID!.optional(),
     BILLION_NOTIFICATIONS_SECRET:
       envSchemas.BILLION_NOTIFICATIONS_SECRET!.optional(),
+    BILLION_ADMIN_EMAILS: envSchemas.BILLION_ADMIN_EMAILS!.optional(),
   },
 
   /**

--- a/apps/nextjs/src/server/notifications.ts
+++ b/apps/nextjs/src/server/notifications.ts
@@ -1,0 +1,238 @@
+import "server-only";
+
+import { z } from "zod/v4";
+
+import {
+  getExpoPushReceipts,
+  sendExpoPushMessages,
+} from "@acme/api/lib/expo-push";
+import { and, eq, isNotNull } from "@acme/db";
+import { db } from "@acme/db/client";
+import {
+  NotificationAlert,
+  NotificationDelivery,
+  PushDevice,
+} from "@acme/db/schema";
+
+export const BreakingAlertSchema = z.object({
+  title: z.string().trim().min(1).max(100).default("BREAKING"),
+  body: z.string().trim().min(1).max(240),
+  contentId: z.uuid().optional(),
+  route: z.string().trim().startsWith("/").max(500),
+  idempotencyKey: z.string().trim().min(8).max(160),
+  operatorUserId: z.string().trim().min(1).optional(),
+  operatorEmail: z.email().optional(),
+});
+
+export async function sendBreakingAlert(
+  input: z.infer<typeof BreakingAlertSchema>,
+) {
+  const [created] = await db
+    .insert(NotificationAlert)
+    .values(input)
+    .onConflictDoNothing({ target: NotificationAlert.idempotencyKey })
+    .returning();
+
+  const alert =
+    created ??
+    (
+      await db
+        .select()
+        .from(NotificationAlert)
+        .where(eq(NotificationAlert.idempotencyKey, input.idempotencyKey))
+        .limit(1)
+    )[0];
+
+  if (!alert) throw new Error("Could not create alert");
+  if (!created) {
+    return {
+      ok: true as const,
+      duplicate: true as const,
+      alertId: alert.id,
+      status: alert.status,
+    };
+  }
+
+  const devices = await db
+    .select({
+      id: PushDevice.id,
+      expoPushToken: PushDevice.expoPushToken,
+    })
+    .from(PushDevice)
+    .where(
+      and(eq(PushDevice.enabled, true), eq(PushDevice.breakingNews, true)),
+    );
+
+  if (devices.length === 0) {
+    await db
+      .update(NotificationAlert)
+      .set({ status: "sent", sentAt: new Date() })
+      .where(eq(NotificationAlert.id, alert.id));
+    return { ok: true as const, alertId: alert.id, recipients: 0 };
+  }
+
+  await db.insert(NotificationDelivery).values(
+    devices.map((device) => ({
+      alertId: alert.id,
+      deviceId: device.id,
+    })),
+  );
+  await db
+    .update(NotificationAlert)
+    .set({ status: "sending" })
+    .where(eq(NotificationAlert.id, alert.id));
+
+  try {
+    const tickets = await sendExpoPushMessages(
+      devices.map((device) => ({
+        to: device.expoPushToken,
+        title: input.title,
+        body: input.body,
+        sound: "default",
+        priority: "high",
+        channelId: "breaking-news",
+        data: {
+          type: "bill",
+          alertId: alert.id,
+          contentId: input.contentId,
+          route: input.route,
+        },
+      })),
+    );
+
+    const deviceByToken = new Map(
+      devices.map((device) => [device.expoPushToken, device]),
+    );
+    let accepted = 0;
+
+    for (const result of tickets) {
+      const device = deviceByToken.get(result.token);
+      if (!device) continue;
+
+      if (result.ticket.status === "ok") {
+        accepted += 1;
+        await db
+          .update(NotificationDelivery)
+          .set({
+            expoTicketId: result.ticket.id,
+            status: "ticketed",
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(NotificationDelivery.alertId, alert.id),
+              eq(NotificationDelivery.deviceId, device.id),
+            ),
+          );
+      } else {
+        await db
+          .update(NotificationDelivery)
+          .set({
+            status: "failed",
+            error: result.ticket.message,
+            updatedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(NotificationDelivery.alertId, alert.id),
+              eq(NotificationDelivery.deviceId, device.id),
+            ),
+          );
+
+        if (result.ticket.details?.error === "DeviceNotRegistered") {
+          await db
+            .update(PushDevice)
+            .set({ enabled: false, updatedAt: new Date() })
+            .where(eq(PushDevice.id, device.id));
+        }
+      }
+    }
+
+    await db
+      .update(NotificationAlert)
+      .set({ status: "sent", sentAt: new Date() })
+      .where(eq(NotificationAlert.id, alert.id));
+
+    return {
+      ok: true as const,
+      alertId: alert.id,
+      recipients: devices.length,
+      accepted,
+      rejected: devices.length - accepted,
+    };
+  } catch (error) {
+    await db
+      .update(NotificationAlert)
+      .set({ status: "failed" })
+      .where(eq(NotificationAlert.id, alert.id));
+    throw error;
+  }
+}
+
+export async function checkNotificationReceipts() {
+  const deliveries = await db
+    .select({
+      id: NotificationDelivery.id,
+      deviceId: NotificationDelivery.deviceId,
+      expoTicketId: NotificationDelivery.expoTicketId,
+    })
+    .from(NotificationDelivery)
+    .where(
+      and(
+        eq(NotificationDelivery.status, "ticketed"),
+        isNotNull(NotificationDelivery.expoTicketId),
+      ),
+    );
+
+  const ticketIds = deliveries
+    .map((delivery) => delivery.expoTicketId)
+    .filter((id): id is string => Boolean(id));
+
+  if (ticketIds.length === 0) {
+    return { ok: true as const, checked: 0, pending: 0 };
+  }
+
+  const receipts = await getExpoPushReceipts(ticketIds);
+  let delivered = 0;
+  let failed = 0;
+
+  for (const delivery of deliveries) {
+    const ticketId = delivery.expoTicketId;
+    if (!ticketId) continue;
+    const receipt = receipts[ticketId];
+    if (!receipt) continue;
+
+    if (receipt.status === "ok") {
+      delivered += 1;
+      await db
+        .update(NotificationDelivery)
+        .set({ status: "delivered", error: null, updatedAt: new Date() })
+        .where(eq(NotificationDelivery.id, delivery.id));
+    } else {
+      failed += 1;
+      await db
+        .update(NotificationDelivery)
+        .set({
+          status: "failed",
+          error: receipt.message,
+          updatedAt: new Date(),
+        })
+        .where(eq(NotificationDelivery.id, delivery.id));
+
+      if (receipt.details?.error === "DeviceNotRegistered") {
+        await db
+          .update(PushDevice)
+          .set({ enabled: false, updatedAt: new Date() })
+          .where(eq(PushDevice.id, delivery.deviceId));
+      }
+    }
+  }
+
+  return {
+    ok: true as const,
+    checked: delivered + failed,
+    delivered,
+    failed,
+    pending: ticketIds.length - delivered - failed,
+  };
+}

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -20,7 +20,10 @@ user.
    least 32 random characters and share it only with trusted operators or the
    receipt scheduler.
 
-3. Create a new native build. Adding `expo-notifications` changes native app
+3. Configure `BILLION_ADMIN_EMAILS` with the comma-separated account email
+   addresses allowed to use the internal notification console.
+
+4. Create a new native build. Adding `expo-notifications` changes native app
    capabilities, so an OTA update is not sufficient:
 
    ```sh
@@ -32,7 +35,7 @@ user.
    Notification key. Production builds use the same EAS project ID already
    configured in `app.config.base.json`.
 
-4. Test on a physical device. Open **Settings → Notifications**, enable
+5. Test on a physical device. Open **Settings → Notifications**, enable
    **Breaking legislation**, and accept the operating-system prompt.
 
 ## Send an editorially approved alert
@@ -76,6 +79,20 @@ future broadcasts do not target an uninstalled or deregistered app.
 
 For production, invoke this endpoint from the existing scheduler or another
 trusted cron service. Do not put the notification secret in the mobile app.
+
+## Internal notification console
+
+Authorized operators can open `/admin/notifications`, sign in with Discord,
+search the latest bills, edit and preview the push copy, confirm the current
+opted-in recipient count, and send. The browser never receives
+`BILLION_NOTIFICATIONS_SECRET`; dashboard actions verify the Better Auth session
+and `BILLION_ADMIN_EMAILS` on the server.
+
+The console records the operator's user ID and email on every alert. Its recent
+history shows delivered, pending, and failed counts, and the **Check receipts**
+action asks Expo for the latest APNs delivery results. Keep the scheduled
+receipt endpoint enabled as the reliable background path; the dashboard button
+is an operator convenience.
 
 ## Data model
 

--- a/packages/db/drizzle/0012_lean_amazoness.sql
+++ b/packages/db/drizzle/0012_lean_amazoness.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "notification_alert" ADD COLUMN "operator_user_id" text;--> statement-breakpoint
+ALTER TABLE "notification_alert" ADD COLUMN "operator_email" text;

--- a/packages/db/drizzle/meta/0012_snapshot.json
+++ b/packages/db/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,3318 @@
+{
+  "id": "230fa489-5dc0-45eb-be15-277e5b5772ae",
+  "prevId": "ef8ab427-c83d-4428-bead-6212e021e287",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bill": {
+      "name": "bill",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "bill_number": {
+          "name": "bill_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sponsor": {
+          "name": "sponsor",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "introduced_date": {
+          "name": "introduced_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "congress": {
+          "name": "congress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "chamber": {
+          "name": "chamber",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actions": {
+          "name": "actions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_website": {
+          "name": "source_website",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(bill_number, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(sponsor, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(summary, '') || ' ' || coalesce(description, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(full_text, '')), 'C')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "bill_search_vector_idx": {
+          "name": "bill_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bill_number_trgm_idx": {
+          "name": "bill_number_trgm_idx",
+          "columns": [
+            {
+              "expression": "bill_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bill_billNumber_sourceWebsite_unique": {
+          "name": "bill_billNumber_sourceWebsite_unique",
+          "nullsNotDistinct": false,
+          "columns": ["bill_number", "source_website"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bill_description_max_100_chars": {
+          "name": "bill_description_max_100_chars",
+          "value": "\"bill\".\"description\" is null or char_length(\"bill\".\"description\") <= 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.blocked_content": {
+      "name": "blocked_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocked_content_user_id_idx": {
+          "name": "blocked_content_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "blocked_content_userId_name_type_unique": {
+          "name": "blocked_content_userId_name_type_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "name", "type"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.brief_change_image": {
+      "name": "brief_change_image",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_brief_id": {
+          "name": "content_brief_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_index": {
+          "name": "change_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "change_hash": {
+          "name": "change_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_data": {
+          "name": "image_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_mime_type": {
+          "name": "image_mime_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_width": {
+          "name": "image_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_height": {
+          "name": "image_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prompt": {
+          "name": "prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "brief_change_image_brief_id_idx": {
+          "name": "brief_change_image_brief_id_idx",
+          "columns": [
+            {
+              "expression": "content_brief_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "brief_change_image_content_brief_id_content_brief_id_fk": {
+          "name": "brief_change_image_content_brief_id_content_brief_id_fk",
+          "tableFrom": "brief_change_image",
+          "tableTo": "content_brief",
+          "columnsFrom": ["content_brief_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "brief_change_image_contentBriefId_changeIndex_unique": {
+          "name": "brief_change_image_contentBriefId_changeIndex_unique",
+          "nullsNotDistinct": false,
+          "columns": ["content_brief_id", "change_index"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.candidate": {
+      "name": "candidate",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "contest_id": {
+          "name": "contest_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "party": {
+          "name": "party",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_url": {
+          "name": "candidate_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "incumbent": {
+          "name": "incumbent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "biography": {
+          "name": "biography",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "candidate_contest_id_idx": {
+          "name": "candidate_contest_id_idx",
+          "columns": [
+            {
+              "expression": "contest_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.civic_api_cache": {
+      "name": "civic_api_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "address_hash": {
+          "name": "address_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "params": {
+          "name": "params",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "response_data": {
+          "name": "response_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "civic_cache_expires_idx": {
+          "name": "civic_cache_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "civic_api_cache_addressHash_endpoint_params_unique": {
+          "name": "civic_api_cache_addressHash_endpoint_params_unique",
+          "nullsNotDistinct": false,
+          "columns": ["address_hash", "endpoint", "params"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_brief": {
+      "name": "content_brief",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brief": {
+          "name": "brief",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "content_brief_content_id_idx": {
+          "name": "content_brief_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_brief_contentType_contentId_unique": {
+          "name": "content_brief_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["content_type", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.content_lens": {
+      "name": "content_lens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lens_data": {
+          "name": "lens_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "content_lens_content_id_idx": {
+          "name": "content_lens_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "content_lens_contentType_contentId_unique": {
+          "name": "content_lens_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["content_type", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.contest": {
+      "name": "contest",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "election_id": {
+          "name": "election_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "office": {
+          "name": "office",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_name": {
+          "name": "district_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "district_scope": {
+          "name": "district_scope",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "number_elected": {
+          "name": "number_elected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "referendum_title": {
+          "name": "referendum_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_subtitle": {
+          "name": "referendum_subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_text": {
+          "name": "referendum_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_pro_statement": {
+          "name": "referendum_pro_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_con_statement": {
+          "name": "referendum_con_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referendum_url": {
+          "name": "referendum_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role_description": {
+          "name": "role_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary_is_ai_generated": {
+          "name": "summary_is_ai_generated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fiscal_impact": {
+          "name": "fiscal_impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citations": {
+          "name": "citations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "contest_election_id_idx": {
+          "name": "contest_election_id_idx",
+          "columns": [
+            {
+              "expression": "election_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.court_case": {
+      "name": "court_case",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "case_number": {
+          "name": "case_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "court": {
+          "name": "court",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filed_date": {
+          "name": "filed_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(case_number, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(description, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(full_text, '')), 'C')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "court_case_search_vector_idx": {
+          "name": "court_case_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "court_case_number_trgm_idx": {
+          "name": "court_case_number_trgm_idx",
+          "columns": [
+            {
+              "expression": "case_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "gin_trgm_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "court_case_caseNumber_court_unique": {
+          "name": "court_case_caseNumber_court_unique",
+          "nullsNotDistinct": false,
+          "columns": ["case_number", "court"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.election": {
+      "name": "election",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "election_type": {
+          "name": "election_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ocd_division_id": {
+          "name": "ocd_division_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deadlines": {
+          "name": "deadlines",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "election_externalId_source_unique": {
+          "name": "election_externalId_source_unique",
+          "nullsNotDistinct": false,
+          "columns": ["external_id", "source"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.government_content": {
+      "name": "government_content",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_date": {
+          "name": "published_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_text": {
+          "name": "full_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_generated_article": {
+          "name": "ai_generated_article",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'whitehouse.gov'"
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "versions": {
+          "name": "versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false,
+          "generated": {
+            "as": "(\n        setweight(to_tsvector('english', coalesce(title, '')), 'A') ||\n        setweight(to_tsvector('english', coalesce(description, '')), 'B') ||\n        setweight(to_tsvector('english', coalesce(full_text, '')), 'C')\n      )",
+            "type": "stored"
+          }
+        }
+      },
+      "indexes": {
+        "government_content_search_vector_idx": {
+          "name": "government_content_search_vector_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "government_content_url_unique": {
+          "name": "government_content_url_unique",
+          "nullsNotDistinct": false,
+          "columns": ["url"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_agenda_item": {
+      "name": "legistar_agenda_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_item_id": {
+          "name": "event_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda_sequence": {
+          "name": "agenda_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_number": {
+          "name": "agenda_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action_name": {
+          "name": "action_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed_flag_name": {
+          "name": "passed_flag_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tally": {
+          "name": "tally",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mover_name": {
+          "name": "mover_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seconder_name": {
+          "name": "seconder_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_file": {
+          "name": "matter_file",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_name": {
+          "name": "matter_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_type": {
+          "name": "matter_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_status": {
+          "name": "matter_status",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consent": {
+          "name": "consent",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "agenda_note": {
+          "name": "agenda_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_note": {
+          "name": "minutes_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_agenda_item_event_idx": {
+          "name": "legistar_agenda_item_event_idx",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_agenda_item_jurisdiction_eventItemId_unique": {
+          "name": "legistar_agenda_item_jurisdiction_eventItemId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "event_item_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_body": {
+      "name": "legistar_body",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body_guid": {
+          "name": "body_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_flag": {
+          "name": "active_flag",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "number_of_members": {
+          "name": "number_of_members",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_name": {
+          "name": "contact_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_email": {
+          "name": "contact_email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contact_phone": {
+          "name": "contact_phone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_body_jurisdiction_bodyId_unique": {
+          "name": "legistar_body_jurisdiction_bodyId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "body_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_matter": {
+      "name": "legistar_matter",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matter_id": {
+          "name": "matter_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matter_guid": {
+          "name": "matter_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "matter_file": {
+          "name": "matter_file",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type_name": {
+          "name": "type_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_name": {
+          "name": "status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_name": {
+          "name": "body_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "intro_date": {
+          "name": "intro_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_date": {
+          "name": "agenda_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "passed_date": {
+          "name": "passed_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enactment_date": {
+          "name": "enactment_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enactment_number": {
+          "name": "enactment_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requester": {
+          "name": "requester",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_matter_file_idx": {
+          "name": "legistar_matter_file_idx",
+          "columns": [
+            {
+              "expression": "matter_file",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_matter_jurisdiction_matterId_unique": {
+          "name": "legistar_matter_jurisdiction_matterId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "matter_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_meeting": {
+      "name": "legistar_meeting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_guid": {
+          "name": "event_guid",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_id": {
+          "name": "body_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body_name": {
+          "name": "body_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time": {
+          "name": "time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_file": {
+          "name": "agenda_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_file": {
+          "name": "minutes_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_path": {
+          "name": "video_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agenda_status_name": {
+          "name": "agenda_status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "minutes_status_name": {
+          "name": "minutes_status_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "in_site_url": {
+          "name": "in_site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "legistar_meeting_date_idx": {
+          "name": "legistar_meeting_date_idx",
+          "columns": [
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_meeting_jurisdiction_eventId_unique": {
+          "name": "legistar_meeting_jurisdiction_eventId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "event_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legistar_vote": {
+      "name": "legistar_vote",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "jurisdiction": {
+          "name": "jurisdiction",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote_id": {
+          "name": "vote_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_item_id": {
+          "name": "event_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_id": {
+          "name": "person_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "person_name": {
+          "name": "person_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_name": {
+          "name": "value_name",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort": {
+          "name": "sort",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_utc": {
+          "name": "last_modified_utc",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legistar_vote_event_item_idx": {
+          "name": "legistar_vote_event_item_idx",
+          "columns": [
+            {
+              "expression": "event_item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legistar_vote_person_idx": {
+          "name": "legistar_vote_person_idx",
+          "columns": [
+            {
+              "expression": "person_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "legistar_vote_jurisdiction_voteId_unique": {
+          "name": "legistar_vote_jurisdiction_voteId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["jurisdiction", "vote_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_alert": {
+      "name": "notification_alert",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'breaking'"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "varchar(240)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route": {
+          "name": "route",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(160)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "operator_user_id": {
+          "name": "operator_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "operator_email": {
+          "name": "operator_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_alert_idempotencyKey_unique": {
+          "name": "notification_alert_idempotencyKey_unique",
+          "nullsNotDistinct": false,
+          "columns": ["idempotency_key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_delivery": {
+      "name": "notification_delivery",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "alert_id": {
+          "name": "alert_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expo_ticket_id": {
+          "name": "expo_ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notification_delivery_receipt_idx": {
+          "name": "notification_delivery_receipt_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expo_ticket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_delivery_alert_id_notification_alert_id_fk": {
+          "name": "notification_delivery_alert_id_notification_alert_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "notification_alert",
+          "columnsFrom": ["alert_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_delivery_device_id_push_device_id_fk": {
+          "name": "notification_delivery_device_id_push_device_id_fk",
+          "tableFrom": "notification_delivery",
+          "tableTo": "push_device",
+          "columnsFrom": ["device_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "notification_delivery_alertId_deviceId_unique": {
+          "name": "notification_delivery_alertId_deviceId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["alert_id", "device_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polling_location": {
+      "name": "polling_location",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "election_id": {
+          "name": "election_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address_line1": {
+          "name": "address_line1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "address_line2": {
+          "name": "address_line2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "city": {
+          "name": "city",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "varchar(2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zip": {
+          "name": "zip",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hours": {
+          "name": "hours",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latitude": {
+          "name": "latitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "longitude": {
+          "name": "longitude",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location_type": {
+          "name": "location_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_services": {
+          "name": "voter_services",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "polling_location_election_id_idx": {
+          "name": "polling_location_election_id_idx",
+          "columns": [
+            {
+              "expression": "election_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post": {
+      "name": "post",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_device": {
+      "name": "push_device",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expo_push_token": {
+          "name": "expo_push_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "breaking_news": {
+          "name": "breaking_news",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_device_user_id_idx": {
+          "name": "push_device_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "push_device_expoPushToken_unique": {
+          "name": "push_device_expoPushToken_unique",
+          "nullsNotDistinct": false,
+          "columns": ["expo_push_token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.role_description": {
+      "name": "role_description",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'seed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "role_description_role_level_unique": {
+          "name": "role_description_role_level_unique",
+          "nullsNotDistinct": false,
+          "columns": ["role", "level"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_article": {
+      "name": "saved_article",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "saved_article_user_id_idx": {
+          "name": "saved_article_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "saved_article_userId_contentId_unique": {
+          "name": "saved_article_userId_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraper_cursor": {
+      "name": "scraper_cursor",
+      "schema": "",
+      "columns": {
+        "scraper_key": {
+          "name": "scraper_key",
+          "type": "varchar(100)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_updated_at": {
+          "name": "source_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scraper_retry": {
+      "name": "scraper_retry",
+      "schema": "",
+      "columns": {
+        "scraper_key": {
+          "name": "scraper_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_key": {
+          "name": "item_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_reason": {
+          "name": "last_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_failed_at": {
+          "name": "first_failed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scraper_retry_due_idx": {
+          "name": "scraper_retry_due_idx",
+          "columns": [
+            {
+              "expression": "scraper_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "scraper_retry_scraper_key_item_key_pk": {
+          "name": "scraper_retry_scraper_key_item_key_pk",
+          "columns": ["scraper_key", "item_key"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference": {
+      "name": "user_preference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topics": {
+          "name": "topics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "content_types": {
+          "name": "content_types",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preference_userId_unique": {
+          "name": "user_preference_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "personalize": {
+          "name": "personalize",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "analytics": {
+          "name": "analytics",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "crash": {
+          "name": "crash",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "offline": {
+          "name": "offline",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_settings_userId_unique": {
+          "name": "user_settings_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.video": {
+      "name": "video",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_data": {
+          "name": "image_data",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_mime_type": {
+          "name": "image_mime_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_width": {
+          "name": "image_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_height": {
+          "name": "image_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "author": {
+          "name": "author",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagement_metrics": {
+          "name": "engagement_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"likes\":0,\"comments\":0,\"shares\":0}'::jsonb"
+        },
+        "source_content_hash": {
+          "name": "source_content_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "video_content_id_idx": {
+          "name": "video_content_id_idx",
+          "columns": [
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "video_created_at_idx": {
+          "name": "video_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "video_contentType_contentId_unique": {
+          "name": "video_contentType_contentId_unique",
+          "nullsNotDistinct": false,
+          "columns": ["content_type", "content_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1785467219379,
       "tag": "0011_rainy_blue_shield",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1785468925963,
+      "tag": "0012_lean_amazoness",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -604,6 +604,8 @@ export const NotificationAlert = pgTable(
     route: t.text().notNull(),
     idempotencyKey: t.varchar({ length: 160 }).notNull(),
     status: t.varchar({ length: 20 }).notNull().default("draft"),
+    operatorUserId: t.text(),
+    operatorEmail: t.text(),
     createdAt: t.timestamp({ withTimezone: true }).defaultNow().notNull(),
     sentAt: t.timestamp({ withTimezone: true }),
   }),

--- a/packages/env/src/registry.ts
+++ b/packages/env/src/registry.ts
@@ -273,6 +273,15 @@ export const envRegistry = [
     schema: string.min(32, "must be at least 32 characters"),
   }),
   define({
+    key: "BILLION_ADMIN_EMAILS",
+    description:
+      "Comma-separated Better Auth email allowlist for the internal notification dashboard.",
+    group: "Notifications",
+    secret: false,
+    requirements: { nextjs: "recommended" },
+    schema: emailList,
+  }),
+  define({
     key: "GOOGLE_CIVIC_API_KEY",
     description:
       "Google Civic Information API key for real ballot and representative data.",


### PR DESCRIPTION
## Summary

- add a Better Auth-protected notification console at `/admin/notifications`
- restrict operators with the server-only `BILLION_ADMIN_EMAILS` allowlist
- support bill search, editable push copy, live preview, recipient confirmation, and direct bill routing
- record the sending operator and show ticket/receipt delivery history
- share one server-only send and receipt implementation between the dashboard and bearer-protected API endpoints

## Safety

- the notification bearer secret is never exposed to the browser
- every server action re-checks the signed-in operator allowlist
- dashboard alerts can target only bills that exist in the database
- the confirmation control resets after each successful broadcast

## Validation

- `pnpm lint`
- `pnpm test`
- `pnpm format`
- `pnpm --filter @acme/nextjs typecheck`
- `pnpm --filter @acme/db db-check`
- `CI=1 pnpm --filter @acme/nextjs build`

## Stack

Depends on #266, which adds the push notification infrastructure.