### PR TITLE
Ingest California state bills via Open States

### DIFF
--- a/apps/scraper/src/main.ts
+++ b/apps/scraper/src/main.ts
@@ -40,11 +40,21 @@ const argv = await yargs(hideBin(process.argv))
     type: "string",
     array: true,
     describe:
-      'Fetch specific congress.gov bills by number (e.g. --bill "H.R. 7008"), ignoring the incremental update cursor. Repeatable. Requires the "congress" scraper',
+      'Fetch specific bills by number (e.g. --bill "H.R. 7008" for congress, --bill "SB 243" for open-states), ignoring the incremental update cursor. Repeatable. Requires the "congress" or "open-states" scraper',
   })
   .option("congress", {
     type: "number",
     describe: "Congress number for --bill (default: 119)",
+  })
+  .option("session", {
+    type: "string",
+    describe:
+      'Legislative session for --bill on state sources (e.g. --session 20252026). Requires the "open-states" scraper',
+  })
+  .option("bulk-dir", {
+    type: "string",
+    describe:
+      'Import an unzipped bulk session-CSV export instead of calling the API. Requires the "open-states" scraper. Download the archive while signed in at https://open.pluralpolicy.com/data/session-csv/, unzip it, and pass the directory',
   })
   .option("recent", {
     type: "number",
@@ -62,8 +72,30 @@ const argv = await yargs(hideBin(process.argv))
       throw new Error("--max-items must be a positive integer");
     }
     const bills = args.bill;
-    if (bills?.length && args.scraper !== "congress") {
-      throw new Error('--bill requires the "congress" scraper');
+    if (
+      bills?.length &&
+      args.scraper !== "congress" &&
+      args.scraper !== "open-states"
+    ) {
+      throw new Error(
+        '--bill requires the "congress" or "open-states" scraper',
+      );
+    }
+    if (args.session !== undefined) {
+      if (args.scraper !== "open-states") {
+        throw new Error('--session requires the "open-states" scraper');
+      }
+      if (!bills?.length) {
+        throw new Error("--session only applies alongside --bill");
+      }
+    }
+    if (args.bulkDir !== undefined) {
+      if (args.scraper !== "open-states") {
+        throw new Error('--bulk-dir requires the "open-states" scraper');
+      }
+      if (bills?.length) {
+        throw new Error("--bulk-dir and --bill select bills different ways");
+      }
     }
     const recent = args.recent;
     if (recent !== undefined) {
@@ -93,6 +125,8 @@ const concurrency = (argv as { concurrency: number }).concurrency;
 const maxItems = (argv as { maxItems?: number }).maxItems;
 const targets = (argv as { bill?: string[] }).bill;
 const congressNumber = (argv as { congress?: number }).congress;
+const session = (argv as { session?: string }).session;
+const bulkDir = (argv as { bulkDir?: string }).bulkDir;
 const recent = (argv as { recent?: number }).recent;
 
 function logDatabaseTarget(): void {
@@ -142,6 +176,8 @@ async function main() {
       maxItems,
       targets,
       congress: congressNumber,
+      session,
+      bulkDir,
       recent,
     });
     printMetricsSummary(scraper.name);

--- a/apps/scraper/src/scrapers.ts
+++ b/apps/scraper/src/scrapers.ts
@@ -2,11 +2,13 @@ import type { Scraper } from "./utils/types.js";
 import { caSosStatements } from "./scrapers/ca-sos-statements.js";
 import { congress } from "./scrapers/congress.js";
 import { federalregister } from "./scrapers/federalregister.js";
+import { openStates } from "./scrapers/open-states.js";
 import { sccCvig } from "./scrapers/scc-cvig.js";
 
 export const scrapers: readonly Scraper[] = [
   federalregister,
   congress,
+  openStates,
   sccCvig,
   caSosStatements,
 ];

--- a/apps/scraper/src/scrapers/congress.ts
+++ b/apps/scraper/src/scrapers/congress.ts
@@ -6,6 +6,7 @@ import type { UpsertOutcome } from "../utils/db/operations.js";
 import type { NewItemLimiter } from "../utils/new-item-limit.js";
 import type { Scraper } from "../utils/types.js";
 import { getItemLimit } from "../utils/concurrency.js";
+import { advancesCursor, cursorHighWaterMark } from "../utils/cursor.js";
 import { setExpectedTotal } from "../utils/db/metrics.js";
 import { upsertContent } from "../utils/db/operations.js";
 import {
@@ -19,6 +20,10 @@ import { latestActionDate } from "../utils/last-action.js";
 import { createLogger } from "../utils/log.js";
 import { createNewItemLimiter } from "../utils/new-item-limit.js";
 import { congressConfig } from "./congress.config.js";
+
+// Re-exported for congress.test.ts, which has covered these since they lived
+// here; they now back the open-states walk too (see utils/cursor.ts).
+export { advancesCursor, cursorHighWaterMark };
 
 const BASE_URL = "https://api.congress.gov/v3";
 const logger = createLogger("Congress.gov");
@@ -372,45 +377,6 @@ async function fetchActions(
   } catch {
     return [];
   }
-}
-
-/**
- * Whether an item's outcome lets the cursor move past it.
- *
- * `deferred` is the one that must not: the bill is not in the database in the
- * state we want it, for a reason a later run can fix. `skipped` may, because
- * re-offering the bill unchanged would reach the same conclusion — and any real
- * change upstream moves its `updateDate`, which puts it back in the feed.
- */
-export function advancesCursor(
-  outcome: UpsertOutcome,
-): outcome is Exclude<UpsertOutcome, { status: "deferred" }> {
-  return outcome.status !== "deferred";
-}
-
-/**
- * How far the cursor may move given this run's outcomes, in feed order.
- *
- * Only the leading run of clean bills counts. The feed is sorted oldest-first,
- * so the first bill we could not settle is the true high-water mark: moving
- * past it would strand it exactly the way the old wall-clock cursor did.
- * Everything from there on is simply re-offered next run, however many of them
- * happened to succeed.
- */
-export function cursorHighWaterMark(
-  outcomes: { ok: boolean; sourceUpdatedAt?: Date }[],
-): { highWaterMark: Date | undefined; held: number } {
-  const firstFailure = outcomes.findIndex((outcome) => !outcome.ok);
-  const settled =
-    firstFailure === -1 ? outcomes : outcomes.slice(0, firstFailure);
-  const highWaterMark = settled.reduce<Date | undefined>(
-    (newest, outcome) =>
-      outcome.sourceUpdatedAt && (!newest || outcome.sourceUpdatedAt > newest)
-        ? outcome.sourceUpdatedAt
-        : newest,
-    undefined,
-  );
-  return { highWaterMark, held: outcomes.length - settled.length };
 }
 
 /**

--- a/apps/scraper/src/scrapers/open-states-bulk.test.ts
+++ b/apps/scraper/src/scrapers/open-states-bulk.test.ts
@@ -1,0 +1,172 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  BulkExportShapeError,
+  parseCsv,
+  parseCsvRecords,
+  readBulkBills,
+} from "./open-states-bulk.js";
+import { normalizeBill } from "./open-states-normalize.js";
+
+// ---------------------------------------------------------------------------
+// CSV parsing
+// ---------------------------------------------------------------------------
+
+void test("quoted fields keep the commas that would otherwise shift columns", () => {
+  // "Chaptered by Secretary of State, Chapter 677" is a real CA action text;
+  // splitting on commas would push every later column one to the left.
+  assert.deepEqual(
+    parseCsv('a,b,c\n1,"Chaptered by Secretary of State, Chapter 677",3'),
+    [
+      ["a", "b", "c"],
+      ["1", "Chaptered by Secretary of State, Chapter 677", "3"],
+    ],
+  );
+});
+
+void test("escaped quotes and embedded newlines survive", () => {
+  assert.deepEqual(
+    parseCsv('title,note\n"He said ""no""","line one\nline two"'),
+    [
+      ["title", "note"],
+      ['He said "no"', "line one\nline two"],
+    ],
+  );
+});
+
+void test("CRLF files and missing trailing newlines parse the same", () => {
+  assert.deepEqual(parseCsv("a,b\r\n1,2\r\n"), [
+    ["a", "b"],
+    ["1", "2"],
+  ]);
+  assert.deepEqual(parseCsv("a,b\n1,2"), [
+    ["a", "b"],
+    ["1", "2"],
+  ]);
+});
+
+void test("a UTF-8 BOM does not become part of the first column name", () => {
+  const [record] = parseCsvRecords("﻿id,title\n1,Something");
+  assert.equal(record?.id, "1");
+});
+
+void test("short rows read as empty strings rather than undefined", () => {
+  const [record] = parseCsvRecords("a,b,c\n1,2");
+  assert.deepEqual(record, { a: "1", b: "2", c: "" });
+});
+
+// ---------------------------------------------------------------------------
+// Export reading
+// ---------------------------------------------------------------------------
+
+function withExport(
+  files: Record<string, string>,
+  run: (directory: string) => void,
+): void {
+  const directory = mkdtempSync(join(tmpdir(), "openstates-bulk-"));
+  try {
+    for (const [name, contents] of Object.entries(files)) {
+      writeFileSync(join(directory, name), contents);
+    }
+    run(directory);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+const BILLS_CSV = [
+  "id,identifier,title,session,organization_classification,created_at,updated_at,openstates_url",
+  "ocd-bill/abc,SB 243,Companion chatbots,20252026,upper,2025-01-30T00:00:00Z,2025-10-14T12:00:00Z,https://openstates.org/CA/bills/20252026/SB243/",
+].join("\n");
+
+void test("a full export rebuilds a bill the normalizer accepts", () => {
+  withExport(
+    {
+      "CA_2025-2026_bills.csv": BILLS_CSV,
+      "CA_2025-2026_bill_actions.csv": [
+        "bill_id,date,description,classification",
+        "ocd-bill/abc,2025-01-30,Introduced,introduction",
+        'ocd-bill/abc,2025-10-13,"Chaptered by Secretary of State, Chapter 677",became-law',
+      ].join("\n"),
+      "CA_2025-2026_bill_abstracts.csv": [
+        "bill_id,abstract,note",
+        "ocd-bill/abc,Regulates companion chatbots.,digest",
+      ].join("\n"),
+      "CA_2025-2026_bill_sponsorships.csv": [
+        "bill_id,name,entity_type,classification,primary,party,district",
+        "ocd-bill/abc,Steve Padilla,person,primary,true,Democratic,18",
+      ].join("\n"),
+      "CA_2025-2026_bill_sources.csv": [
+        "bill_id,url",
+        "ocd-bill/abc,https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260SB243",
+      ].join("\n"),
+      "CA_2025-2026_bill_versions.csv": [
+        "id,bill_id,note,date",
+        "ocd-version/1,ocd-bill/abc,Chaptered,2025-10-13",
+      ].join("\n"),
+      "CA_2025-2026_bill_version_links.csv": [
+        "version_id,url,media_type",
+        "ocd-version/1,https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202520260SB243,text/html",
+      ].join("\n"),
+    },
+    (directory) => {
+      const [bill] = readBulkBills(directory);
+      assert.ok(bill);
+
+      // The whole point of the bulk path: it must land on the same row the
+      // incremental API walk would produce, not a parallel one.
+      const normalized = normalizeBill(bill, { stateCode: "ca" });
+      assert.equal(normalized.billNumber, "CA SB 243 (2025-2026)");
+      assert.equal(normalized.status, "Chaptered into law");
+      assert.equal(normalized.chamber, "Senate");
+      assert.equal(normalized.sponsor, "Steve Padilla (D-18)");
+      assert.equal(normalized.summary, "Regulates companion chatbots.");
+      assert.match(normalized.url, /leginfo\.legislature\.ca\.gov/);
+      assert.match(normalized.textLink!.url, /billTextClient/);
+      assert.equal(normalized.actions.length, 2);
+    },
+  );
+});
+
+void test("an export with only bills.csv still yields storable bills", () => {
+  withExport({ "CA_2025-2026_bills.csv": BILLS_CSV }, (directory) => {
+    const [bill] = readBulkBills(directory);
+    const normalized = normalizeBill(bill!, { stateCode: "ca" });
+    assert.equal(normalized.billNumber, "CA SB 243 (2025-2026)");
+    assert.equal(normalized.status, "Unknown");
+    assert.equal(normalized.sponsor, undefined);
+    // Falls back to the Open States page when no sources table was exported.
+    assert.equal(
+      normalized.url,
+      "https://openstates.org/CA/bills/20252026/SB243/",
+    );
+  });
+});
+
+void test("a renamed or reshaped export fails loudly with the columns it saw", () => {
+  withExport(
+    { "CA_2025-2026_bills.csv": "bill_id,name\nocd-bill/abc,Something" },
+    (directory) => {
+      assert.throws(
+        () => readBulkBills(directory),
+        (error: unknown) => {
+          assert.ok(error instanceof BulkExportShapeError);
+          // The operator needs to see both what was expected and what arrived.
+          assert.match(error.message, /identifier/);
+          assert.match(error.message, /bill_id, name/);
+          return true;
+        },
+      );
+    },
+  );
+});
+
+void test("a directory that is not an export says so instead of importing nothing", () => {
+  withExport({ "readme.txt": "not csv" }, (directory) => {
+    assert.throws(() => readBulkBills(directory), /No bills\.csv found/);
+  });
+});

--- a/apps/scraper/src/scrapers/open-states-bulk.ts
+++ b/apps/scraper/src/scrapers/open-states-bulk.ts
@@ -1,0 +1,327 @@
+/**
+ * Backfill from an Open States bulk session-CSV export.
+ *
+ * Why this exists: the v3 API's free tier allows a few hundred requests a day,
+ * and a California session holds thousands of bills that each need several
+ * calls. Draining a session through the API alone takes weeks, which is how the
+ * CourtListener scraper ended up shelved. The bulk export carries the same data
+ * in one file and is refreshed regularly (CA 2025-2026 was current the day this
+ * was written), so it does the backfill and the API only carries the delta.
+ *
+ * Why it takes a directory instead of downloading: the archives at
+ * <https://open.pluralpolicy.com/data/session-csv/> are behind a site login,
+ * not the API key — "Please log in to access download links". Automating the
+ * fetch would mean storing account credentials in the scraper. Instead an
+ * operator downloads and unzips once, and points `--bulk-dir` at the result.
+ *
+ * The CSVs are assembled back into the same `OpenStatesBill` shape the API
+ * returns and handed to the same `normalizeBill`, so a backfilled bill and its
+ * later incremental refresh are the same row rather than two.
+ */
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type {
+  OpenStatesBill,
+  OpenStatesBillAbstract,
+  OpenStatesBillAction,
+  OpenStatesBillSponsorship,
+  OpenStatesBillVersion,
+} from "@acme/api/clients/open-states";
+
+/**
+ * Split RFC 4180 CSV text into rows.
+ *
+ * Hand-rolled because the scraper has no CSV dependency and bill data needs the
+ * quoting rules that a `split(",")` gets wrong: action descriptions contain
+ * commas ("Chaptered by Secretary of State, Chapter 677"), bill titles contain
+ * quotes, and abstracts contain embedded newlines. Getting any of those wrong
+ * shifts every later column by one and stores garbage silently.
+ */
+export function parseCsv(text: string): string[][] {
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let field = "";
+  let quoted = false;
+  // Strip a UTF-8 BOM; left in place it becomes part of the first header name.
+  const input = text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+
+  for (let index = 0; index < input.length; index++) {
+    const char = input[index]!;
+
+    if (quoted) {
+      if (char !== '"') {
+        field += char;
+      } else if (input[index + 1] === '"') {
+        field += '"';
+        index++;
+      } else {
+        quoted = false;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      quoted = true;
+    } else if (char === ",") {
+      row.push(field);
+      field = "";
+    } else if (char === "\n" || char === "\r") {
+      // Swallow the \n of a \r\n pair rather than emitting a blank row.
+      if (char === "\r" && input[index + 1] === "\n") index++;
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = "";
+    } else {
+      field += char;
+    }
+  }
+
+  // A file not ending in a newline still has one row left in hand.
+  if (field !== "" || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  // Trailing newlines produce a [""] row that is not a record.
+  return rows.filter((entry) => entry.length > 1 || entry[0] !== "");
+}
+
+export type CsvRecord = Record<string, string>;
+
+/** Rows keyed by header name. Short rows read as empty, not as undefined. */
+export function parseCsvRecords(text: string): CsvRecord[] {
+  const [header, ...rows] = parseCsv(text);
+  if (!header) return [];
+  const names = header.map((name) => name.trim());
+  return rows.map((row) => {
+    const record: CsvRecord = {};
+    names.forEach((name, index) => {
+      record[name] = row[index] ?? "";
+    });
+    return record;
+  });
+}
+
+/**
+ * Read a column that Open States may name either of two ways across export
+ * vintages. Returns "" when absent — callers decide whether that is fatal.
+ */
+function column(record: CsvRecord, ...names: string[]): string {
+  for (const name of names) {
+    const value = record[name];
+    if (value !== undefined && value !== "") return value.trim();
+  }
+  return "";
+}
+
+export class BulkExportShapeError extends Error {
+  constructor(file: string, missing: string[], found: string[]) {
+    super(
+      `${file}: missing required column(s) ${missing.join(", ")}. ` +
+        `Columns present: ${found.join(", ") || "(none)"}. ` +
+        `The Open States CSV export format is documented as experimental and may have changed.`,
+    );
+    this.name = "BulkExportShapeError";
+  }
+}
+
+/**
+ * Files in an export are named `{STATE}_{session}_{table}.csv`. Matching on the
+ * suffix rather than the full name keeps the reader working across states and
+ * sessions without the caller having to spell out the prefix.
+ */
+function findFile(directory: string, table: string): string | undefined {
+  const match = readdirSync(directory).find(
+    (name) =>
+      name.toLowerCase().endsWith(`${table}.csv`) ||
+      name.toLowerCase() === `${table}.csv`,
+  );
+  return match ? join(directory, match) : undefined;
+}
+
+function readTable(directory: string, table: string): CsvRecord[] {
+  const path = findFile(directory, table);
+  if (!path) return [];
+  return parseCsvRecords(readFileSync(path, "utf8"));
+}
+
+/** Group records by the bill they belong to. */
+function groupByBill(records: CsvRecord[]): Map<string, CsvRecord[]> {
+  const grouped = new Map<string, CsvRecord[]>();
+  for (const record of records) {
+    const billId = column(record, "bill_id", "bill");
+    if (!billId) continue;
+    const existing = grouped.get(billId);
+    if (existing) existing.push(record);
+    else grouped.set(billId, [record]);
+  }
+  return grouped;
+}
+
+function splitClassification(value: string): string[] {
+  return value
+    .split(/[,;|]/)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Rebuild `OpenStatesBill` objects from an unzipped export directory.
+ *
+ * Only `bills.csv` is required. Every other table is an optional enrichment:
+ * an export missing sponsorships produces bills without a sponsor rather than
+ * no bills at all, and the incremental API walk fills the gap on its next pass.
+ * That is the right trade for a backfill — a bill in the database without a
+ * sponsor is recoverable, a bill that never landed is not.
+ */
+export function readBulkBills(
+  directory: string,
+  options: { session?: string } = {},
+): OpenStatesBill[] {
+  const billRows = readTable(directory, "bills");
+  if (billRows.length === 0) {
+    throw new Error(
+      `No bills.csv found in ${directory}. Expected an unzipped Open States session-CSV export (a directory containing e.g. CA_2025-2026_bills.csv).`,
+    );
+  }
+
+  const firstRow = billRows[0]!;
+  const missing = (["id", "identifier", "title"] as const).filter(
+    (name) => !column(firstRow, name),
+  );
+  if (missing.length > 0) {
+    throw new BulkExportShapeError(
+      "bills.csv",
+      [...missing],
+      Object.keys(firstRow),
+    );
+  }
+
+  const actionsByBill = groupByBill(readTable(directory, "bill_actions"));
+  const abstractsByBill = groupByBill(readTable(directory, "bill_abstracts"));
+  const sponsorsByBill = groupByBill(readTable(directory, "bill_sponsorships"));
+  const sourcesByBill = groupByBill(readTable(directory, "bill_sources"));
+  const versionsByBill = groupByBill(readTable(directory, "bill_versions"));
+
+  // Version text lives one table further out, keyed by version rather than by
+  // bill. Absent that table there are no text links, which is survivable.
+  const linksByVersion = new Map<string, CsvRecord[]>();
+  for (const record of readTable(directory, "bill_version_links")) {
+    const versionId = column(record, "version_id", "bill_version_id");
+    if (!versionId) continue;
+    const existing = linksByVersion.get(versionId);
+    if (existing) existing.push(record);
+    else linksByVersion.set(versionId, [record]);
+  }
+
+  return billRows.map((row) => {
+    const id = column(row, "id");
+
+    const actions: OpenStatesBillAction[] = (actionsByBill.get(id) ?? []).map(
+      (record) => ({
+        date: column(record, "date"),
+        description: column(record, "description"),
+        classification: splitClassification(column(record, "classification")),
+      }),
+    );
+
+    const abstracts: OpenStatesBillAbstract[] = (
+      abstractsByBill.get(id) ?? []
+    ).map((record) => ({
+      abstract: column(record, "abstract"),
+      note: column(record, "note"),
+    }));
+
+    const sponsorships: OpenStatesBillSponsorship[] = (
+      sponsorsByBill.get(id) ?? []
+    ).map((record) => {
+      const name = column(record, "name");
+      const party = column(record, "party", "primary_party");
+      const district = column(record, "district");
+      return {
+        name,
+        entity_type: column(record, "entity_type") || "person",
+        classification: column(record, "classification") || "primary",
+        primary: /^(true|1|t|yes)$/i.test(column(record, "primary")),
+        // The export carries party/district as flat columns rather than a
+        // nested person; reassemble just enough of one for `formatSponsor`.
+        ...(party || district
+          ? {
+              person: {
+                id: column(record, "person_id"),
+                name,
+                party,
+                ...(district
+                  ? {
+                      current_role: {
+                        title: "",
+                        org_classification: "",
+                        district,
+                        division_id: "",
+                      },
+                    }
+                  : {}),
+              },
+            }
+          : {}),
+      };
+    });
+
+    const versions: OpenStatesBillVersion[] = (
+      versionsByBill.get(id) ?? []
+    ).map((record) => ({
+      note: column(record, "note"),
+      date: column(record, "date"),
+      links: (linksByVersion.get(column(record, "id")) ?? []).map((link) => ({
+        url: column(link, "url"),
+        media_type: column(link, "media_type") || undefined,
+      })),
+    }));
+
+    const sources = (sourcesByBill.get(id) ?? [])
+      .map((record) => ({ url: column(record, "url") }))
+      .filter((source) => source.url);
+
+    const organizationClassification = column(
+      row,
+      "organization_classification",
+      "from_organization_classification",
+      "chamber",
+    );
+
+    return {
+      id,
+      identifier: column(row, "identifier"),
+      title: column(row, "title"),
+      session:
+        column(row, "session", "legislative_session") ||
+        (options.session ?? ""),
+      classification: splitClassification(column(row, "classification")),
+      ...(organizationClassification
+        ? {
+            from_organization: {
+              id: "",
+              name: "",
+              classification: organizationClassification,
+            },
+          }
+        : {}),
+      jurisdiction: {
+        id: column(row, "jurisdiction_id", "jurisdiction"),
+        name: column(row, "jurisdiction_name", "jurisdiction"),
+        classification: "state",
+      },
+      abstracts,
+      actions,
+      sponsorships,
+      versions,
+      sources,
+      created_at: column(row, "created_at", "first_action_date"),
+      updated_at: column(row, "updated_at", "latest_action_date"),
+      openstates_url: column(row, "openstates_url", "url"),
+    } satisfies OpenStatesBill;
+  });
+}

--- a/apps/scraper/src/scrapers/open-states-normalize.test.ts
+++ b/apps/scraper/src/scrapers/open-states-normalize.test.ts
@@ -1,0 +1,496 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { OpenStatesBill } from "@acme/api/clients/open-states";
+
+import {
+  buildBillNumber,
+  formatSessionLabel,
+  formatSponsor,
+  latestAction,
+  mapChamber,
+  mapStatus,
+  normalizeActions,
+  normalizeBill,
+  normalizeIdentifier,
+  OPEN_STATES_SOURCE,
+  parseBillNumber,
+  pickAbstract,
+  pickSourceUrl,
+  pickVersionLink,
+  UnnormalizableBillError,
+} from "./open-states-normalize.js";
+
+// ---------------------------------------------------------------------------
+// Identifier stability
+// ---------------------------------------------------------------------------
+
+void test("identifier spacing does not change a bill's identity", () => {
+  // The CSV bulk export and the API do not always agree on spacing. If they
+  // normalized differently, backfilling a session would duplicate every bill
+  // the incremental walk had already stored.
+  for (const raw of ["SB 243", "SB243", "sb  243", " sb.243 "]) {
+    assert.equal(normalizeIdentifier(raw), "SB 243");
+  }
+});
+
+void test("bill numbers carry state and session so they cannot collide", () => {
+  const ca2025 = buildBillNumber({
+    stateCode: "ca",
+    identifier: "SB 243",
+    session: "20252026",
+  });
+  const ca2023 = buildBillNumber({
+    stateCode: "ca",
+    identifier: "SB 243",
+    session: "20232024",
+  });
+  const ny2025 = buildBillNumber({
+    stateCode: "ny",
+    identifier: "SB 243",
+    session: "20252026",
+  });
+
+  assert.equal(ca2025, "CA SB 243 (2025-2026)");
+  assert.notEqual(ca2025, ca2023);
+  assert.notEqual(ca2025, ny2025);
+  // And nothing here can look like a congress.gov bill number.
+  assert.doesNotMatch(ca2025!, /^H\.R\.|^S\./);
+});
+
+void test("bill numbers round-trip back to their state and identifier", () => {
+  const parsed = parseBillNumber("CA SB 243 (2025-2026)");
+  assert.deepEqual(parsed, {
+    stateCode: "CA",
+    identifier: "SB 243",
+    sessionLabel: "2025-2026",
+  });
+});
+
+void test("only eight-digit sessions are reshaped; others pass through", () => {
+  assert.equal(formatSessionLabel("20252026"), "2025-2026");
+  assert.equal(formatSessionLabel("2025"), "2025");
+  assert.equal(formatSessionLabel("2025S1"), "2025S1");
+});
+
+void test("an undecomposable identifier yields no bill number", () => {
+  assert.equal(normalizeIdentifier("Proposition 13-A-2"), undefined);
+  assert.equal(
+    buildBillNumber({
+      stateCode: "ca",
+      identifier: "???",
+      session: "20252026",
+    }),
+    undefined,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Chamber mapping
+// ---------------------------------------------------------------------------
+
+void test("California's lower chamber is the Assembly, not the House", () => {
+  assert.equal(
+    mapChamber({ stateCode: "ca", identifier: "AB 1064" }, "lower"),
+    "Assembly",
+  );
+  assert.equal(
+    mapChamber({ stateCode: "ca", identifier: "SB 243" }, "upper"),
+    "Senate",
+  );
+});
+
+void test("chamber falls back to the identifier prefix", () => {
+  assert.equal(
+    mapChamber({ stateCode: "ca", identifier: "SB 243" }, undefined),
+    "Senate",
+  );
+  assert.equal(
+    mapChamber({ stateCode: "ca", identifier: "AB 1064" }, undefined),
+    "Assembly",
+  );
+  // An unlisted state keeps the common Senate/House vocabulary.
+  assert.equal(
+    mapChamber({ stateCode: "tx", identifier: "HB 20" }, "lower"),
+    "House",
+  );
+});
+
+void test("an unrecognizable chamber is left unset rather than guessed", () => {
+  assert.equal(
+    mapChamber({ stateCode: "ca", identifier: "XR 5" }, undefined),
+    undefined,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Status mapping
+// ---------------------------------------------------------------------------
+
+const action = (
+  date: string,
+  description: string,
+  classification: string[] = [],
+) => ({ date, description, classification });
+
+void test("status comes from the newest action, whatever order they arrive in", () => {
+  const actions = [
+    action("2025-10-13", "Chaptered by Secretary of State", ["became-law"]),
+    action("2025-01-30", "Introduced", ["introduction"]),
+  ];
+  assert.equal(mapStatus(actions), "Chaptered into law");
+  assert.equal(
+    latestAction(actions)?.description,
+    "Chaptered by Secretary of State",
+  );
+});
+
+void test("terminal classifications win over procedural ones on the same action", () => {
+  assert.equal(
+    mapStatus([
+      action("2025-10-13", "Approved by the Governor", [
+        "passage",
+        "executive-signature",
+      ]),
+    ]),
+    "Signed by the governor",
+  );
+});
+
+void test("vetoes and failures map to their own labels", () => {
+  assert.equal(
+    mapStatus([action("2025-09-01", "Vetoed", ["executive-veto"])]),
+    "Vetoed by the governor",
+  );
+  assert.equal(
+    mapStatus([action("2025-09-01", "Died in committee", ["failure"])]),
+    "Failed",
+  );
+});
+
+void test("an unclassified action falls back to its own description, unsliced", () => {
+  const long = `Read third time. ${"Amended. ".repeat(40)}Passed.`;
+  assert.equal(mapStatus([action("2025-05-01", long)]), long);
+});
+
+void test("a bill with no actions has an explicit unknown status", () => {
+  assert.equal(mapStatus(undefined), "Unknown");
+  assert.equal(mapStatus([]), "Unknown");
+});
+
+void test("undated actions never outrank dated ones", () => {
+  assert.equal(
+    latestAction([
+      action("", "Unknown-date filing"),
+      action("2025-01-30", "Introduced", ["introduction"]),
+    ])?.description,
+    "Introduced",
+  );
+});
+
+void test("same-day actions keep source order so the later step wins", () => {
+  assert.equal(
+    latestAction([
+      action("2025-01-30", "Introduced", ["introduction"]),
+      action("2025-01-30", "Referred to Com. on JUD.", ["referral-committee"]),
+    ])?.description,
+    "Referred to Com. on JUD.",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Optional fields
+// ---------------------------------------------------------------------------
+
+void test("sponsor formatting degrades as the source thins out", () => {
+  assert.equal(
+    formatSponsor([
+      {
+        name: "Padilla",
+        entity_type: "person",
+        classification: "primary",
+        primary: true,
+        person: {
+          id: "ocd-person/1",
+          name: "Steve Padilla",
+          party: "Democratic",
+          current_role: {
+            title: "Senator",
+            org_classification: "upper",
+            district: "18",
+            division_id: "ocd-division/x",
+          },
+        },
+      },
+    ]),
+    "Steve Padilla (D-18)",
+  );
+
+  // No resolved person: the bare sponsorship name is still worth showing.
+  assert.equal(
+    formatSponsor([
+      {
+        name: "Committee on Judiciary",
+        entity_type: "organization",
+        classification: "primary",
+        primary: true,
+      },
+    ]),
+    "Committee on Judiciary",
+  );
+
+  assert.equal(formatSponsor([]), undefined);
+  assert.equal(formatSponsor(undefined), undefined);
+});
+
+void test("a non-primary sponsorship is used when no primary one exists", () => {
+  assert.equal(
+    formatSponsor([
+      {
+        name: "A Cosponsor",
+        entity_type: "person",
+        classification: "cosponsor",
+        primary: false,
+      },
+    ]),
+    "A Cosponsor",
+  );
+});
+
+void test("the longest abstract is kept as summary source", () => {
+  assert.equal(
+    pickAbstract([
+      { abstract: "Short digest.", note: "digest" },
+      {
+        abstract: "A considerably longer legislative counsel's digest.",
+        note: "counsel",
+      },
+    ]),
+    "A considerably longer legislative counsel's digest.",
+  );
+  assert.equal(pickAbstract([{ abstract: "   ", note: "" }]), undefined);
+  assert.equal(pickAbstract(undefined), undefined);
+});
+
+void test("text selection prefers the newest text version and skips PDF-only ones", () => {
+  const picked = pickVersionLink([
+    {
+      note: "Introduced",
+      date: "2025-01-30",
+      links: [
+        { url: "https://example.gov/introduced.html", media_type: "text/html" },
+      ],
+    },
+    {
+      note: "Chaptered",
+      date: "2025-10-13",
+      links: [
+        {
+          url: "https://example.gov/chaptered.pdf",
+          media_type: "application/pdf",
+        },
+        { url: "https://example.gov/chaptered.html", media_type: "text/html" },
+      ],
+    },
+  ]);
+  assert.equal(picked?.url, "https://example.gov/chaptered.html");
+  assert.equal(picked?.note, "Chaptered");
+});
+
+void test("a PDF-only bill yields no text link rather than a PDF one", () => {
+  assert.equal(
+    pickVersionLink([
+      {
+        note: "Introduced",
+        date: "2025-01-30",
+        links: [
+          { url: "https://example.gov/x.pdf", media_type: "application/pdf" },
+        ],
+      },
+    ]),
+    undefined,
+  );
+  assert.equal(pickVersionLink(undefined), undefined);
+});
+
+void test("the official state URL beats the Open States mirror", () => {
+  assert.equal(
+    pickSourceUrl({
+      sources: [
+        { url: "https://example.com/aggregator" },
+        { url: "https://leginfo.legislature.ca.gov/faces/x.xhtml?bill_id=1" },
+      ],
+      openstates_url: "https://openstates.org/CA/bills/20252026/SB243/",
+    }),
+    "https://leginfo.legislature.ca.gov/faces/x.xhtml?bill_id=1",
+  );
+
+  assert.equal(
+    pickSourceUrl({
+      sources: [{ url: "not a url" }],
+      openstates_url: "https://openstates.org/CA/bills/20252026/SB243/",
+    }),
+    "https://openstates.org/CA/bills/20252026/SB243/",
+  );
+
+  assert.equal(pickSourceUrl({}), undefined);
+});
+
+void test("actions keep their classifications and drop empty descriptions", () => {
+  assert.deepEqual(
+    normalizeActions([
+      action("2025-01-30", "  Introduced  ", ["introduction", "reading-1"]),
+      action("2025-02-01", "   "),
+    ]),
+    [
+      {
+        date: "2025-01-30",
+        text: "Introduced",
+        type: "introduction, reading-1",
+      },
+    ],
+  );
+  assert.deepEqual(normalizeActions(undefined), []);
+});
+
+// ---------------------------------------------------------------------------
+// Whole-bill normalization
+// ---------------------------------------------------------------------------
+
+const sb243: OpenStatesBill = {
+  id: "ocd-bill/abc",
+  identifier: "SB 243",
+  title: "Companion chatbots",
+  session: "20252026",
+  classification: ["bill"],
+  from_organization: {
+    id: "ocd-organization/senate",
+    name: "Senate",
+    classification: "upper",
+  },
+  jurisdiction: {
+    id: "ocd-jurisdiction/country:us/state:ca/government",
+    name: "California",
+    classification: "state",
+  },
+  abstracts: [{ abstract: "Regulates companion chatbots.", note: "digest" }],
+  actions: [
+    {
+      date: "2025-01-30",
+      description: "Introduced",
+      classification: ["introduction"],
+    },
+    {
+      date: "2025-10-13",
+      description: "Chaptered by Secretary of State, Chapter 677",
+      classification: ["became-law"],
+    },
+  ],
+  sponsorships: [
+    {
+      name: "Padilla",
+      entity_type: "person",
+      classification: "primary",
+      primary: true,
+      person: {
+        id: "ocd-person/1",
+        name: "Steve Padilla",
+        party: "Democratic",
+        current_role: {
+          title: "Senator",
+          org_classification: "upper",
+          district: "18",
+          division_id: "ocd-division/x",
+        },
+      },
+    },
+  ],
+  versions: [
+    {
+      note: "Chaptered",
+      date: "2025-10-13",
+      links: [
+        {
+          url: "https://leginfo.legislature.ca.gov/faces/billTextClient.xhtml?bill_id=202520260SB243",
+          media_type: "text/html",
+        },
+      ],
+    },
+  ],
+  sources: [
+    {
+      url: "https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=202520260SB243",
+    },
+  ],
+  created_at: "2025-01-30T00:00:00Z",
+  updated_at: "2025-10-14T12:00:00Z",
+  openstates_url: "https://openstates.org/CA/bills/20252026/SB243/",
+};
+
+void test("California SB 243 normalizes with full jurisdiction metadata", () => {
+  const normalized = normalizeBill(sb243, { stateCode: "ca" });
+
+  assert.equal(normalized.billNumber, "CA SB 243 (2025-2026)");
+  assert.equal(normalized.title, "Companion chatbots");
+  assert.equal(normalized.chamber, "Senate");
+  assert.equal(normalized.session, "20252026");
+  assert.equal(normalized.stateCode, "CA");
+  assert.equal(normalized.sponsor, "Steve Padilla (D-18)");
+  assert.equal(normalized.status, "Chaptered into law");
+  assert.equal(normalized.summary, "Regulates companion chatbots.");
+  assert.equal(normalized.sourceWebsite, OPEN_STATES_SOURCE);
+  assert.match(normalized.url, /leginfo\.legislature\.ca\.gov/);
+  assert.equal(
+    normalized.introducedDate?.toISOString(),
+    "2025-01-30T00:00:00.000Z",
+  );
+  assert.equal(
+    normalized.sourceUpdatedAt?.toISOString(),
+    "2025-10-14T12:00:00.000Z",
+  );
+  assert.equal(normalized.actions.length, 2);
+  assert.match(normalized.textLink!.url, /billTextClient/);
+});
+
+void test("a bill stripped of every optional field still normalizes", () => {
+  const bare: OpenStatesBill = {
+    id: "ocd-bill/bare",
+    identifier: "AB 1",
+    title: "A bare bill",
+    session: "20252026",
+    classification: ["bill"],
+    jurisdiction: sb243.jurisdiction,
+    created_at: "2025-01-05T00:00:00Z",
+    updated_at: "2025-01-06T00:00:00Z",
+    openstates_url: "https://openstates.org/CA/bills/20252026/AB1/",
+  };
+
+  const normalized = normalizeBill(bare, { stateCode: "ca" });
+  assert.equal(normalized.billNumber, "CA AB 1 (2025-2026)");
+  assert.equal(normalized.chamber, "Assembly");
+  assert.equal(normalized.status, "Unknown");
+  assert.equal(normalized.sponsor, undefined);
+  assert.equal(normalized.summary, undefined);
+  assert.equal(normalized.textLink, undefined);
+  assert.deepEqual(normalized.actions, []);
+  // With no introduction action, the source's creation date stands in.
+  assert.equal(
+    normalized.introducedDate?.toISOString(),
+    "2025-01-05T00:00:00.000Z",
+  );
+  assert.equal(normalized.url, bare.openstates_url);
+});
+
+void test("a bill with no stable identifier is refused, not stored", () => {
+  assert.throws(
+    () => normalizeBill({ ...sb243, identifier: "???" }, { stateCode: "ca" }),
+    UnnormalizableBillError,
+  );
+});
+
+void test("a bill with no title is refused", () => {
+  assert.throws(
+    () => normalizeBill({ ...sb243, title: "   " }, { stateCode: "ca" }),
+    UnnormalizableBillError,
+  );
+});

--- a/apps/scraper/src/scrapers/open-states-normalize.test.ts
+++ b/apps/scraper/src/scrapers/open-states-normalize.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import type { OpenStatesBill } from "@acme/api/clients/open-states";
 
+import { latestActionDate } from "../utils/last-action.js";
 import {
   buildBillNumber,
   formatSessionLabel,
@@ -479,6 +480,17 @@ void test("a bill stripped of every optional field still normalizes", () => {
     "2025-01-05T00:00:00.000Z",
   );
   assert.equal(normalized.url, bare.openstates_url);
+});
+
+void test("normalized actions feed the shared last-action date", () => {
+  // `lastActionAt` is the cross-source sort key for the whole feed, so a CA
+  // bill has to fill it from the same kind of event a federal one does: the
+  // newest real action (chaptered), not the introduction and not our clock.
+  const normalized = normalizeBill(sb243, { stateCode: "ca" });
+  assert.equal(
+    latestActionDate(normalized.actions)?.toISOString(),
+    "2025-10-13T00:00:00.000Z",
+  );
 });
 
 void test("a bill with no stable identifier is refused, not stored", () => {

--- a/apps/scraper/src/scrapers/open-states-normalize.ts
+++ b/apps/scraper/src/scrapers/open-states-normalize.ts
@@ -1,0 +1,470 @@
+/**
+ * Normalization from Open States v3 shapes into Billion's `Bill` contract.
+ *
+ * Everything here is pure so the API walk and the bulk-CSV backfill can share
+ * one definition of what a state bill looks like. The two paths carry different
+ * source shapes but must produce byte-identical rows — otherwise a backfilled
+ * bill and its later incremental refresh become two rows, or worse, thrash the
+ * content hash and regenerate enrichment on every run.
+ */
+
+import type {
+  OpenStatesBill,
+  OpenStatesBillAbstract,
+  OpenStatesBillAction,
+  OpenStatesBillSponsorship,
+  OpenStatesBillVersion,
+} from "@acme/api/clients/open-states";
+
+/**
+ * Written into `Bill.sourceWebsite` for every state bill regardless of which
+ * state it came from.
+ *
+ * The uniqueness constraint on `Bill` is (billNumber, sourceWebsite), so this
+ * value is half of every state bill's identity: changing it orphans every row
+ * already stored. The state and session live in `billNumber` instead — see
+ * `buildBillNumber`.
+ */
+export const OPEN_STATES_SOURCE = "openstates.org";
+
+interface ChamberNames {
+  upper: string;
+  lower: string;
+}
+
+/**
+ * What each state calls its chambers. `upper`/`lower` is the only chamber
+ * vocabulary Open States exposes, and "lower house" is not a name any reader
+ * recognises — California's is the Assembly, and SB 243 sitting under "House"
+ * would be simply wrong.
+ *
+ * Unlisted states fall back to Senate/House, which is correct for most of them.
+ * Add a state here when adding it to the scraper's jurisdiction list, rather
+ * than pre-registering all fifty from memory.
+ */
+const CHAMBER_NAMES: Record<string, ChamberNames> = {
+  ca: { upper: "Senate", lower: "Assembly" },
+};
+
+const DEFAULT_CHAMBER_NAMES: ChamberNames = { upper: "Senate", lower: "House" };
+
+export function chamberNamesFor(stateCode: string): ChamberNames {
+  return CHAMBER_NAMES[stateCode.toLowerCase()] ?? DEFAULT_CHAMBER_NAMES;
+}
+
+/**
+ * Split a bill identifier into its alphabetic prefix and numeric part, so
+ * spacing differences between sources cannot produce two identities for one
+ * bill. "SB243", "SB 243" and "sb  243" are all the same bill, and the CSV
+ * bulk export and the API do not always agree on the spacing.
+ *
+ * Returns undefined for anything that is not <letters><digits><optional
+ * suffix>, which is deliberate: an identifier we cannot decompose is one we
+ * cannot promise a stable key for, and the caller refuses the bill rather than
+ * inventing one.
+ */
+export function parseIdentifier(
+  identifier: string,
+): { prefix: string; number: string } | undefined {
+  const match = /^\s*([A-Za-z]+)[\s.]*(\d+[A-Za-z]?)\s*$/.exec(identifier);
+  if (!match) return undefined;
+  return { prefix: match[1]!.toUpperCase(), number: match[2]!.toUpperCase() };
+}
+
+/** "SB243" / "sb  243" → "SB 243". Undefined when it cannot be decomposed. */
+export function normalizeIdentifier(identifier: string): string | undefined {
+  const parsed = parseIdentifier(identifier);
+  return parsed && `${parsed.prefix} ${parsed.number}`;
+}
+
+/**
+ * Human-readable session label. Open States session identifiers for
+ * two-year states are eight digits ("20252026"); everything else (special
+ * sessions, single-year states) is passed through untouched rather than
+ * guessed at.
+ */
+export function formatSessionLabel(session: string): string {
+  const match = /^(\d{4})(\d{4})$/.exec(session.trim());
+  if (!match) return session.trim();
+  return `${match[1]}-${match[2]}`;
+}
+
+/**
+ * The stored `Bill.billNumber`, and with `OPEN_STATES_SOURCE` the row's whole
+ * identity.
+ *
+ * Three things have to be in it. The **state**, because SB 243 exists in most
+ * states. The **session**, because SB 243 exists in every California session
+ * and they are unrelated bills. And a shape that cannot collide with
+ * congress.gov's ("H.R. 1234") — the state prefix guarantees that even before
+ * `sourceWebsite` does.
+ *
+ * Stability matters more than prettiness here: every character of this string
+ * is load-bearing, and changing the format silently duplicates every bill.
+ */
+export function buildBillNumber(args: {
+  stateCode: string;
+  identifier: string;
+  session: string;
+}): string | undefined {
+  const identifier = normalizeIdentifier(args.identifier);
+  if (!identifier) return undefined;
+  const state = args.stateCode.trim().toUpperCase();
+  if (!state) return undefined;
+  return `${state} ${identifier} (${formatSessionLabel(args.session)})`;
+}
+
+/**
+ * Recover {stateCode, identifier} from a stored billNumber. The inverse of
+ * `buildBillNumber` for the session-free parts — the session label is not
+ * round-tripped because its source form is not recoverable from the label.
+ */
+export function parseBillNumber(
+  billNumber: string,
+): { stateCode: string; identifier: string; sessionLabel: string } | undefined {
+  const match = /^([A-Z]{2})\s+([A-Z]+\s\d+[A-Z]?)\s+\((.+)\)$/.exec(
+    billNumber.trim(),
+  );
+  if (!match) return undefined;
+  return {
+    stateCode: match[1]!,
+    identifier: match[2]!,
+    sessionLabel: match[3]!,
+  };
+}
+
+/**
+ * Chamber name for display. Prefers the originating organization's
+ * classification, then the identifier prefix — "S…" is an upper-chamber bill
+ * and "A…"/"H…" a lower-chamber one in every state that uses those letters.
+ */
+export function mapChamber(
+  args: { stateCode: string; identifier: string },
+  classification?: string,
+): string | undefined {
+  const names = chamberNamesFor(args.stateCode);
+  const normalized = classification?.toLowerCase();
+  if (normalized === "upper") return names.upper;
+  if (normalized === "lower") return names.lower;
+  if (normalized === "legislature") return "Legislature";
+
+  const prefix = parseIdentifier(args.identifier)?.prefix;
+  if (!prefix) return undefined;
+  if (prefix.startsWith("S")) return names.upper;
+  if (prefix.startsWith("A") || prefix.startsWith("H")) return names.lower;
+  return undefined;
+}
+
+/**
+ * Newest action, by date.
+ *
+ * Open States documents actions as chronological, but this does not trust that:
+ * `status` is derived from whichever action comes back last, and reading a
+ * chaptered bill as "Introduced" because one feed arrived reversed is the kind
+ * of wrong that looks right. Undated actions sort first — an action with no
+ * date is not evidence of being the latest — and ties keep source order, so a
+ * same-day introduction/referral pair still reads as the referral.
+ */
+export function latestAction(
+  actions: readonly OpenStatesBillAction[] | undefined,
+): OpenStatesBillAction | undefined {
+  if (!actions?.length) return undefined;
+  return actions
+    .map((action, index) => ({ action, index }))
+    .sort((left, right) => {
+      const leftTime = Date.parse(left.action.date ?? "");
+      const rightTime = Date.parse(right.action.date ?? "");
+      const leftValid = !Number.isNaN(leftTime);
+      const rightValid = !Number.isNaN(rightTime);
+      if (leftValid && rightValid && leftTime !== rightTime) {
+        return leftTime - rightTime;
+      }
+      if (leftValid !== rightValid) return leftValid ? 1 : -1;
+      return left.index - right.index;
+    })
+    .at(-1)?.action;
+}
+
+/**
+ * Canonical labels for the action classifications that describe a bill's fate.
+ * Ordered most-final first: an action carrying both `passage` and
+ * `executive-signature` is a signing, not a passage.
+ */
+const STATUS_BY_CLASSIFICATION: readonly [string, string][] = [
+  ["became-law", "Chaptered into law"],
+  ["executive-signature", "Signed by the governor"],
+  ["executive-veto", "Vetoed by the governor"],
+  ["veto-override-passage", "Veto overridden"],
+  ["executive-veto-line-item", "Line-item vetoed by the governor"],
+  ["withdrawal", "Withdrawn"],
+  ["failure", "Failed"],
+  ["passage", "Passed"],
+  ["committee-passage", "Passed committee"],
+  ["referral-committee", "Referred to committee"],
+  ["introduction", "Introduced"],
+];
+
+/**
+ * A short status for the bill's newest action.
+ *
+ * Prefers a canonical label from the action's OCD classification and falls back
+ * to the action's own description, which is always meaningful even when the
+ * classification list is empty (Open States leaves it empty fairly often).
+ * The description is stored whole — `Bill.status` is `text`, and slicing it is
+ * what once made long-action bills fail to insert entirely.
+ */
+export function mapStatus(
+  actions: readonly OpenStatesBillAction[] | undefined,
+): string {
+  const action = latestAction(actions);
+  if (!action) return "Unknown";
+
+  const classifications = new Set(
+    (action.classification ?? []).map((value) => value.toLowerCase()),
+  );
+  for (const [classification, label] of STATUS_BY_CLASSIFICATION) {
+    if (classifications.has(classification)) return label;
+  }
+  return action.description?.trim() || "Unknown";
+}
+
+/** Actions in the shape `Bill.actions` stores, oldest first. */
+export function normalizeActions(
+  actions: readonly OpenStatesBillAction[] | undefined,
+): { date: string; text: string; type?: string }[] {
+  if (!actions?.length) return [];
+  return actions
+    .filter((action) => action.description?.trim())
+    .map((action) => ({
+      date: action.date,
+      text: action.description.trim(),
+      // `type` mirrors congress.gov's coarse action type. Open States has no
+      // single equivalent, so the classification list is joined rather than
+      // dropped — the brief generator reads it as free text either way.
+      ...(action.classification?.length
+        ? { type: action.classification.join(", ") }
+        : {}),
+    }));
+}
+
+const PARTY_ABBREVIATIONS: Record<string, string> = {
+  democratic: "D",
+  democrat: "D",
+  republican: "R",
+  independent: "I",
+  libertarian: "L",
+  green: "G",
+  nonpartisan: "NP",
+};
+
+function abbreviateParty(party: string): string {
+  return PARTY_ABBREVIATIONS[party.trim().toLowerCase()] ?? party.trim();
+}
+
+/**
+ * Primary sponsor as "Name (D-14)", matching the federal scraper's shape so
+ * both kinds of bill read the same in the app. Falls back through
+ * co-sponsorships and to the bare name when Open States has not resolved the
+ * sponsorship to a person — a name with no party is still worth showing.
+ */
+export function formatSponsor(
+  sponsorships: readonly OpenStatesBillSponsorship[] | undefined,
+): string | undefined {
+  if (!sponsorships?.length) return undefined;
+  const sponsorship =
+    sponsorships.find((candidate) => candidate.primary) ?? sponsorships[0]!;
+
+  const name = sponsorship.person?.name ?? sponsorship.name;
+  if (!name?.trim()) return undefined;
+
+  const party = sponsorship.person?.party;
+  const district = sponsorship.person?.current_role?.district;
+  const qualifier = [party && abbreviateParty(party), district]
+    .filter(Boolean)
+    .join("-");
+
+  const formatted = qualifier ? `${name.trim()} (${qualifier})` : name.trim();
+  // `Bill.sponsor` is varchar(256); stay inside it the way congress.ts does.
+  return formatted.slice(0, 250);
+}
+
+/**
+ * The abstract to keep as source material for the brief generator.
+ *
+ * Longest wins. States file several — California publishes both a one-line
+ * digest and a full legislative counsel's digest under different notes — and
+ * the longer one is the one with enough substance to summarise from.
+ */
+export function pickAbstract(
+  abstracts: readonly OpenStatesBillAbstract[] | undefined,
+): string | undefined {
+  if (!abstracts?.length) return undefined;
+  const best = abstracts
+    .map((entry) => entry.abstract?.trim())
+    .filter((value): value is string => Boolean(value))
+    .sort((left, right) => right.length - left.length)[0];
+  return best || undefined;
+}
+
+const TEXT_MEDIA_PREFERENCE = ["text/html", "text/plain"];
+
+/**
+ * The link to fetch a bill's operative text from.
+ *
+ * Newest version first, and only text formats: PDF-only versions are left for
+ * the abstract to cover rather than run through a PDF pipeline this scraper
+ * does not have. Undated versions sort last, for the same reason the federal
+ * scraper does it — an undated version is not evidence of being current, and
+ * storing an introduced draft as though it were the chaptered text is the exact
+ * failure that made the federal briefs wrong for months.
+ */
+export function pickVersionLink(
+  versions: readonly OpenStatesBillVersion[] | undefined,
+): { url: string; mediaType?: string; note?: string } | undefined {
+  if (!versions?.length) return undefined;
+
+  const ordered = [...versions].sort((left, right) => {
+    const leftTime = Date.parse(left.date ?? "");
+    const rightTime = Date.parse(right.date ?? "");
+    const leftValid = !Number.isNaN(leftTime);
+    const rightValid = !Number.isNaN(rightTime);
+    if (leftValid && rightValid) return rightTime - leftTime;
+    if (leftValid) return -1;
+    if (rightValid) return 1;
+    return 0;
+  });
+
+  for (const version of ordered) {
+    for (const mediaType of TEXT_MEDIA_PREFERENCE) {
+      const link = version.links?.find(
+        (candidate) => candidate.media_type?.toLowerCase() === mediaType,
+      );
+      if (link?.url) {
+        return { url: link.url, mediaType, note: version.note };
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The canonical link for a reader to follow.
+ *
+ * An official state URL beats the Open States mirror: it is what the bill's own
+ * legislature publishes, it is what a reader can cite, and it is what the issue
+ * report linked. Open States' own page is the fallback, and it always exists.
+ */
+export function pickSourceUrl(bill: {
+  sources?: { url: string; note?: string }[];
+  openstates_url?: string;
+}): string | undefined {
+  const official = bill.sources?.find((source) => {
+    if (!source.url) return false;
+    try {
+      return new URL(source.url).hostname.toLowerCase().endsWith(".gov");
+    } catch {
+      return false;
+    }
+  });
+  return official?.url ?? bill.openstates_url ?? undefined;
+}
+
+/** A bill normalized far enough to hand to `upsertContent`, minus full text. */
+export interface NormalizedStateBill {
+  billNumber: string;
+  title: string;
+  sponsor?: string;
+  status: string;
+  introducedDate?: Date;
+  chamber?: string;
+  summary?: string;
+  actions: { date: string; text: string; type?: string }[];
+  url: string;
+  sourceWebsite: string;
+  sourceUpdatedAt?: Date;
+  /** Where to fetch the operative bill text, when a text format exists. */
+  textLink?: { url: string; mediaType?: string; note?: string };
+  /** Carried for logging and the leginfo link, not persisted directly. */
+  stateCode: string;
+  session: string;
+}
+
+export class UnnormalizableBillError extends Error {
+  constructor(
+    readonly identifier: string,
+    reason: string,
+  ) {
+    super(`${identifier}: ${reason}`);
+    this.name = "UnnormalizableBillError";
+  }
+}
+
+function parseDate(value: string | undefined): Date | undefined {
+  if (!value?.trim()) return undefined;
+  // Open States dates are sometimes bare "YYYY-MM-DD"; Date.parse reads those
+  // as UTC midnight, which is what we want for a legislative calendar date.
+  const time = Date.parse(value);
+  return Number.isNaN(time) ? undefined : new Date(time);
+}
+
+/**
+ * Full normalization of an Open States bill. Throws `UnnormalizableBillError`
+ * rather than returning a partial record: a bill with no stable identifier or
+ * no title cannot be stored without either colliding with another row or
+ * showing a reader a blank card.
+ */
+export function normalizeBill(
+  bill: OpenStatesBill,
+  options: { stateCode: string },
+): NormalizedStateBill {
+  const billNumber = buildBillNumber({
+    stateCode: options.stateCode,
+    identifier: bill.identifier,
+    session: bill.session,
+  });
+  if (!billNumber) {
+    throw new UnnormalizableBillError(
+      bill.identifier || bill.id,
+      "identifier does not decompose into a stable bill number",
+    );
+  }
+
+  const title = bill.title?.trim();
+  if (!title) {
+    throw new UnnormalizableBillError(bill.identifier, "no title published");
+  }
+
+  const url = pickSourceUrl(bill);
+  if (!url) {
+    throw new UnnormalizableBillError(bill.identifier, "no source URL");
+  }
+
+  const introducedDate =
+    parseDate(
+      latestAction(
+        bill.actions?.filter((action) =>
+          action.classification?.includes("introduction"),
+        ),
+      )?.date,
+    ) ?? parseDate(bill.created_at);
+
+  return {
+    billNumber,
+    title,
+    sponsor: formatSponsor(bill.sponsorships),
+    status: mapStatus(bill.actions),
+    introducedDate,
+    chamber: mapChamber(
+      { stateCode: options.stateCode, identifier: bill.identifier },
+      bill.from_organization?.classification,
+    ),
+    summary: pickAbstract(bill.abstracts),
+    actions: normalizeActions(bill.actions),
+    url,
+    sourceWebsite: OPEN_STATES_SOURCE,
+    sourceUpdatedAt: parseDate(bill.updated_at),
+    textLink: pickVersionLink(bill.versions),
+    stateCode: options.stateCode.toUpperCase(),
+    session: bill.session,
+  };
+}

--- a/apps/scraper/src/scrapers/open-states.config.ts
+++ b/apps/scraper/src/scrapers/open-states.config.ts
@@ -1,0 +1,29 @@
+import type { ScraperEnvContract } from "@acme/env";
+
+export const openStatesConfig = {
+  id: "open-states",
+  name: "Open States",
+  source:
+    "Open States v3 API — state legislature bills, sponsors, actions, and text (California)",
+  environment: {
+    required: ["POSTGRES_URL", "OPEN_STATES_API_KEY"],
+    requiredAny: [
+      ["OPENROUTER_API_KEY", "LOCAL_LLM_BASE_URL", "DEEPSEEK_API_KEY"],
+    ],
+    recommended: ["OPENROUTER_API_KEY", "LOCAL_LLM_BASE_URL"],
+    optional: [
+      "OPENROUTER_MODEL",
+      "LOCAL_LLM_MODEL",
+      "LOCAL_LLM_API_KEY",
+      "DEEPSEEK_API_KEY",
+      "BFL_API_KEY",
+      "BFL_MODEL",
+      "LOCAL_FLUX_BASE_URL",
+      "LOCAL_FLUX_MODEL",
+      "GOOGLE_API_KEY",
+      "GOOGLE_SEARCH_ENGINE_ID",
+      "OPEN_STATES_MAX_ITEMS",
+      "OPEN_STATES_STATES",
+    ],
+  },
+} as const satisfies ScraperEnvContract;

--- a/apps/scraper/src/scrapers/open-states.test.ts
+++ b/apps/scraper/src/scrapers/open-states.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildOpenStatesUrl } from "./open-states.js";
+
+test("Open States include filters use repeated query parameters", () => {
+  const url = buildOpenStatesUrl("/bills", {
+    jurisdiction: "ocd-jurisdiction/country:us/state:ca/government",
+    include: ["sponsorships", "abstracts", "actions", "versions"],
+    per_page: 20,
+  });
+
+  assert.deepEqual(url.searchParams.getAll("include"), [
+    "sponsorships",
+    "abstracts",
+    "actions",
+    "versions",
+  ]);
+  assert.equal(url.searchParams.get("per_page"), "20");
+});

--- a/apps/scraper/src/scrapers/open-states.ts
+++ b/apps/scraper/src/scrapers/open-states.ts
@@ -35,6 +35,7 @@ import {
   retryQueueDepth,
 } from "../utils/db/retry-queue.js";
 import { fetchWithRetry } from "../utils/fetch.js";
+import { latestActionDate } from "../utils/last-action.js";
 import { createLogger } from "../utils/log.js";
 import { createNewItemLimiter } from "../utils/new-item-limit.js";
 import {
@@ -204,6 +205,11 @@ async function processBill(
         summary: normalized.summary,
         fullText,
         actions: normalized.actions,
+        // The sort key for every "recent" listing. State bills share the feed
+        // with federal ones, so a CA bill chaptered last week has to rank
+        // against a House bill passed last week — which only works if both
+        // sources fill this from the same kind of event.
+        lastActionAt: latestActionDate(normalized.actions),
         url: normalized.url,
         sourceWebsite: normalized.sourceWebsite,
         sourceUpdatedAt: normalized.sourceUpdatedAt,

--- a/apps/scraper/src/scrapers/open-states.ts
+++ b/apps/scraper/src/scrapers/open-states.ts
@@ -115,15 +115,32 @@ function jurisdictionFor(stateCode: string): string {
  * and `Retry-After` handling that an unattended run needs. The request shape is
  * the same, and the response types are still the client's.
  */
-async function openStatesFetch<T>(
+type OpenStatesQueryParams = Record<
+  string,
+  string | number | readonly string[] | undefined
+>;
+
+export function buildOpenStatesUrl(
   path: string,
-  params: Record<string, string | number | undefined>,
-): Promise<T> {
+  params: OpenStatesQueryParams,
+): URL {
   const url = new URL(`${BASE_URL}${path}`);
   for (const [key, value] of Object.entries(params)) {
     if (value === undefined) continue;
-    url.searchParams.set(key, String(value));
+    if (Array.isArray(value)) {
+      for (const item of value) url.searchParams.append(key, item);
+    } else {
+      url.searchParams.set(key, String(value));
+    }
   }
+  return url;
+}
+
+async function openStatesFetch<T>(
+  path: string,
+  params: OpenStatesQueryParams,
+): Promise<T> {
+  const url = buildOpenStatesUrl(path, params);
 
   const res = await fetchWithRetry(url.toString(), {
     headers: { "X-API-KEY": getApiKey(), Accept: "application/json" },
@@ -132,7 +149,12 @@ async function openStatesFetch<T>(
 }
 
 /** Everything the normalizer can use, in one request per page. */
-const LIST_INCLUDES = "sponsorships,abstracts,actions,versions";
+const LIST_INCLUDES = [
+  "sponsorships",
+  "abstracts",
+  "actions",
+  "versions",
+] as const;
 
 function stripHtml(html: string): string {
   return html

--- a/apps/scraper/src/scrapers/open-states.ts
+++ b/apps/scraper/src/scrapers/open-states.ts
@@ -1,0 +1,624 @@
+/**
+ * State-legislature bill ingestion via the Open States v3 API.
+ *
+ * Structured like the congress.gov scraper — an ascending `updated_since` walk
+ * with a persisted source cursor and a retry queue — with one deliberate
+ * difference: it asks the *list* endpoint for sponsorships, abstracts, actions
+ * and versions in a single request rather than fetching each bill's detail
+ * separately. That is a quota decision. The free Open States tier allows a few
+ * hundred requests a day and a California session holds thousands of bills; at
+ * one request per bill a backfill would take weeks, which is exactly why the
+ * CourtListener scraper is shelved. Twenty fully-hydrated bills per request
+ * keeps a whole session inside a day's budget.
+ *
+ * Bill *text* is fetched from the state's own site (leginfo for California),
+ * not from Open States, so it does not draw on the API budget at all.
+ */
+
+import type { OpenStatesBill } from "@acme/api/clients/open-states";
+import { eq } from "@acme/db";
+import { db } from "@acme/db/client";
+import { ScraperCursor } from "@acme/db/schema";
+
+import type { UpsertOutcome } from "../utils/db/operations.js";
+import type { NewItemLimiter } from "../utils/new-item-limit.js";
+import type { Scraper } from "../utils/types.js";
+import type { NormalizedStateBill } from "./open-states-normalize.js";
+import { getItemLimit } from "../utils/concurrency.js";
+import { advancesCursor, cursorHighWaterMark } from "../utils/cursor.js";
+import { setExpectedTotal } from "../utils/db/metrics.js";
+import { upsertContent } from "../utils/db/operations.js";
+import {
+  clearRetry,
+  dueRetries,
+  recordRetry,
+  retryQueueDepth,
+} from "../utils/db/retry-queue.js";
+import { fetchWithRetry } from "../utils/fetch.js";
+import { createLogger } from "../utils/log.js";
+import { createNewItemLimiter } from "../utils/new-item-limit.js";
+import {
+  assertWithinTsvectorLimit,
+  BillTextTooLargeError,
+} from "./congress.js";
+import { readBulkBills } from "./open-states-bulk.js";
+import {
+  normalizeBill,
+  normalizeIdentifier,
+  UnnormalizableBillError,
+} from "./open-states-normalize.js";
+import { openStatesConfig } from "./open-states.config.js";
+
+const BASE_URL = "https://v3.openstates.org";
+const logger = createLogger("Open States");
+
+/**
+ * Bills per list request. The API caps `/bills` at 20 and silently clamps
+ * anything larger, so asking for more only makes the page count misleading.
+ */
+const PAGE_SIZE = 20;
+
+/**
+ * Pause between list requests. The free tier enforces a per-minute ceiling as
+ * well as a daily one, and a tight pagination loop trips it within seconds.
+ * `fetchWithRetry` would recover from the resulting 429s, but spending the
+ * budget on rejected requests is not recovery.
+ */
+const PAGE_DELAY_MS = 1_000;
+
+const DEFAULT_STATES = ["ca"];
+
+interface OpenStatesScraperConfig {
+  maxBills?: number;
+  /** Two-letter state codes to walk. */
+  states?: string[];
+  /** Bill identifiers to fetch directly instead of walking the cursor. */
+  bills?: string[];
+  /** Session identifier for targeted runs, e.g. "20252026". */
+  session?: string;
+  /** Unzipped bulk session-CSV export to import instead of calling the API. */
+  bulkDir?: string;
+}
+
+interface BillListResponse {
+  results: OpenStatesBill[];
+  pagination: {
+    page: number;
+    max_page: number;
+    per_page: number;
+    total_items: number;
+  };
+}
+
+function getApiKey(): string {
+  const key = process.env.OPEN_STATES_API_KEY;
+  if (!key) {
+    throw new Error(
+      "OPEN_STATES_API_KEY is not set. Get one at https://open.pluralpolicy.com/accounts/profile/",
+    );
+  }
+  return key;
+}
+
+function jurisdictionFor(stateCode: string): string {
+  const code = stateCode.toLowerCase();
+  if (code === "dc")
+    return "ocd-jurisdiction/country:us/district:dc/government";
+  return `ocd-jurisdiction/country:us/state:${code}/government`;
+}
+
+/**
+ * Open States calls go through `fetchWithRetry` rather than the shared
+ * `@acme/api` client. The client throws on any non-2xx, including the 429 a
+ * free-tier key sees routinely; `fetchWithRetry` carries the per-host backoff
+ * and `Retry-After` handling that an unattended run needs. The request shape is
+ * the same, and the response types are still the client's.
+ */
+async function openStatesFetch<T>(
+  path: string,
+  params: Record<string, string | number | undefined>,
+): Promise<T> {
+  const url = new URL(`${BASE_URL}${path}`);
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined) continue;
+    url.searchParams.set(key, String(value));
+  }
+
+  const res = await fetchWithRetry(url.toString(), {
+    headers: { "X-API-KEY": getApiKey(), Accept: "application/json" },
+  });
+  return res.json() as Promise<T>;
+}
+
+/** Everything the normalizer can use, in one request per page. */
+const LIST_INCLUDES = "sponsorships,abstracts,actions,versions";
+
+function stripHtml(html: string): string {
+  return html
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&#(\d+);/g, (_, code: string) =>
+      String.fromCodePoint(Number(code)),
+    )
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+/**
+ * Fetch the operative bill text from the state's own site.
+ *
+ * Optional by design: a bill with an abstract but no retrievable text is still
+ * worth storing, and states publish text on their own schedule. Oversize is the
+ * one failure that propagates — see `BillTextTooLargeError`, which exists so a
+ * bill is never stored silently truncated.
+ */
+async function fetchFullText(
+  bill: NormalizedStateBill,
+): Promise<string | undefined> {
+  if (!bill.textLink) return undefined;
+  try {
+    const res = await fetchWithRetry(bill.textLink.url);
+    const raw = await res.text();
+    if (!raw) return undefined;
+    const text = stripHtml(raw);
+    if (!text) return undefined;
+    return assertWithinTsvectorLimit(text, bill.billNumber) || undefined;
+  } catch (error) {
+    if (error instanceof BillTextTooLargeError) throw error;
+    logger.warn(
+      `${bill.billNumber}: could not fetch text from ${bill.textLink.url}`,
+    );
+    return undefined;
+  }
+}
+
+async function processBill(
+  bill: OpenStatesBill,
+  stateCode: string,
+  newItemLimiter: NewItemLimiter,
+): Promise<{ outcome: UpsertOutcome; sourceUpdatedAt?: Date }> {
+  const normalized = normalizeBill(bill, { stateCode });
+  const fullText = await fetchFullText(normalized);
+
+  const outcome = await upsertContent(
+    {
+      type: "bill",
+      data: {
+        billNumber: normalized.billNumber,
+        title: normalized.title,
+        // As with congress.gov, the abstract is kept as source material and the
+        // DB pipeline generates the compact, app-facing description.
+        description: undefined,
+        sponsor: normalized.sponsor,
+        status: normalized.status,
+        introducedDate: normalized.introducedDate,
+        // `congress` is federal-only and stays null for state bills; the
+        // session lives in `billNumber`, where it is part of the row's identity.
+        congress: undefined,
+        chamber: normalized.chamber,
+        summary: normalized.summary,
+        fullText,
+        actions: normalized.actions,
+        url: normalized.url,
+        sourceWebsite: normalized.sourceWebsite,
+        sourceUpdatedAt: normalized.sourceUpdatedAt,
+      },
+    },
+    { newItemLimiter },
+  );
+
+  if (outcome.status === "written") {
+    logger.success(`Processed: ${normalized.billNumber} — ${normalized.title}`);
+  } else {
+    logger.info(
+      `${outcome.status === "skipped" ? "Skipped" : "Deferred"}: ${normalized.billNumber} — ${outcome.reason}`,
+    );
+  }
+  return { outcome, sourceUpdatedAt: normalized.sourceUpdatedAt };
+}
+
+/**
+ * One page of the update feed, oldest-first from `updatedSince`.
+ *
+ * Ascending for the same reason the federal walk is: bounded at `maxBills`, a
+ * descending window hands us the newest N and strands everything older, and the
+ * cursor then jumps past the strand.
+ */
+async function fetchBillPage(args: {
+  stateCode: string;
+  page: number;
+  updatedSince?: string;
+  session?: string;
+}): Promise<BillListResponse> {
+  return openStatesFetch<BillListResponse>("/bills", {
+    jurisdiction: jurisdictionFor(args.stateCode),
+    sort: "updated_asc",
+    include: LIST_INCLUDES,
+    page: args.page,
+    per_page: PAGE_SIZE,
+    updated_since: args.updatedSince,
+    session: args.session,
+  });
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Import an unzipped bulk session-CSV export.
+ *
+ * Deliberately does not touch the cursor. The export is a snapshot of a whole
+ * session with no position in the update feed, so there is no high-water mark
+ * to take from it — and writing one would strand every bill changed between the
+ * export's build date and now. The incremental walk still has to sweep after a
+ * backfill; the backfill just means it finds almost everything already stored
+ * and unchanged, which costs nothing.
+ */
+async function importBulk(
+  directory: string,
+  stateCode: string,
+  maxBills: number,
+): Promise<void> {
+  logger.info(`Importing bulk export from ${directory} (state=${stateCode})`);
+  const bills = readBulkBills(directory).slice(0, maxBills);
+  logger.info(`Read ${bills.length} bill(s) from the export`);
+
+  if (bills.length === 0) {
+    logger.success("Export contained no bills");
+    return;
+  }
+
+  setExpectedTotal(bills.length);
+  const limit = getItemLimit();
+  const newItemLimiter = createNewItemLimiter();
+  let failures = 0;
+  let unnormalizable = 0;
+
+  await Promise.all(
+    bills.map((bill) =>
+      limit(async () => {
+        try {
+          await processBill(bill, stateCode, newItemLimiter);
+        } catch (error) {
+          if (error instanceof UnnormalizableBillError) {
+            unnormalizable += 1;
+            logger.warn(`Skipping ${error.message}`);
+            return;
+          }
+          if (error instanceof BillTextTooLargeError) {
+            logger.warn(`Skipping ${error.message}`);
+            return;
+          }
+          failures += 1;
+          logger.error(`Error importing ${bill.identifier}`, error);
+        }
+      }),
+    ),
+  );
+
+  if (unnormalizable > 0) {
+    logger.warn(`${unnormalizable} bill(s) had no stable identifier or title`);
+  }
+  if (failures > 0) {
+    logger.warn(
+      `${failures} bill(s) failed; re-run the import to retry them, or let the incremental walk pick them up`,
+    );
+  }
+  logger.success("Completed");
+}
+
+/**
+ * Fetch specific bills by identifier, bypassing the cursor. The counterpart of
+ * the federal scraper's `--bill`: a bill that overflowed a busy window becomes
+ * unreachable once the cursor moves past it, and this is how it gets back.
+ */
+async function scrapeTargeted(
+  identifiers: string[],
+  stateCode: string,
+  session: string | undefined,
+): Promise<void> {
+  const wanted = identifiers.map((identifier) => {
+    const normalized = normalizeIdentifier(identifier);
+    if (!normalized) {
+      throw new Error(
+        `Unrecognized bill identifier "${identifier}" (expected e.g. "SB 243" or "AB 1064")`,
+      );
+    }
+    return normalized;
+  });
+
+  logger.info(
+    `Fetching ${wanted.length} requested bill(s) from ${stateCode.toUpperCase()}${session ? ` session ${session}` : ""}...`,
+  );
+  setExpectedTotal(wanted.length);
+
+  const newItemLimiter = createNewItemLimiter(wanted.length);
+  const failures: { identifier: string; reason: unknown }[] = [];
+
+  for (const identifier of wanted) {
+    try {
+      // `q` is the only identifier-ish filter /bills offers; match the exact
+      // identifier out of the results rather than trusting the search ranking.
+      const response = await openStatesFetch<BillListResponse>("/bills", {
+        jurisdiction: jurisdictionFor(stateCode),
+        q: identifier,
+        include: LIST_INCLUDES,
+        per_page: PAGE_SIZE,
+        session,
+      });
+
+      const match = response.results.find(
+        (bill) => normalizeIdentifier(bill.identifier) === identifier,
+      );
+      if (!match) {
+        failures.push({ identifier, reason: "not found in Open States" });
+        continue;
+      }
+
+      const { outcome } = await processBill(match, stateCode, newItemLimiter);
+      if (outcome.status !== "written") {
+        failures.push({
+          identifier,
+          reason: `${outcome.status}: ${outcome.reason}`,
+        });
+      }
+    } catch (error) {
+      failures.push({ identifier, reason: error });
+    }
+    await sleep(PAGE_DELAY_MS);
+  }
+
+  // A targeted run has no later run to retry it — fail loudly so the caller
+  // knows the bill still is not in the database.
+  for (const { identifier, reason } of failures) {
+    logger.error(`Error processing ${identifier}`, reason);
+  }
+  if (failures.length > 0) {
+    throw new Error(
+      `Failed to process ${failures.length} of ${wanted.length} requested bill(s)`,
+    );
+  }
+  logger.success("Completed");
+}
+
+/** The incremental walk for one state. */
+async function scrapeState(stateCode: string, maxBills: number): Promise<void> {
+  const scraperKey = `open-states:${stateCode.toLowerCase()}`;
+  const [lastScrape] = await db
+    .select({ lastUpdated: ScraperCursor.sourceUpdatedAt })
+    .from(ScraperCursor)
+    .where(eq(ScraperCursor.scraperKey, scraperKey))
+    .limit(1);
+
+  // The API takes `updated_since` as a date, so the cursor is coarser than the
+  // timestamp we store. Re-offering the cursor's own day is the safe direction
+  // to round: an unchanged bill hashes identically and costs a no-op upsert,
+  // whereas rounding forward would drop everything updated later that day.
+  const updatedSince = lastScrape?.lastUpdated
+    ?.toISOString()
+    .slice(0, "YYYY-MM-DD".length);
+
+  logger.info(
+    updatedSince
+      ? `${stateCode.toUpperCase()}: fetching bills updated since ${updatedSince} (oldest first)`
+      : `${stateCode.toUpperCase()}: no source cursor yet — starting from the beginning of the feed`,
+  );
+
+  const bills: OpenStatesBill[] = [];
+  let page = 1;
+  let maxPage = 1;
+
+  while (bills.length < maxBills && page <= maxPage) {
+    const response = await fetchBillPage({ stateCode, page, updatedSince });
+    bills.push(...(response.results ?? []));
+    maxPage = response.pagination?.max_page ?? 1;
+    if (page === 1) {
+      logger.info(
+        `${stateCode.toUpperCase()}: ${response.pagination?.total_items ?? 0} bill(s) match the window across ${maxPage} page(s)`,
+      );
+    }
+    if ((response.results ?? []).length === 0) break;
+    page += 1;
+    if (bills.length < maxBills && page <= maxPage) await sleep(PAGE_DELAY_MS);
+  }
+
+  const window = bills.slice(0, maxBills);
+  logger.info(`${stateCode.toUpperCase()}: fetched ${window.length} bill(s)`);
+
+  // Retries drain after the feed, and are capped, for the same reason as the
+  // federal walk: a backed-up queue must not push this week's legislation
+  // behind last month's problem cases.
+  const retryBudget = Math.max(5, Math.floor(maxBills / 4));
+  const retries = await dueRetries(scraperKey, retryBudget);
+  if (retries.length > 0) {
+    logger.info(
+      `Retry queue: ${await retryQueueDepth(scraperKey)} outstanding, ${retries.length} due this run`,
+    );
+  }
+
+  if (window.length === 0 && retries.length === 0) {
+    logger.success(
+      `${stateCode.toUpperCase()}: no new or updated bills since last scrape`,
+    );
+    return;
+  }
+
+  setExpectedTotal(window.length + retries.length);
+  const limit = getItemLimit();
+  const newItemLimiter = createNewItemLimiter();
+
+  /**
+   * Run one bill and translate its result into a cursor decision. An item we
+   * could not finish goes to the retry queue and is then reported `ok`, because
+   * the queue — not the cursor — is what remembers it from that point. Failing
+   * to *record* the retry is the one case that still holds the cursor.
+   */
+  const runBill = async (
+    bill: OpenStatesBill,
+  ): Promise<{ ok: boolean; sourceUpdatedAt?: Date }> => {
+    const itemKey = bill.id;
+    const feedUpdatedAt = bill.updated_at
+      ? new Date(bill.updated_at)
+      : undefined;
+
+    const queue = async (reason: string) => {
+      try {
+        await recordRetry(scraperKey, itemKey, reason);
+        return { ok: true, sourceUpdatedAt: feedUpdatedAt };
+      } catch (error) {
+        logger.error(`Could not queue ${itemKey} for retry`, error);
+        return { ok: false };
+      }
+    };
+
+    try {
+      const { outcome, sourceUpdatedAt } = await processBill(
+        bill,
+        stateCode,
+        newItemLimiter,
+      );
+      if (advancesCursor(outcome)) {
+        await clearRetry(scraperKey, itemKey);
+        return { ok: true, sourceUpdatedAt };
+      }
+      return queue(outcome.reason);
+    } catch (error) {
+      // Both of these are deliberate refusals rather than failures to retry:
+      // the bill will be exactly as unnormalizable or as oversized next run, so
+      // queueing it would burn an attempt a day forever.
+      if (
+        error instanceof UnnormalizableBillError ||
+        error instanceof BillTextTooLargeError
+      ) {
+        logger.warn(`Skipping ${error.message}`);
+        await clearRetry(scraperKey, itemKey);
+        return { ok: true, sourceUpdatedAt: feedUpdatedAt };
+      }
+      logger.error(`Error processing ${bill.identifier}`, error);
+      return queue(error instanceof Error ? error.message : String(error));
+    }
+  };
+
+  const outcomes = await Promise.all(
+    window.map((bill) => limit(() => runBill(bill))),
+  );
+
+  const { highWaterMark, held } = cursorHighWaterMark(outcomes);
+  if (held > 0) {
+    logger.warn(
+      `${held} bill(s) could not even be queued; holding the cursor so the page is re-offered next run`,
+    );
+  }
+
+  if (highWaterMark) {
+    await db
+      .insert(ScraperCursor)
+      .values({ scraperKey, sourceUpdatedAt: highWaterMark })
+      .onConflictDoUpdate({
+        target: ScraperCursor.scraperKey,
+        set: { sourceUpdatedAt: highWaterMark, updatedAt: new Date() },
+      });
+    logger.info(`Cursor advanced to ${highWaterMark.toISOString()}`);
+  } else if (window.length > 0) {
+    logger.warn("Cursor not advanced — no bill was durably processed");
+  }
+
+  // Retries run after the cursor is written and never feed into it: these bills
+  // sit behind the cursor by definition, so their timestamps could only drag it
+  // backwards.
+  if (retries.length > 0) {
+    await Promise.all(
+      retries.map(({ itemKey }) =>
+        limit(async () => {
+          try {
+            const response = await openStatesFetch<OpenStatesBill>(
+              `/bills/${encodeURIComponent(itemKey)}`,
+              { include: LIST_INCLUDES },
+            );
+            const { outcome } = await processBill(
+              response,
+              stateCode,
+              newItemLimiter,
+            );
+            if (advancesCursor(outcome)) {
+              await clearRetry(scraperKey, itemKey);
+            } else {
+              await recordRetry(scraperKey, itemKey, outcome.reason);
+            }
+          } catch (error) {
+            if (
+              error instanceof UnnormalizableBillError ||
+              error instanceof BillTextTooLargeError
+            ) {
+              logger.warn(`Skipping ${itemKey}: ${error.message}`);
+              await clearRetry(scraperKey, itemKey);
+              return;
+            }
+            logger.error(`Retry failed for ${itemKey}`, error);
+            await recordRetry(
+              scraperKey,
+              itemKey,
+              error instanceof Error ? error.message : String(error),
+            );
+          }
+        }),
+      ),
+    );
+    logger.info(
+      `Retry queue: ${await retryQueueDepth(scraperKey)} still outstanding`,
+    );
+  }
+
+  logger.success(`${stateCode.toUpperCase()}: completed`);
+}
+
+export function parseStates(value: string | undefined): string[] | undefined {
+  const states = (value ?? "")
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+  return states.length > 0 ? states : undefined;
+}
+
+async function scrape(config: OpenStatesScraperConfig = {}): Promise<void> {
+  const {
+    maxBills = 100,
+    states = parseStates(process.env.OPEN_STATES_STATES) ?? DEFAULT_STATES,
+  } = config;
+
+  if (config.bulkDir) {
+    // A bulk export is a single state's session by construction.
+    return importBulk(config.bulkDir, states[0] ?? "ca", maxBills);
+  }
+
+  if (config.bills?.length) {
+    return scrapeTargeted(config.bills, states[0] ?? "ca", config.session);
+  }
+
+  logger.info(`Starting (states=${states.join(", ")})...`);
+
+  // States walk sequentially, each with its own cursor. Running them
+  // concurrently would multiply the request rate against a shared per-minute
+  // quota, and there is one state today.
+  for (const stateCode of states) {
+    // The per-run limit is per state, matching how `--max-items` reads for
+    // every other scraper: a cap on what this run will take on from a source.
+    await scrapeState(stateCode, maxBills);
+  }
+}
+
+export const openStates: Scraper = {
+  ...openStatesConfig,
+  scrape: (options) =>
+    scrape({
+      maxBills:
+        (options?.maxItems ?? Number(process.env.OPEN_STATES_MAX_ITEMS)) || 100,
+      bills: options?.targets,
+      ...(options?.session ? { session: options.session } : {}),
+      ...(options?.bulkDir ? { bulkDir: options.bulkDir } : {}),
+    }),
+};

--- a/apps/scraper/src/utils/cursor.ts
+++ b/apps/scraper/src/utils/cursor.ts
@@ -1,0 +1,40 @@
+import type { UpsertOutcome } from "./db/operations.js";
+
+/**
+ * Whether an item's outcome lets the cursor move past it.
+ *
+ * `deferred` is the one that must not: the item is not in the database in the
+ * state we want it, for a reason a later run can fix. `skipped` may, because
+ * re-offering the item unchanged would reach the same conclusion — and any real
+ * change upstream moves its source timestamp, which puts it back in the feed.
+ */
+export function advancesCursor(
+  outcome: UpsertOutcome,
+): outcome is Exclude<UpsertOutcome, { status: "deferred" }> {
+  return outcome.status !== "deferred";
+}
+
+/**
+ * How far the cursor may move given this run's outcomes, in feed order.
+ *
+ * Only the leading run of clean items counts. The feed is sorted oldest-first,
+ * so the first item we could not settle is the true high-water mark: moving
+ * past it would strand it exactly the way a wall-clock cursor does. Everything
+ * from there on is simply re-offered next run, however many of them happened to
+ * succeed.
+ */
+export function cursorHighWaterMark(
+  outcomes: { ok: boolean; sourceUpdatedAt?: Date }[],
+): { highWaterMark: Date | undefined; held: number } {
+  const firstFailure = outcomes.findIndex((outcome) => !outcome.ok);
+  const settled =
+    firstFailure === -1 ? outcomes : outcomes.slice(0, firstFailure);
+  const highWaterMark = settled.reduce<Date | undefined>(
+    (newest, outcome) =>
+      outcome.sourceUpdatedAt && (!newest || outcome.sourceUpdatedAt > newest)
+        ? outcome.sourceUpdatedAt
+        : newest,
+    undefined,
+  );
+  return { highWaterMark, held: outcomes.length - settled.length };
+}

--- a/apps/scraper/src/utils/types.ts
+++ b/apps/scraper/src/utils/types.ts
@@ -67,6 +67,13 @@ export interface ScraperRunOptions {
   targets?: string[];
   /** Congress number for targeted congress.gov runs (e.g. 119). */
   congress?: number;
+  /** Legislative session for targeted state runs (e.g. "20252026"). */
+  session?: string;
+  /**
+   * Path to an unzipped bulk export to import instead of calling the source's
+   * API. Scrapers without a bulk path ignore this.
+   */
+  bulkDir?: string;
   /**
    * Refresh the N most recently updated records instead of walking the
    * incremental cursor. Keeps active items current rather than pursuing

--- a/docs/civic-data-sources.md
+++ b/docs/civic-data-sources.md
@@ -5,7 +5,7 @@ How to obtain keys/access for every civic integration. For local dev, copy `.env
 | Source                                 | Key required | Cost            | Env variable                                                          |
 | -------------------------------------- | ------------ | --------------- | --------------------------------------------------------------------- |
 | Google Civic API                       | Yes          | Free (25k/day)  | `GOOGLE_CIVIC_API_KEY`                                                |
-| Open States API                        | Yes          | Free            | `OPEN_STATES_API_KEY`                                                 |
+| Open States API                        | Yes          | Free (~500 req/day default tier) | `OPEN_STATES_API_KEY`                              |
 | Google Places (address autocomplete)   | Yes          | Pay-as-you-go   | `GOOGLE_PLACES_API_KEY` (→ `GOOGLE_API_KEY` → `GOOGLE_CIVIC_API_KEY`) |
 | Vote Smart                             | Yes          | Free (org tier) | `VOTE_SMART_API_KEY`                                                  |
 | Legistar (local councils)              | No           | Free            | —                                                                     |
@@ -19,7 +19,14 @@ How to obtain keys/access for every civic integration. For local dev, copy `.env
 
 > ⚠️ **Representatives API turned down 2025-04-30.** Google retired the `/representatives` endpoint; only the **Elections** endpoints (`elections`, `voterinfo`, results) remain. Those are what `getVoterInfo` and the enrichment pipeline use, and the only Civic calls the app makes. The dead `getRepresentatives` / `getRepresentativesEnriched` functions have been **removed** from `civic.ts`. A replacement "your elected officials" lookup (Open States legislators + Legistar local + OCD-IDs via the Divisions API for address→district) is a roadmap feature — [issue #123](https://github.com/billion-app/billion/issues/123).
 
-**Open States API** — CA state bills, legislators, voting records. [Sign up](https://openstates.org/accounts/signup/) → verify email → [profile](https://openstates.org/accounts/profile/) → API Keys → Generate. Docs: <https://docs.openstates.org/api-v3/>. → `OPEN_STATES_API_KEY`.
+**Open States API** — CA state bills, legislators, voting records. [Sign up](https://open.pluralpolicy.com/accounts/signup/) → verify email → [profile](https://open.pluralpolicy.com/accounts/profile/) → API Keys → Generate. Docs: <https://docs.openstates.org/api-v3/>. → `OPEN_STATES_API_KEY`.
+
+The default tier is capped at roughly 500 requests/day with a per-minute limit
+on top; higher tiers are granted on request. The `open-states` scraper is built
+to fit inside that — it hydrates twenty bills per request rather than fetching
+each bill's detail — and the same account can download login-gated bulk session
+CSVs for backfills that cost no quota at all. See
+[the scraper docs](./scraper.md#state-bills-open-states).
 
 **Google Places (Autocomplete New)** — US street-address autocomplete for the ballot lookup. Same Cloud Console flow as Civic; enable "Places API (New)". Reuses the Google key chain. See `packages/api/src/lib/places.ts` (session-token billing). → `GOOGLE_PLACES_API_KEY`.
 

--- a/docs/data-sources-api.md
+++ b/docs/data-sources-api.md
@@ -134,6 +134,12 @@ When no human source has a summary, the engine falls back to grounded AI (SPUR B
 **Auth:** `OPEN_STATES_API_KEY`  
 **Scope:** California state bills and legislators (expandable to other states)
 
+This client backs **live** queries from the `openStates` tRPC router — search,
+bill detail, legislators, votes — which is a different job from ingestion.
+Durable state-bill ingestion into the `Bill` table runs through the
+`open-states` scraper, which talks to the same API but with retry/backoff and a
+persisted cursor. See [the scraper docs](./scraper.md#state-bills-open-states).
+
 ```ts
 import {
   getBills,

--- a/docs/government-information-structure.md
+++ b/docs/government-information-structure.md
@@ -47,7 +47,7 @@ Most US legislatures are **bicameral** — split into two **chambers** that must
 
 | Document type | What it is | Current coverage |
 |---|---|---|
-| **State bill** | Same concept as federal bill; CA uses AB (Assembly) and SB (Senate) numbering | Partial — Open States API key held; integration planned |
+| **State bill** | Same concept as federal bill; CA uses AB (Assembly) and SB (Senate) numbering | ✓ CA — ingested into `Bill` by the `open-states` scraper |
 | **State resolution** | Same as federal equivalents | Not covered |
 
 ### Executive — Governor
@@ -118,7 +118,7 @@ This is where the most government decisions affecting daily life are made — an
 | Federal | Legislative | Regulations | Partial |
 | Federal | Executive | Presidential actions (EO, proclamation, memoranda) | ✓ |
 | Federal | Judicial | SCOTUS opinions | ✓ |
-| State (CA) | Legislative | State bills | Planned (Open States) |
+| State (CA) | Legislative | State bills | ✓ (Open States) |
 | State (CA) | Direct democracy | Statewide propositions | ✓ |
 | State (CA) | Direct democracy | LAO fiscal analyses | ✓ |
 | Local | Council/Board | City/county legislation | ✓ (Legistar) |

--- a/docs/launch.md
+++ b/docs/launch.md
@@ -141,7 +141,7 @@ string copied from the provider is normally already safe to paste.
 | ----------------------- | ---------------- | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `GOOGLE_CIVIC_API_KEY`  | Launch required  | Elections, representatives, polling locations, and voter information | Some civic calls use mock development data; explicit live voter-info calls can report that the key is not configured. | Create a server key in [Google Cloud Credentials](https://console.cloud.google.com/apis/credentials), enable the [Civic Information API](https://developers.google.com/civic-information/docs/using_api), and restrict the key to that API. |
 | `GOOGLE_PLACES_API_KEY` | Launch required  | Address autocomplete and place details                               | Falls back to `GOOGLE_API_KEY`, then `GOOGLE_CIVIC_API_KEY`, then local mock suggestions.                             | Enable **Places API (New)** and create a restricted server key; see [Places setup](https://developers.google.com/maps/documentation/places/web-service/cloud-setup).                                                                        |
-| `OPEN_STATES_API_KEY`   | Feature required | California state bills, legislators, and voting records              | Open States-backed enrichments are skipped or return no enrichment.                                                   | [Open States account/API keys](https://openstates.org/accounts/profile/).                                                                                                                                                                   |
+| `OPEN_STATES_API_KEY`   | Feature required | California state bills, legislators, and voting records; required by the `open-states` scraper | Open States-backed enrichments are skipped or return no enrichment, and the `open-states` scraper fails env validation. | [Open States account/API keys](https://open.pluralpolicy.com/accounts/profile/).                                                                                                                                                                   |
 | `VOTE_SMART_API_KEY`    | Feature required | Candidate and state-measure enrichment                               | Vote Smart-backed adapters skip enrichment.                                                                           | Request access from [Vote Smart](https://votesmart.org/share/api).                                                                                                                                                                          |
 
 Use a dedicated `GOOGLE_PLACES_API_KEY` in production even though the code has
@@ -185,8 +185,8 @@ bundle. It must contain only the public API origin, never an API key or secret.
 
 ## Scraper and scheduled data jobs
 
-The registered CLI scrapers are `federalregister`, `congress`, `scotus`,
-`scc-cvig`, and `ca-sos-statements`. The VOTE411, LAO cache, and VIG archive
+The registered CLI scrapers are `federalregister`, `congress`, `open-states`,
+`scotus`, `scc-cvig`, and `ca-sos-statements`. The VOTE411, LAO cache, and VIG archive
 implementations are retained under `scrapers/disabled` but are not runnable or
 scheduled because the app does not consume their output.
 
@@ -220,6 +220,7 @@ validation consume those declarations. An `all` run validates their union.
 | ------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
 | `federalregister`   | `POSTGRES_URL`; one of `OPENROUTER_API_KEY` or `DEEPSEEK_API_KEY` | `BFL_API_KEY`; `GOOGLE_API_KEY` + `GOOGLE_SEARCH_ENGINE_ID`      | Uses the keyless Federal Register API.                                                     |
 | `congress`          | `POSTGRES_URL`, `CONGRESS_API_KEY`; one of the two AI keys        | `BFL_API_KEY`; Google image-search pair                          | Get a free Congress key from [Congress.gov API signup](https://api.congress.gov/sign-up/). |
+| `open-states`       | `POSTGRES_URL`, `OPEN_STATES_API_KEY`; one of the two AI keys     | `BFL_API_KEY`; Google image-search pair                          | Free key from [Open States](https://open.pluralpolicy.com/accounts/profile/); default tier ~500 req/day. `OPEN_STATES_STATES` selects states (default `ca`). |
 | `scotus`            | `POSTGRES_URL`; one of the two AI keys                            | `COURTLISTENER_API_KEY`, `BFL_API_KEY`; Google image-search pair | Runs anonymously at lower CourtListener rate limits when its token is absent.              |
 | `scc-cvig`          | `POSTGRES_URL`                                                    | `GOOGLE_GENERATIVE_AI_API_KEY`                                   | Text-layer PDF extraction still runs; Gemini is only a fallback.                           |
 | `ca-sos-statements` | `POSTGRES_URL`                                                    | None                                                             | Uses public California SOS voter-guide pages.                                              |
@@ -237,6 +238,7 @@ limit; retries and additional invocations each receive a fresh allowance.
 | `SCOTUS_MAX_ITEMS`              |      50 | CourtListener opinion clusters      |
 | `SCC_CVIG_MAX_ITEMS`            |      10 | Santa Clara voter-guide PDFs        |
 | `CA_SOS_MAX_ITEMS`              |       9 | California SOS office pages         |
+| `OPEN_STATES_MAX_ITEMS`         |     100 | Open States bills, per state        |
 | `SCRAPER_MAX_NEW_ITEMS_PER_RUN` |      10 | New records receiving AI/image work |
 
 The last setting is an enrichment budget, not a source-fetch limit. Raw records
@@ -385,6 +387,7 @@ upstream outage obvious:
 pnpm --filter @acme/scraper run start federalregister --concurrency 1
 pnpm --filter @acme/scraper run start scotus --concurrency 1
 pnpm --filter @acme/scraper run start congress --concurrency 1
+pnpm --filter @acme/scraper run start open-states --concurrency 1
 pnpm --filter @acme/scraper run start scc-cvig --concurrency 1
 pnpm --filter @acme/scraper run start ca-sos-statements --concurrency 1
 ```

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -38,6 +38,7 @@ source of truth for what `all` runs**, in this order:
 | ---------------------- | ------------------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `federalregister.ts`   | federalregister.gov REST API   | `government_content` | REST (presidential documents); HTML→Markdown via Turndown                                                                       |
 | `congress.ts`          | congress.gov REST API          | `bill`               | REST (`CONGRESS_API_KEY`), incremental by source `updateDate` — see [Incremental discovery](#incremental-discovery-congressgov) |
+| `open-states.ts`       | Open States v3 API             | `bill`               | REST (`OPEN_STATES_API_KEY`), incremental by source `updated_at` — see [State bills](#state-bills-open-states)                  |
 | `scc-cvig.ts`          | Santa Clara County voter guide | `civic_api_cache`    | PDF extraction; optional Gemini fallback (`GOOGLE_GENERATIVE_AI_API_KEY`)                                                        |
 | `ca-sos-statements.ts` | CA Secretary of State guide    | `civic_api_cache`    | official candidate-statement pages, PDF fallback via `ca-sos-vig-pdf.ts`                                                         |
 
@@ -107,6 +108,70 @@ backfills run — stop and restart freely, the cursor is durable.
 `--bill "H.R. 7008"` (repeatable, plus `--congress`) fetches specific bills
 directly and bypasses the cursor entirely, for backfilling a single bill or
 regenerating one for testing.
+
+## State bills (Open States)
+
+`open-states.ts` ingests state-legislature bills into the same `Bill` table and
+the same AI pipeline as federal ones. California only today
+(`OPEN_STATES_STATES=ca`); the state list is a config value, not a hardcode, and
+each state walks its own cursor keyed `open-states:{state}`.
+
+**Identity.** A state bill's `billNumber` is `"CA SB 243 (2025-2026)"` and its
+`sourceWebsite` is `openstates.org`. All three parts are load-bearing: the
+uniqueness constraint is `(billNumber, sourceWebsite)`, SB 243 exists in most
+states, and SB 243 exists in *every* California session as an unrelated bill.
+Changing that format silently duplicates every row already stored.
+`Bill.congress` stays null for state bills — it is a federal field, and the
+session lives in the bill number instead. Chamber is the state's own vocabulary:
+California's lower house is the **Assembly**, not the House.
+
+**One request per twenty bills.** The walk asks `/bills` for sponsorships,
+abstracts, actions and versions inline rather than fetching each bill's detail
+separately. This is a quota decision, not a style one — the free Open States
+tier allows a few hundred requests a day, and at one request per bill a
+California session would take weeks to drain, which is exactly why the
+CourtListener scraper is parked. Bill *text* is fetched from the state's own
+site (leginfo for CA), so it does not draw on the API budget at all.
+
+Everything else matches the federal walk: ascending `updated_since` from a
+durable cursor, retry queue, and the same three-way `upsertContent` outcome
+contract. `updated_since` is date-granular, so the cursor rounds *back* to its
+own day — an unchanged bill re-offered is a no-op upsert, whereas rounding
+forward would drop everything updated later that day.
+
+`--bill "SB 243"` (with optional `--session 20252026`) fetches specific bills and
+bypasses the cursor, the same way `--bill` does for congress.gov.
+
+### Bulk backfill
+
+`--bulk-dir <path>` imports an unzipped Open States session-CSV export through
+the same normalization and upsert path as the API, with no API requests at all.
+It is the fast way to seed a session before letting the incremental walk take
+over.
+
+It takes a local directory rather than downloading, because the archives at
+<https://open.pluralpolicy.com/data/session-csv/> sit behind a **site login**,
+not the API key — an unauthenticated fetch gets "Please log in to access download
+links". Automating it would mean storing account credentials in the scraper. So:
+sign in, download the session archive, unzip it, and point `--bulk-dir` at the
+directory.
+
+```sh
+pnpm --filter @acme/scraper run start open-states --bulk-dir ~/Downloads/CA_2025-2026_csv
+```
+
+The import deliberately does **not** move the cursor. An export is a snapshot of
+a whole session with no position in the update feed, so there is no high-water
+mark to take from it, and writing one would strand every bill changed since the
+export was built.
+
+Open States documents the CSV format as experimental. The reader maps columns by
+name with a few aliases and raises `BulkExportShapeError` listing the columns it
+actually found if the shape has moved — it will not quietly import shifted data.
+
+**Not ingested:** roll-call votes. `Bill` has no column for them and inventing
+one is out of scope here; the `openStates` tRPC router already serves votes
+live for the bill detail screen.
 
 ## Bill text: which version, and how much
 

--- a/packages/api/src/clients/open-states.ts
+++ b/packages/api/src/clients/open-states.ts
@@ -127,6 +127,12 @@ export interface OpenStatesBill {
   versions?: OpenStatesBillVersion[];
   documents?: OpenStatesBillDocument[];
   votes?: OpenStatesVote[];
+  /**
+   * Where Open States scraped the bill from — for CA these are leginfo URLs.
+   * Returned by /bills without an `include`, but not guaranteed present, so
+   * every consumer must be able to fall back to `openstates_url`.
+   */
+  sources?: { url: string; note?: string }[];
   created_at: string;
   updated_at: string;
   openstates_url: string;

--- a/packages/env/src/registry.ts
+++ b/packages/env/src/registry.ts
@@ -85,6 +85,7 @@ const scraperSourceLimitDefinitions = [
   ["SCOTUS_MAX_ITEMS", "CourtListener opinion clusters per run.", "50"],
   ["SCC_CVIG_MAX_ITEMS", "Santa Clara voter-guide PDFs per run.", "10"],
   ["CA_SOS_MAX_ITEMS", "California SOS office pages per run.", "9"],
+  ["OPEN_STATES_MAX_ITEMS", "Open States bills per state per run.", "100"],
 ] as const;
 
 export const envRegistry = [
@@ -290,8 +291,18 @@ export const envRegistry = [
       "Open States key for state bills, legislators, and voting records.",
     group: "Civic data",
     secret: true,
-    setupUrl: "https://openstates.org/accounts/profile/",
+    setupUrl: "https://open.pluralpolicy.com/accounts/profile/",
     requirements: { nextjs: "optional" },
+    schema: string,
+  }),
+  define({
+    key: "OPEN_STATES_STATES",
+    description:
+      "Comma-separated state codes the Open States scraper ingests (default: ca).",
+    group: "Civic data",
+    secret: false,
+    defaultValue: "ca",
+    requirements: {},
     schema: string,
   }),
   define({


### PR DESCRIPTION
Closes #158.

Billion could query state legislation on demand through the existing Open States client and tRPC router, but never stored it — so CA SB 243 (companion chatbots, chaptered Oct 2025) was invisible in a feed that carried federal bills fine. This adds durable ingestion into the normal `Bill` pipeline.

## Identity

`billNumber` is `"CA SB 243 (2025-2026)"`, `sourceWebsite` is `openstates.org`. Every part is load-bearing: the unique constraint is `(billNumber, sourceWebsite)`, SB 243 exists in most states, and SB 243 exists in *every* California session as an unrelated bill. Changing the format silently duplicates every stored row.

`Bill.congress` stays null — it is a federal field, and the session lives in the bill number. Chamber uses the state vocabulary: CA maps `lower` to **Assembly**, not House.

## Quota

The free Open States tier allows a few hundred requests/day. The walk asks `/bills` for sponsorships, abstracts, actions and versions inline, so one request returns 20 fully hydrated bills; bill text comes from leginfo and does not touch the quota. At one request per bill a backfill would take weeks — that is what shelved the CourtListener scraper.

`--bulk-dir <path>` imports an unzipped session-CSV export through the identical normalize→upsert path for a zero-quota backfill, so a backfilled bill and its later incremental refresh are one row rather than two. It takes a local directory rather than downloading, because those archives sit behind a **site login**, not the API key — automating it would mean storing account credentials in the scraper. The import deliberately does not move the cursor: an export has no position in the update feed.

Otherwise this mirrors the federal walk — ascending `updated_since` from a durable cursor, retry queue, same three-way `upsertContent` outcome contract. `updated_since` is date-granular so the cursor rounds *back* to its own day; a re-offered unchanged bill is a no-op, whereas rounding forward drops everything updated later that day.

## Acceptance criteria

- [x] `pnpm --filter @acme/scraper run start open-states --max-items 1` validates env and caps the run
- [x] SB 243 normalizes with correct jurisdiction, session, chamber, sponsor, status, source link, and abstract (fixture test)
- [x] Re-running unchanged is idempotent — content hash gates enrichment
- [x] Incremental runs pick up amended/passed/vetoed/chaptered bills
- [x] State bill IDs cannot collide across states, sessions, or with congress.gov
- [x] Unit tests cover normalization, status mapping, identifier stability, missing optional fields
- [x] Docs no longer describe state-bill ingestion as planned
- [ ] **Votes are not ingested** — `Bill` has no column for them and adding one is a schema change beyond this issue. The `openStates` router already serves votes live for the detail screen.

## Verification

`tsc --noEmit` clean on scraper/api/env. 124 scraper tests pass, including the live-query-format regression test. CLI help, env validation, and all three flag guards exercised.

**Live verification and remaining limitation:**

1. **Live API run completed.** A real default-tier key fetched CA SB 243, which exposed and fixed the API query format: `include` must be repeated rather than comma-joined. The bill then completed the full local pipeline with a Big Mac FLUX fallback, and a second run produced zero new entries. The local database contains exactly one bill with its brief, dual lens, and header image.
2. **Bulk CSV column names are unverified** — the archives are login-gated, so no real export was inspected. The reader maps columns by name with aliases and raises `BulkExportShapeError` listing the headers it actually found rather than importing shifted data. Expect to adjust the mapping on first real use.

Also note `--max-items` is per state, not per run. Identical with one state today; worth knowing before adding a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)