### PR TITLE
Stop the format check failing on generated migrations

### DIFF
--- a/packages/db/.prettierignore
+++ b/packages/db/.prettierignore
@@ -1,0 +1,4 @@
+# drizzle-kit owns these — it regenerates them unformatted on every
+# `generate`, so checking them only ever fails CI on generated output.
+# The migration .sql files are not matched by prettier at all.
+drizzle/meta/

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -25,7 +25,7 @@
     "build": "tsc",
     "clean": "git clean -xdf .cache .turbo dist node_modules",
     "dev": "tsc",
-    "format": "prettier --check . --ignore-path ../../.gitignore",
+    "format": "prettier --check . --ignore-path ../../.gitignore --ignore-path .prettierignore",
     "lint": "eslint --flag unstable_native_nodejs_ts_config",
     "push": "drizzle-kit push",
     "generate": "drizzle-kit generate",


### PR DESCRIPTION
Every `drizzle-kit generate` produced a red build until someone hand-formatted files drizzle owns. It cost #279 a failed `format` job.

## Cause

drizzle-kit rewrites `drizzle/meta/_journal.json` and emits a new `NNNN_snapshot.json` on every `generate`, both unformatted — and `@acme/db`'s format script checked them:

```
prettier --check . --ignore-path ../../.gitignore
```

So shipping a migration meant either a red CI run or hand-formatting generated files that the next `generate` overwrites again.

## Change

Add `packages/db/.prettierignore` covering `drizzle/meta/`, and pass it to the format script — the same two-`--ignore-path` pattern `@acme/expo` already uses.

The migration `.sql` files are unaffected: prettier has no parser for them and never matched them in the first place. Only the generated JSON metadata is ignored, and nothing hand-written in `packages/db` loses coverage.

## Verification

Reproduced and fixed, by rewriting the metadata the way drizzle emits it:

```
--- WITHOUT the ignore (what CI hit) ---
[warn] drizzle/meta/_journal.json
[warn] Code style issues found in the above file.

--- WITH the ignore (this change) ---
All matched files use Prettier code style!
```

Full `pnpm format` across the workspace: 11/11 tasks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)