### PR TITLE
Expand state bill Browse coverage

### DIFF
--- a/apps/expo/src/app/(tabs)/feed.tsx
+++ b/apps/expo/src/app/(tabs)/feed.tsx
@@ -159,7 +159,7 @@ function FeedCard({
     >
       {/* top meta */}
       <View style={s.meta}>
-        {item.jurisdiction === "ca" && item.contentLabel ? (
+        {item.jurisdiction !== "federal" && item.contentLabel ? (
           <Text style={[s.stateLabel, { color: t.color }]}>
             {item.contentLabel}
           </Text>

--- a/apps/expo/src/app/(tabs)/index.tsx
+++ b/apps/expo/src/app/(tabs)/index.tsx
@@ -31,7 +31,7 @@ import { colors, fontBody, fontDisplay, hair, planes } from "~/styles";
 import { queryClient, trpc, trpcClient } from "~/utils/api";
 import { toCardItem } from "~/utils/content";
 import { daysUntil, isWithinDays } from "~/utils/dates";
-import { JURISDICTIONS } from "~/utils/jurisdiction";
+import { isStateJurisdiction, JURISDICTIONS } from "~/utils/jurisdiction";
 
 // Below this length a query is treated as "not searching yet" to avoid
 // hammering the server-side full-text search on the first keystroke.
@@ -56,6 +56,7 @@ export default function BrowseScreen() {
   const refreshInFlight = useRef(false);
   const { jurisdiction, setJurisdiction } = useContentJurisdiction();
   const jurisdictionInfo = JURISDICTIONS[jurisdiction];
+  const isState = isStateJurisdiction(jurisdiction);
   const otherJurisdiction = jurisdiction === "federal" ? "ca" : "federal";
 
   const handleFilterChange = (f: VideoPost["type"] | "all") => {
@@ -257,11 +258,11 @@ export default function BrowseScreen() {
             {!listIsLoading && !listError && items.length > 0 && (
               <View style={s.resultsCountWrap}>
                 <Text style={s.resultsCount}>
-                  {items.length} {jurisdiction === "ca" ? "bill" : "result"}
+                  {items.length} {isState ? "bill" : "result"}
                   {items.length === 1 ? "" : "s"} ·{" "}
                   {isSearching
                     ? "sorted by relevance"
-                    : jurisdiction === "ca"
+                    : isState
                       ? "sorted by latest action"
                       : "sorted by recent"}
                 </Text>
@@ -345,25 +346,27 @@ export default function BrowseScreen() {
           ) : (
             <View style={s.center}>
               <Text style={s.emptyTitle}>
-                {jurisdiction === "ca" && filter === "court_case"
-                  ? "No California court cases yet"
-                  : jurisdiction === "ca"
-                    ? `No California ${filter === "all" ? "bills" : "records"} found`
+                {isState && filter === "court_case"
+                  ? `No ${jurisdictionInfo.name} court cases yet`
+                  : isState
+                    ? `No ${jurisdictionInfo.name} ${filter === "all" ? "bills" : "records"} found`
                     : isSearching
                       ? `No federal match for “${query.trim()}”`
                       : "Nothing found"}
               </Text>
               <Text style={s.emptySub}>
-                {jurisdiction === "ca"
-                  ? "Billion covers California’s Legislature today. State courts and executive orders aren’t ingested yet."
+                {isState
+                  ? `Billion covers ${jurisdictionInfo.name}’s Legislature today. State courts and executive orders aren’t ingested yet.`
                   : "Try a different search or filter."}
               </Text>
-              {jurisdiction === "ca" && filter !== "bill" ? (
+              {isState && filter !== "bill" && filter !== "all" ? (
                 <TouchableOpacity
                   style={s.emptyAction}
                   onPress={() => handleFilterChange("bill")}
                 >
-                  <Text style={s.emptyActionText}>Show California bills</Text>
+                  <Text style={s.emptyActionText}>
+                    Show {jurisdictionInfo.name} bills
+                  </Text>
                 </TouchableOpacity>
               ) : null}
             </View>

--- a/apps/expo/src/app/article-detail.tsx
+++ b/apps/expo/src/app/article-detail.tsx
@@ -49,6 +49,7 @@ import { queryClient, trpc } from "~/utils/api";
 import { authClient } from "~/utils/auth";
 import { formatDate } from "~/utils/dates";
 import { contentImageSource } from "~/utils/editorial-visuals";
+import { isStateJurisdiction, JURISDICTIONS } from "~/utils/jurisdiction";
 
 export const ErrorBoundary = createRouteErrorBoundary("article-detail");
 
@@ -340,7 +341,8 @@ export default function ArticleDetailScreen() {
   // Actions are the official legislative record from the source (congress.gov).
   const timelineSourceUrl = hasRealActions ? content.url : undefined;
   const sponsor = content.type === "bill" ? content.sponsor : undefined;
-  const isStateBill = content.type === "bill" && content.jurisdiction === "ca";
+  const isStateBill =
+    content.type === "bill" && isStateJurisdiction(content.jurisdiction);
   const displayBillNumber = isStateBill
     ? content.billNumber.replace(/\s+\([^)]+\)$/, "")
     : content.billNumber;
@@ -414,7 +416,8 @@ export default function ArticleDetailScreen() {
 
         {isStateBill ? (
           <Text style={s.jurisdictionLine}>
-            California Legislature · {content.sessionLabel} regular session
+            {JURISDICTIONS[content.jurisdiction].body}
+            {content.sessionLabel ? ` · ${content.sessionLabel}` : ""}
           </Text>
         ) : null}
 

--- a/apps/expo/src/app/bill-sponsor-profile.tsx
+++ b/apps/expo/src/app/bill-sponsor-profile.tsx
@@ -56,7 +56,7 @@ export default function BillSponsorProfileScreen() {
   }
 
   const { jurisdiction, sponsor, sponsoredBills, sourceUrl } = query.data;
-  const isStateSponsor = jurisdiction === "ca";
+  const isStateSponsor = jurisdiction !== "federal";
   const location = [
     sponsor.state,
     sponsor.district && `District ${sponsor.district}`,

--- a/apps/expo/src/app/settings/saved-articles.tsx
+++ b/apps/expo/src/app/settings/saved-articles.tsx
@@ -10,6 +10,10 @@ import { Swipeable } from "react-native-gesture-handler";
 import { useRouter } from "expo-router";
 import { useInfiniteQuery, useMutation } from "@tanstack/react-query";
 
+import type {
+  ContentJurisdiction,
+  JurisdictionCode,
+} from "~/utils/jurisdiction";
 import { Text } from "~/components/Themed";
 import { ContentCard, Icon, NavHeader } from "~/components/ui";
 import { colors, hair, planes } from "~/styles";
@@ -24,8 +28,8 @@ interface SavedItem {
   description: string | null;
   type: "bill" | "government_content" | "court_case";
   billNumber?: string;
-  jurisdiction?: "federal" | "ca";
-  jurisdictionCode?: "US" | "CA";
+  jurisdiction?: ContentJurisdiction;
+  jurisdictionCode?: JurisdictionCode;
   billStatus?: string;
   activityAt?: Date;
   chamber?: string;

--- a/apps/expo/src/components/JurisdictionPicker.tsx
+++ b/apps/expo/src/components/JurisdictionPicker.tsx
@@ -12,7 +12,11 @@ import type { ContentJurisdiction } from "~/utils/jurisdiction";
 import { Text } from "~/components/Themed";
 import { Icon, Kicker } from "~/components/ui";
 import { colors, fontBody, fontDisplay, hair, planes } from "~/styles";
-import { addressIsInCalifornia, JURISDICTIONS } from "~/utils/jurisdiction";
+import {
+  jurisdictionFromAddress,
+  JURISDICTIONS,
+  STATE_JURISDICTIONS,
+} from "~/utils/jurisdiction";
 
 export function JurisdictionScopeRow({
   jurisdiction,
@@ -63,7 +67,7 @@ export function JurisdictionPicker({
   onSetAddress: () => void;
 }) {
   const insets = useSafeAreaInsets();
-  const californiaIsHome = addressIsInCalifornia(address);
+  const homeJurisdiction = jurisdictionFromAddress(address);
   return (
     <Modal
       visible={visible}
@@ -107,18 +111,21 @@ export function JurisdictionPicker({
             />
 
             <Kicker style={s.groupLabel}>States</Kicker>
-            <JurisdictionOption
-              jurisdiction="ca"
-              selected={selected === "ca"}
-              isHome={californiaIsHome}
-              onPress={() => onSelect("ca")}
-            />
+            {STATE_JURISDICTIONS.map((jurisdiction) => (
+              <JurisdictionOption
+                key={jurisdiction}
+                jurisdiction={jurisdiction}
+                selected={selected === jurisdiction}
+                isHome={homeJurisdiction === jurisdiction}
+                onPress={() => onSelect(jurisdiction)}
+              />
+            ))}
 
             <View style={s.coverageNote}>
               <Icon name="info" size={16} color={colors.textSecondary} />
               <Text style={s.coverageText}>
-                California is the only state Billion covers so far. More are
-                being added.
+                State bill coverage currently includes California, Missouri,
+                North Carolina and Texas.
               </Text>
             </View>
           </ScrollView>

--- a/apps/expo/src/hooks/useContentJurisdiction.ts
+++ b/apps/expo/src/hooks/useContentJurisdiction.ts
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 
 import type { ContentJurisdiction } from "~/utils/jurisdiction";
 import { preferenceStorage } from "~/utils/client-storage";
+import { isContentJurisdiction } from "~/utils/jurisdiction";
 
 const JURISDICTION_KEY = "content_jurisdiction";
 
@@ -9,7 +10,7 @@ export function useContentJurisdiction() {
   const [jurisdiction, setJurisdictionState] = useState<ContentJurisdiction>(
     () => {
       const stored = preferenceStorage.getItem(JURISDICTION_KEY);
-      return stored === "ca" || stored === "federal" ? stored : "federal";
+      return isContentJurisdiction(stored) ? stored : "federal";
     },
   );
 

--- a/apps/expo/src/utils/content.ts
+++ b/apps/expo/src/utils/content.ts
@@ -1,6 +1,11 @@
 /** Shared shape + helpers for backend content items (bills, orders, cases). */
 import type { ContentCardItem } from "~/components/ui";
+import type {
+  ContentJurisdiction,
+  JurisdictionCode,
+} from "~/utils/jurisdiction";
 import { resolveType } from "~/styles";
+import { isStateJurisdiction, JURISDICTIONS } from "~/utils/jurisdiction";
 
 export interface ContentItem {
   id: string;
@@ -10,8 +15,8 @@ export interface ContentItem {
   thumbnailUrl?: string;
   imageUri?: string;
   billNumber?: string;
-  jurisdiction?: "federal" | "ca";
-  jurisdictionCode?: "US" | "CA";
+  jurisdiction?: ContentJurisdiction;
+  jurisdictionCode?: JurisdictionCode;
   billStatus?: string;
   activityAt?: Date;
   chamber?: string;
@@ -54,7 +59,10 @@ export function toCardItem(
   item: ContentItem,
   options: { showJurisdiction?: boolean } = {},
 ): ContentCardItem {
-  const isStateBill = item.type === "bill" && item.jurisdiction === "ca";
+  const stateName = isStateJurisdiction(item.jurisdiction)
+    ? JURISDICTIONS[item.jurisdiction].name
+    : undefined;
+  const isStateBill = item.type === "bill" && !!stateName;
   const activity = relativeActivity(item.activityAt);
   return {
     id: item.id,
@@ -68,7 +76,7 @@ export function toCardItem(
       ? [item.billStatus, activity].filter(Boolean).join(" · ")
       : STATUS_LABEL[item.type],
     meta: isStateBill
-      ? [item.chamber && `California ${item.chamber}`, item.sponsor]
+      ? [item.chamber && `${stateName} ${item.chamber}`, item.sponsor]
           .filter(Boolean)
           .join(" · ")
       : undefined,

--- a/apps/expo/src/utils/jurisdiction.ts
+++ b/apps/expo/src/utils/jurisdiction.ts
@@ -1,4 +1,14 @@
-export type ContentJurisdiction = "federal" | "ca";
+export const CONTENT_JURISDICTIONS = [
+  "federal",
+  "ca",
+  "mo",
+  "nc",
+  "tx",
+] as const;
+
+export type ContentJurisdiction = (typeof CONTENT_JURISDICTIONS)[number];
+export type StateJurisdiction = Exclude<ContentJurisdiction, "federal">;
+export type JurisdictionCode = "US" | "CA" | "MO" | "NC" | "TX";
 
 export interface JurisdictionDefinition {
   id: ContentJurisdiction;
@@ -6,10 +16,17 @@ export interface JurisdictionDefinition {
   body: string;
   session: string;
   description: string;
-  code: "US" | "CA";
+  code: JurisdictionCode;
   icon: "globe" | "pin";
   subtitlePlace: string;
 }
+
+export const STATE_JURISDICTIONS: StateJurisdiction[] = [
+  "ca",
+  "mo",
+  "nc",
+  "tx",
+];
 
 export const JURISDICTIONS: Record<
   ContentJurisdiction,
@@ -35,8 +52,62 @@ export const JURISDICTIONS: Record<
     icon: "pin",
     subtitlePlace: "Sacramento",
   },
+  mo: {
+    id: "mo",
+    name: "Missouri",
+    body: "Missouri General Assembly",
+    session: "2026 regular session",
+    description: "General Assembly · 2026 regular session",
+    code: "MO",
+    icon: "pin",
+    subtitlePlace: "Jefferson City",
+  },
+  nc: {
+    id: "nc",
+    name: "North Carolina",
+    body: "North Carolina General Assembly",
+    session: "2025–2026 regular session",
+    description: "General Assembly · 2025–2026 regular session",
+    code: "NC",
+    icon: "pin",
+    subtitlePlace: "Raleigh",
+  },
+  tx: {
+    id: "tx",
+    name: "Texas",
+    body: "Texas Legislature",
+    session: "89th Legislature · 2nd called session",
+    description: "State Legislature · 89th Legislature",
+    code: "TX",
+    icon: "pin",
+    subtitlePlace: "Austin",
+  },
 };
 
-export function addressIsInCalifornia(address: string | null): boolean {
-  return !!address && /(?:,|\s)(?:CA|California)(?:\s|,|\d|$)/i.test(address);
+const ADDRESS_PATTERNS: Record<StateJurisdiction, RegExp> = {
+  ca: /(?:,|\s)(?:CA|California)(?:\s|,|\d|$)/i,
+  mo: /(?:,|\s)(?:MO|Missouri)(?:\s|,|\d|$)/i,
+  nc: /(?:,|\s)(?:NC|North Carolina)(?:\s|,|\d|$)/i,
+  tx: /(?:,|\s)(?:TX|Texas)(?:\s|,|\d|$)/i,
+};
+
+export function isContentJurisdiction(
+  value: string | null,
+): value is ContentJurisdiction {
+  return CONTENT_JURISDICTIONS.some((jurisdiction) => jurisdiction === value);
+}
+
+export function isStateJurisdiction(
+  jurisdiction: ContentJurisdiction | undefined,
+): jurisdiction is StateJurisdiction {
+  return !!jurisdiction && jurisdiction !== "federal";
+}
+
+export function jurisdictionFromAddress(
+  address: string | null,
+): StateJurisdiction | undefined {
+  if (!address) return undefined;
+  return STATE_JURISDICTIONS.find((jurisdiction) =>
+    ADDRESS_PATTERNS[jurisdiction].test(address),
+  );
 }

--- a/apps/scraper/README.md
+++ b/apps/scraper/README.md
@@ -129,6 +129,7 @@ CONGRESS_MAX_ITEMS=10 pnpm --filter @acme/scraper run start congress
 | `SCC_CVIG_MAX_ITEMS`            |      10 | Voter-guide PDF documents                           |
 | `CA_SOS_MAX_ITEMS`              |       9 | Statewide-office candidate-statement pages          |
 | `SCRAPER_MAX_NEW_ITEMS_PER_RUN` |      10 | New records receiving expensive AI/image enrichment |
+| `SCRAPER_SKIP_DUAL_LENS`        |       0 | Skip optional dual-lens generation during backfills |
 
 These are per-run limits, not durable calendar-day quotas. Schedule one run per
 day to obtain a daily cap. If the scheduler retries or runs multiple times, each
@@ -136,6 +137,11 @@ invocation gets a fresh allowance. Source limits cap API/page work;
 `SCRAPER_MAX_NEW_ITEMS_PER_RUN` separately caps expensive enrichment. Extra
 bills that require a generated description are deferred before insertion;
 other content may still be stored raw for later backfill.
+
+For a large, explicitly bounded seed, set `SCRAPER_SKIP_DUAL_LENS=1` to write
+each bill as soon as its required summary, brief, and header art are complete.
+The optional lenses can then be filled by `retroactive-lenses` without holding
+up the source backfill.
 
 ---
 

--- a/apps/scraper/src/main.ts
+++ b/apps/scraper/src/main.ts
@@ -49,7 +49,7 @@ const argv = await yargs(hideBin(process.argv))
   .option("session", {
     type: "string",
     describe:
-      'Legislative session for --bill on state sources (e.g. --session 20252026). Requires the "open-states" scraper',
+      'Legislative session for --bill or --bulk-dir on state sources (e.g. --session 20252026). Requires the "open-states" scraper',
   })
   .option("bulk-dir", {
     type: "string",
@@ -85,8 +85,10 @@ const argv = await yargs(hideBin(process.argv))
       if (args.scraper !== "open-states") {
         throw new Error('--session requires the "open-states" scraper');
       }
-      if (!bills?.length) {
-        throw new Error("--session only applies alongside --bill");
+      if (!bills?.length && args.bulkDir === undefined) {
+        throw new Error(
+          "--session only applies alongside --bill or --bulk-dir",
+        );
       }
     }
     if (args.bulkDir !== undefined) {

--- a/apps/scraper/src/scrapers/open-states-bulk.test.ts
+++ b/apps/scraper/src/scrapers/open-states-bulk.test.ts
@@ -147,6 +147,18 @@ void test("an export with only bills.csv still yields storable bills", () => {
   });
 });
 
+void test("an explicit session fills exports that omit the session column", () => {
+  const billsWithoutSession = [
+    "id,identifier,title,organization_classification,created_at,updated_at,openstates_url",
+    "ocd-bill/tx,SB 1,Appropriations,upper,2025-08-15T00:00:00Z,2026-07-09T00:00:00Z,https://openstates.org/TX/bills/892/SB1/",
+  ].join("\n");
+  withExport({ "TX_892_bills.csv": billsWithoutSession }, (directory) => {
+    const [bill] = readBulkBills(directory, { session: "892" });
+    const normalized = normalizeBill(bill!, { stateCode: "tx" });
+    assert.equal(normalized.billNumber, "TX SB 1 (892)");
+  });
+});
+
 void test("a renamed or reshaped export fails loudly with the columns it saw", () => {
   withExport(
     { "CA_2025-2026_bills.csv": "bill_id,name\nocd-bill/abc,Something" },

--- a/apps/scraper/src/scrapers/open-states-bulk.ts
+++ b/apps/scraper/src/scrapers/open-states-bulk.ts
@@ -297,7 +297,7 @@ export function readBulkBills(
       identifier: column(row, "identifier"),
       title: column(row, "title"),
       session:
-        column(row, "session", "legislative_session") ||
+        column(row, "session", "session_identifier", "legislative_session") ||
         (options.session ?? ""),
       classification: splitClassification(column(row, "classification")),
       ...(organizationClassification

--- a/apps/scraper/src/scrapers/open-states-normalize.test.ts
+++ b/apps/scraper/src/scrapers/open-states-normalize.test.ts
@@ -273,7 +273,7 @@ void test("the longest abstract is kept as summary source", () => {
   assert.equal(pickAbstract(undefined), undefined);
 });
 
-void test("text selection prefers the newest text version and skips PDF-only ones", () => {
+void test("text selection prefers HTML over PDF for the newest version", () => {
   const picked = pickVersionLink([
     {
       note: "Introduced",
@@ -298,8 +298,8 @@ void test("text selection prefers the newest text version and skips PDF-only one
   assert.equal(picked?.note, "Chaptered");
 });
 
-void test("a PDF-only bill yields no text link rather than a PDF one", () => {
-  assert.equal(
+void test("a PDF-only bill yields a PDF text source", () => {
+  assert.deepEqual(
     pickVersionLink([
       {
         note: "Introduced",
@@ -309,7 +309,11 @@ void test("a PDF-only bill yields no text link rather than a PDF one", () => {
         ],
       },
     ]),
-    undefined,
+    {
+      url: "https://example.gov/x.pdf",
+      mediaType: "application/pdf",
+      note: "Introduced",
+    },
   );
   assert.equal(pickVersionLink(undefined), undefined);
 });

--- a/apps/scraper/src/scrapers/open-states-normalize.ts
+++ b/apps/scraper/src/scrapers/open-states-normalize.ts
@@ -306,17 +306,17 @@ export function pickAbstract(
   return best || undefined;
 }
 
-const TEXT_MEDIA_PREFERENCE = ["text/html", "text/plain"];
+const TEXT_MEDIA_PREFERENCE = ["text/html", "text/plain", "application/pdf"];
 
 /**
  * The link to fetch a bill's operative text from.
  *
- * Newest version first, and only text formats: PDF-only versions are left for
- * the abstract to cover rather than run through a PDF pipeline this scraper
- * does not have. Undated versions sort last, for the same reason the federal
- * scraper does it — an undated version is not evidence of being current, and
- * storing an introduced draft as though it were the chaptered text is the exact
- * failure that made the federal briefs wrong for months.
+ * Newest version first, preferring HTML/plain text before PDF. PDF support is
+ * required for states such as North Carolina whose bulk exports publish no
+ * abstracts or HTML versions. Undated versions sort last, for the same reason
+ * the federal scraper does it — an undated version is not evidence of being
+ * current, and storing an introduced draft as though it were the chaptered
+ * text is the exact failure that made the federal briefs wrong for months.
  */
 export function pickVersionLink(
   versions: readonly OpenStatesBillVersion[] | undefined,

--- a/apps/scraper/src/scrapers/open-states.config.ts
+++ b/apps/scraper/src/scrapers/open-states.config.ts
@@ -4,7 +4,7 @@ export const openStatesConfig = {
   id: "open-states",
   name: "Open States",
   source:
-    "Open States v3 API — state legislature bills, sponsors, actions, and text (California)",
+    "Open States v3 API — state legislature bills, sponsors, actions, and text",
   environment: {
     required: ["POSTGRES_URL", "OPEN_STATES_API_KEY"],
     requiredAny: [

--- a/apps/scraper/src/scrapers/open-states.config.ts
+++ b/apps/scraper/src/scrapers/open-states.config.ts
@@ -24,6 +24,7 @@ export const openStatesConfig = {
       "GOOGLE_SEARCH_ENGINE_ID",
       "OPEN_STATES_MAX_ITEMS",
       "OPEN_STATES_STATES",
+      "SCRAPER_SKIP_DUAL_LENS",
     ],
   },
 } as const satisfies ScraperEnvContract;

--- a/apps/scraper/src/scrapers/open-states.ts
+++ b/apps/scraper/src/scrapers/open-states.ts
@@ -15,6 +15,8 @@
  * not from Open States, so it does not draw on the API budget at all.
  */
 
+import { getDocumentProxy } from "unpdf";
+
 import type { OpenStatesBill } from "@acme/api/clients/open-states";
 import { eq } from "@acme/db";
 import { db } from "@acme/db/client";
@@ -172,6 +174,21 @@ function stripHtml(html: string): string {
     .trim();
 }
 
+async function extractPdfText(bytes: Uint8Array): Promise<string> {
+  const document = await getDocumentProxy(bytes);
+  const pages: string[] = [];
+  for (let pageNumber = 1; pageNumber <= document.numPages; pageNumber++) {
+    const page = await document.getPage(pageNumber);
+    const content = await page.getTextContent();
+    const text = (content.items as { str?: string }[])
+      .map((item) => item.str?.trim())
+      .filter(Boolean)
+      .join(" ");
+    if (text) pages.push(text);
+  }
+  return pages.join("\n\n");
+}
+
 /**
  * Fetch the operative bill text from the state's own site.
  *
@@ -186,9 +203,12 @@ async function fetchFullText(
   if (!bill.textLink) return undefined;
   try {
     const res = await fetchWithRetry(bill.textLink.url);
-    const raw = await res.text();
-    if (!raw) return undefined;
-    const text = stripHtml(raw);
+    const isPdf =
+      bill.textLink.mediaType?.toLowerCase() === "application/pdf" ||
+      /\.pdf(?:$|[?#])/i.test(bill.textLink.url);
+    const text = isPdf
+      ? await extractPdfText(new Uint8Array(await res.arrayBuffer()))
+      : stripHtml(await res.text());
     if (!text) return undefined;
     return assertWithinTsvectorLimit(text, bill.billNumber) || undefined;
   } catch (error) {
@@ -290,9 +310,10 @@ async function importBulk(
   directory: string,
   stateCode: string,
   maxBills: number,
+  session?: string,
 ): Promise<void> {
   logger.info(`Importing bulk export from ${directory} (state=${stateCode})`);
-  const bills = readBulkBills(directory).slice(0, maxBills);
+  const bills = readBulkBills(directory, { session }).slice(0, maxBills);
   logger.info(`Read ${bills.length} bill(s) from the export`);
 
   if (bills.length === 0) {
@@ -620,7 +641,12 @@ async function scrape(config: OpenStatesScraperConfig = {}): Promise<void> {
 
   if (config.bulkDir) {
     // A bulk export is a single state's session by construction.
-    return importBulk(config.bulkDir, states[0] ?? "ca", maxBills);
+    return importBulk(
+      config.bulkDir,
+      states[0] ?? "ca",
+      maxBills,
+      config.session,
+    );
   }
 
   if (config.bills?.length) {

--- a/apps/scraper/src/utils/db/operations.ts
+++ b/apps/scraper/src/utils/db/operations.ts
@@ -18,6 +18,7 @@ import type {
   CourtCaseData,
   GovernmentContentData,
 } from "../types.js";
+import type { BuiltVideoRecord, DbExecutor } from "./video-operations.js";
 import { generateBillBrief } from "../ai/bill-brief.js";
 import { generateImageSearchKeywords } from "../ai/image-keywords.js";
 import { getTextModelVersion } from "../ai/provider.js";
@@ -50,7 +51,6 @@ import {
   incrementTotalProcessed,
   incrementVideosGenerated,
 } from "./metrics.js";
-import type { BuiltVideoRecord, DbExecutor } from "./video-operations.js";
 import {
   buildVideoRecord,
   generateVideoForContent,
@@ -59,6 +59,7 @@ import {
 
 const logger = createLogger("db");
 const forceAIRegeneration = process.env.SCRAPER_FORCE_AI_REGEN === "1";
+const skipOptionalDualLens = process.env.SCRAPER_SKIP_DUAL_LENS === "1";
 
 type ContentData =
   | { type: "bill"; data: BillData }
@@ -207,7 +208,9 @@ export async function upsertContent(
       : !hasPersistedSummary && !sourceDescription && hasSummarySource;
     shouldGenerateArticle =
       generatesArticle &&
-      (forceAIRegeneration ? hasUsableText : hasUsableText && !existing.hasArticle);
+      (forceAIRegeneration
+        ? hasUsableText
+        : hasUsableText && !existing.hasArticle);
     shouldGenerateImage =
       (forceAIRegeneration || !existing.hasThumbnail) && hasUsableText;
     progressKind = "changed";
@@ -218,7 +221,9 @@ export async function upsertContent(
       : !hasPersistedSummary && !sourceDescription && hasSummarySource;
     shouldGenerateArticle =
       generatesArticle &&
-      (forceAIRegeneration ? hasUsableText : hasUsableText && !existing.hasArticle);
+      (forceAIRegeneration
+        ? hasUsableText
+        : hasUsableText && !existing.hasArticle);
     shouldGenerateImage =
       (forceAIRegeneration || !existing.hasThumbnail) && hasUsableText;
     progressKind = "unchanged";
@@ -596,7 +601,12 @@ export async function upsertContent(
     // along with every other derived asset: the lens runs an agentic research
     // loop, and it is the budget's whole purpose to not pay for that on a bill
     // we are only persisting raw. `retroactive-lenses` backfills them.
-    if (hasUsableText && result?.id && !budgetExhausted) {
+    if (
+      hasUsableText &&
+      result?.id &&
+      !budgetExhausted &&
+      !skipOptionalDualLens
+    ) {
       await upsertContentLens(
         result.id,
         input.type,
@@ -962,23 +972,25 @@ async function assembleNewBill(args: {
   // running it inside the transaction would hold a connection open for minutes.
   // A failure here leaves a complete bill with no lens, which `retroactive-
   // lenses` fills in later.
-  try {
-    await upsertContentLens(
-      billId,
-      "bill",
-      contentHash,
-      data.title,
-      data.fullText,
-      "bill",
-      null,
-      args.claimBudget,
-    );
-  } catch (error) {
-    logger.warn(
-      `Dual lens failed for ${label} — the bill is stored and complete without it: ${
-        error instanceof Error ? error.message : error
-      }`,
-    );
+  if (!skipOptionalDualLens) {
+    try {
+      await upsertContentLens(
+        billId,
+        "bill",
+        contentHash,
+        data.title,
+        data.fullText,
+        "bill",
+        null,
+        args.claimBudget,
+      );
+    } catch (error) {
+      logger.warn(
+        `Dual lens failed for ${label} — the bill is stored and complete without it: ${
+          error instanceof Error ? error.message : error
+        }`,
+      );
+    }
   }
 
   return { status: "ready", id: billId };
@@ -1025,7 +1037,11 @@ export async function buildBillBriefRecord(args: {
 
   const modelVersion = getTextModelVersion();
   return {
-    brief: { ...generated, generatedAt: new Date().toISOString(), modelVersion },
+    brief: {
+      ...generated,
+      generatedAt: new Date().toISOString(),
+      modelVersion,
+    },
     modelVersion,
   };
 }

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -112,9 +112,10 @@ regenerating one for testing.
 ## State bills (Open States)
 
 `open-states.ts` ingests state-legislature bills into the same `Bill` table and
-the same AI pipeline as federal ones. California only today
-(`OPEN_STATES_STATES=ca`); the state list is a config value, not a hardcode, and
-each state walks its own cursor keyed `open-states:{state}`.
+the same AI pipeline as federal ones. Browse currently supports California,
+Missouri, North Carolina, and Texas
+(`OPEN_STATES_STATES=ca,mo,nc,tx`); each state walks its own cursor keyed
+`open-states:{state}`.
 
 **Identity.** A state bill's `billNumber` is `"CA SB 243 (2025-2026)"` and its
 `sourceWebsite` is `openstates.org`. All three parts are load-bearing: the
@@ -157,7 +158,7 @@ sign in, download the session archive, unzip it, and point `--bulk-dir` at the
 directory.
 
 ```sh
-pnpm --filter @acme/scraper run start open-states --bulk-dir ~/Downloads/CA_2025-2026_csv
+pnpm --filter @acme/scraper run start open-states --bulk-dir ~/Downloads/CA_2025-2026_csv --session 20252026
 ```
 
 The import deliberately does **not** move the cursor. An export is a snapshot of
@@ -168,6 +169,8 @@ export was built.
 Open States documents the CSV format as experimental. The reader maps columns by
 name with a few aliases and raises `BulkExportShapeError` listing the columns it
 actually found if the shape has moved — it will not quietly import shifted data.
+Pass `--session` for exports that omit a session column; it becomes part of each
+bill's stable identity.
 
 **Not ingested:** roll-call votes. `Bill` has no column for them and inventing
 one is out of scope here; the `openStates` tRPC router already serves votes

--- a/packages/api/src/lib/bill-sponsor.test.ts
+++ b/packages/api/src/lib/bill-sponsor.test.ts
@@ -56,4 +56,10 @@ void test("parses a state-legislator district without treating it as a state", (
   });
   assert.equal(sponsorRole("Senate", "ca"), "California State Senator");
   assert.equal(sponsorRole("Assembly", "ca"), "California Assemblymember");
+  assert.equal(sponsorRole("Senate", "mo"), "Missouri State Senator");
+  assert.equal(
+    sponsorRole("House", "nc"),
+    "North Carolina State Representative",
+  );
+  assert.equal(sponsorRole("House", "tx"), "Texas State Representative");
 });

--- a/packages/api/src/lib/bill-sponsor.ts
+++ b/packages/api/src/lib/bill-sponsor.ts
@@ -1,3 +1,9 @@
+import type { ContentJurisdiction } from "./content-jurisdiction";
+import {
+  isStateJurisdiction,
+  STATE_JURISDICTIONS,
+} from "./content-jurisdiction";
+
 export interface BillSponsorIdentity {
   raw: string;
   name: string;
@@ -18,7 +24,7 @@ const PARTY_NAMES: Record<string, string> = {
 /** Parse the normalized sponsor label stored by the Congress.gov scraper. */
 export function parseBillSponsor(
   raw: string,
-  jurisdiction: "federal" | "ca" = "federal",
+  jurisdiction: ContentJurisdiction = "federal",
 ): BillSponsorIdentity {
   const value = raw.trim();
   const match = /^(.*?)\s*\(([^)]+)\)\s*$/.exec(value);
@@ -55,12 +61,16 @@ export function parseBillSponsor(
 
 export function sponsorRole(
   chamber?: string | null,
-  jurisdiction: "federal" | "ca" = "federal",
+  jurisdiction: ContentJurisdiction = "federal",
 ): string {
-  if (jurisdiction === "ca") {
-    return chamber?.toLowerCase() === "senate"
-      ? "California State Senator"
-      : "California Assemblymember";
+  if (isStateJurisdiction(jurisdiction)) {
+    const state = STATE_JURISDICTIONS[jurisdiction];
+    if (chamber?.toLowerCase() === "senate") {
+      return `${state.name} State Senator`;
+    }
+    return jurisdiction === "ca"
+      ? "California Assemblymember"
+      : `${state.name} State Representative`;
   }
   return chamber?.toLowerCase() === "senate"
     ? "U.S. Senator"

--- a/packages/api/src/lib/content-jurisdiction.test.ts
+++ b/packages/api/src/lib/content-jurisdiction.test.ts
@@ -3,6 +3,8 @@ import test from "node:test";
 
 import {
   billJurisdiction,
+  displaySessionLabel,
+  jurisdictionCode,
   officialSourceLabel,
   parseStateBillNumber,
 } from "./content-jurisdiction";
@@ -15,15 +17,32 @@ void test("parses an Open States bill identity", () => {
   });
 });
 
-void test("distinguishes California and federal bills", () => {
+void test("distinguishes supported state and federal bills", () => {
   assert.equal(
     billJurisdiction("openstates.org", "CA SB 243 (2025-2026)"),
     "ca",
   );
+  assert.equal(billJurisdiction("openstates.org", "MO SB 1320 (2026)"), "mo");
+  assert.equal(billJurisdiction("openstates.org", "NC SB 445 (2025)"), "nc");
+  assert.equal(billJurisdiction("openstates.org", "TX SB 1 (892)"), "tx");
   assert.equal(billJurisdiction("congress.gov", "S. 243"), "federal");
 });
 
 void test("uses a jurisdiction-correct official source label", () => {
   assert.equal(officialSourceLabel("ca"), "California Legislature");
+  assert.equal(officialSourceLabel("mo"), "Missouri General Assembly");
+  assert.equal(officialSourceLabel("nc"), "North Carolina General Assembly");
+  assert.equal(officialSourceLabel("tx"), "Texas Legislature");
   assert.equal(officialSourceLabel("federal"), "congress.gov");
+});
+
+void test("provides codes and friendly current-session labels", () => {
+  assert.equal(jurisdictionCode("mo"), "MO");
+  assert.equal(jurisdictionCode("nc"), "NC");
+  assert.equal(jurisdictionCode("tx"), "TX");
+  assert.equal(
+    displaySessionLabel("tx", "892"),
+    "89th Legislature · 2nd called session",
+  );
+  assert.equal(displaySessionLabel("tx", "881"), "881");
 });

--- a/packages/api/src/lib/content-jurisdiction.ts
+++ b/packages/api/src/lib/content-jurisdiction.ts
@@ -1,11 +1,68 @@
-export const JURISDICTIONS = ["federal", "ca"] as const;
+export const JURISDICTIONS = ["federal", "ca", "mo", "nc", "tx"] as const;
 
 export type ContentJurisdiction = (typeof JURISDICTIONS)[number];
+export type StateJurisdiction = Exclude<ContentJurisdiction, "federal">;
+
+export const JURISDICTION_CODES = ["US", "CA", "MO", "NC", "TX"] as const;
+export type JurisdictionCode = (typeof JURISDICTION_CODES)[number];
+
+interface StateJurisdictionDefinition {
+  code: Exclude<JurisdictionCode, "US">;
+  name: string;
+  legislature: string;
+  lowerChamber: string;
+  currentSession: string;
+  currentSessionLabel: string;
+}
+
+export const STATE_JURISDICTIONS: Record<
+  StateJurisdiction,
+  StateJurisdictionDefinition
+> = {
+  ca: {
+    code: "CA",
+    name: "California",
+    legislature: "California Legislature",
+    lowerChamber: "Assembly",
+    currentSession: "2025-2026",
+    currentSessionLabel: "2025–2026 regular session",
+  },
+  mo: {
+    code: "MO",
+    name: "Missouri",
+    legislature: "Missouri General Assembly",
+    lowerChamber: "House",
+    currentSession: "2026",
+    currentSessionLabel: "2026 regular session",
+  },
+  nc: {
+    code: "NC",
+    name: "North Carolina",
+    legislature: "North Carolina General Assembly",
+    lowerChamber: "House",
+    currentSession: "2025",
+    currentSessionLabel: "2025–2026 regular session",
+  },
+  tx: {
+    code: "TX",
+    name: "Texas",
+    legislature: "Texas Legislature",
+    lowerChamber: "House",
+    currentSession: "892",
+    currentSessionLabel: "89th Legislature · 2nd called session",
+  },
+};
 
 export interface StateBillIdentity {
   stateCode: string;
   identifier: string;
   sessionLabel: string;
+}
+
+export function isStateJurisdiction(
+  jurisdiction: ContentJurisdiction,
+): jurisdiction is StateJurisdiction {
+  return jurisdiction !== "federal";
 }
 
 /** Recover the display identity embedded by the Open States scraper. */
@@ -18,11 +75,7 @@ export function parseStateBillNumber(
   if (!match) return undefined;
   const [, stateCode, identifier, sessionLabel] = match;
   if (!stateCode || !identifier || !sessionLabel) return undefined;
-  return {
-    stateCode,
-    identifier,
-    sessionLabel,
-  };
+  return { stateCode, identifier, sessionLabel };
 }
 
 export function billJurisdiction(
@@ -31,17 +84,45 @@ export function billJurisdiction(
 ): ContentJurisdiction {
   if (sourceWebsite === "openstates.org") {
     const identity = parseStateBillNumber(billNumber);
-    if (identity?.stateCode === "CA") return "ca";
+    const jurisdiction = identity?.stateCode.toLowerCase();
+    if (
+      jurisdiction &&
+      jurisdiction !== "federal" &&
+      jurisdiction in STATE_JURISDICTIONS
+    ) {
+      return jurisdiction as StateJurisdiction;
+    }
   }
   return "federal";
 }
 
 export function jurisdictionCode(
   jurisdiction: ContentJurisdiction,
-): "US" | "CA" {
-  return jurisdiction === "ca" ? "CA" : "US";
+): JurisdictionCode {
+  return isStateJurisdiction(jurisdiction)
+    ? STATE_JURISDICTIONS[jurisdiction].code
+    : "US";
+}
+
+export function jurisdictionName(jurisdiction: ContentJurisdiction): string {
+  return isStateJurisdiction(jurisdiction)
+    ? STATE_JURISDICTIONS[jurisdiction].name
+    : "United States";
 }
 
 export function officialSourceLabel(jurisdiction: ContentJurisdiction): string {
-  return jurisdiction === "ca" ? "California Legislature" : "congress.gov";
+  return isStateJurisdiction(jurisdiction)
+    ? STATE_JURISDICTIONS[jurisdiction].legislature
+    : "congress.gov";
+}
+
+export function displaySessionLabel(
+  jurisdiction: ContentJurisdiction,
+  sourceSessionLabel: string | undefined,
+): string | undefined {
+  if (!isStateJurisdiction(jurisdiction)) return sourceSessionLabel;
+  const definition = STATE_JURISDICTIONS[jurisdiction];
+  return sourceSessionLabel === definition.currentSession
+    ? definition.currentSessionLabel
+    : sourceSessionLabel;
 }

--- a/packages/api/src/router/content.ts
+++ b/packages/api/src/router/content.ts
@@ -21,6 +21,8 @@ import { toBillTimelineActions } from "../lib/bill-actions";
 import { parseBillSponsor, sponsorRole } from "../lib/bill-sponsor";
 import {
   billJurisdiction,
+  displaySessionLabel,
+  JURISDICTION_CODES,
   jurisdictionCode,
   JURISDICTIONS,
   officialSourceLabel,
@@ -293,7 +295,7 @@ const ContentCardSchema = z.object({
   imageUri: z.string().optional(), // Add support for AI-generated data URIs
   billNumber: z.string().optional(), // Human-readable bill identifier, e.g. "H.R. 1234"
   jurisdiction: z.enum(JURISDICTIONS).optional(),
-  jurisdictionCode: z.enum(["US", "CA"]).optional(),
+  jurisdictionCode: z.enum(JURISDICTION_CODES).optional(),
   billStatus: z.string().optional(),
   activityAt: z.date().optional(),
   chamber: z.string().optional(),
@@ -344,9 +346,9 @@ function toBillCard(bill: BillCardSource): ContentCard & { type: "bill" } {
 }
 
 const billJurisdictionCondition = (jurisdiction: ContentJurisdiction) =>
-  jurisdiction === "ca"
-    ? sql`${Bill.sourceWebsite} = 'openstates.org' and ${Bill.billNumber} like 'CA %'`
-    : sql`${Bill.sourceWebsite} <> 'openstates.org'`;
+  jurisdiction === "federal"
+    ? sql`${Bill.sourceWebsite} <> 'openstates.org'`
+    : sql`${Bill.sourceWebsite} = 'openstates.org' and ${Bill.billNumber} like ${`${jurisdiction.toUpperCase()} %`}`;
 
 // Schema for detailed content
 const _ContentDetailSchema = ContentCardSchema.extend({
@@ -831,7 +833,10 @@ export const contentRouter = {
             billNumber: b.billNumber,
             jurisdiction,
             jurisdictionCode: jurisdictionCode(jurisdiction),
-            sessionLabel: stateIdentity?.sessionLabel,
+            sessionLabel: displaySessionLabel(
+              jurisdiction,
+              stateIdentity?.sessionLabel,
+            ),
             sourceLabel: officialSourceLabel(jurisdiction),
             sponsor,
             articleContent:

--- a/packages/api/src/router/video.ts
+++ b/packages/api/src/router/video.ts
@@ -7,7 +7,11 @@ import { Bill, CourtCase, GovernmentContent, Video } from "@acme/db/schema";
 
 import {
   billJurisdiction,
+  isStateJurisdiction,
+  JURISDICTION_CODES,
   jurisdictionCode,
+  jurisdictionName,
+  JURISDICTIONS,
   officialSourceLabel,
 } from "../lib/content-jurisdiction";
 import { publicProcedure } from "../trpc";
@@ -28,8 +32,8 @@ export const VideoPostSchema = z.object({
   thumbnailUrl: z.string().optional(), // URL from source content (scraped)
   originalContentId: z.string(), // Reference to source content
   sourceUrl: z.string().optional(), // Official source site
-  jurisdiction: z.enum(["federal", "ca"]).optional(),
-  jurisdictionCode: z.enum(["US", "CA"]).optional(),
+  jurisdiction: z.enum(JURISDICTIONS).optional(),
+  jurisdictionCode: z.enum(JURISDICTION_CODES).optional(),
   contentLabel: z.string().optional(),
   sourceLabel: z.string().optional(),
   activityAt: z.date().optional(),
@@ -134,10 +138,9 @@ export const videoRouter = {
         const jurisdiction = bill
           ? billJurisdiction(bill.sourceWebsite, bill.billNumber)
           : "federal";
-        const contentLabel =
-          jurisdiction === "ca"
-            ? `California · ${bill?.chamber === "Assembly" ? "Assembly Bill" : "Senate Bill"}`
-            : undefined;
+        const contentLabel = isStateJurisdiction(jurisdiction)
+          ? `${jurisdictionName(jurisdiction)} · ${bill?.chamber ?? "State"} Bill`
+          : undefined;
 
         return {
           id: video.id,

--- a/packages/env/src/registry.ts
+++ b/packages/env/src/registry.ts
@@ -472,6 +472,16 @@ export const envRegistry = [
     schema: z.enum(["0", "1"]),
   }),
   define({
+    key: "SCRAPER_SKIP_DUAL_LENS",
+    description:
+      "Set to 1 for bounded backfills that will generate optional dual lenses separately later.",
+    group: "Scraper operations",
+    secret: false,
+    defaultValue: "0",
+    requirements: { scraper: "optional" },
+    schema: z.enum(["0", "1"]),
+  }),
+  define({
     key: "SCRAPER_MAX_NEW_ITEMS_PER_RUN",
     description:
       "Max brand-new items (per data source) that get AI enrichment in one run; extras roll over to the next run.",


### PR DESCRIPTION
## Summary

- add Browse support for Missouri, North Carolina, and Texas alongside California
- centralize jurisdiction metadata so state copy, sessions, sponsor roles, address matching, API filters, and saved/feed behavior stay consistent
- replace the California-only chooser with a four-state picker while preserving a simple path to a scalable selector later
- remove the redundant “Show California bills” action from the default All empty state
- make Open States bulk imports session-aware and able to extract bill text from PDF sources (required for North Carolina)
- add an explicit bounded-backfill switch that defers optional dual-lens research while preserving required summaries, structured briefs, and header art

## Why

The scraper backend already supports state legislation, but Browse and the content API assumed California in several places. This makes the current four-state rollout explicit and data-driven without prematurely designing the eventual nationwide state-selection experience.

## Screenshot

<img width="390" height="844" alt="State jurisdiction picker showing California, Missouri, North Carolina, and Texas" src="https://github.com/user-attachments/assets/04a53737-2251-426e-9362-5dbddbdcea68" />

## Data rollout

Bounded production backfills are running for the exact 100 most recently updated bills in each newly supported state. Each bill is transactionally withheld until its description, source text, structured brief, and header art are complete. A separate finalizer verifies all four requirements for all 100 rows in every state before it writes the Missouri, North Carolina, and Texas incremental high-water cursors; it refuses to advance them if any state falls short.

The optional dual-lens research pass is deliberately deferred for this seed and can be filled independently with `retroactive-lenses`.

## Validation

- API tests: 19 passed
- scraper tests: 125 passed
- API, Expo, scraper, and environment typechecks passed
- API and Expo lint passed
- scraper production image build passed
- local Expo web smoke test passed against the updated API and production-shaped data
- GitHub CI: bundle, lint, test, and typecheck passed

Closes #285
