### PR TITLE
Remove print leaders from bill statuses

### DIFF
--- a/apps/scraper/src/scrapers/open-states-normalize.test.ts
+++ b/apps/scraper/src/scrapers/open-states-normalize.test.ts
@@ -174,6 +174,22 @@ void test("an unclassified action falls back to its own description, unsliced", 
   assert.equal(mapStatus([action("2025-05-01", long)]), long);
 });
 
+void test("print-form dot leaders are removed from fallback statuses", () => {
+  assert.equal(
+    mapStatus([
+      action("2025-09-17", "Effective on . . . . . . . . . . . . . . ."),
+    ]),
+    "Effective on",
+  );
+});
+
+void test("a genuine trailing ellipsis is preserved", () => {
+  assert.equal(
+    mapStatus([action("2025-05-01", "Further action pending...")]),
+    "Further action pending...",
+  );
+});
+
 void test("a bill with no actions has an explicit unknown status", () => {
   assert.equal(mapStatus(undefined), "Unknown");
   assert.equal(mapStatus([]), "Unknown");

--- a/apps/scraper/src/scrapers/open-states-normalize.ts
+++ b/apps/scraper/src/scrapers/open-states-normalize.ts
@@ -15,6 +15,7 @@ import type {
   OpenStatesBillSponsorship,
   OpenStatesBillVersion,
 } from "@acme/api/clients/open-states";
+import { sanitizeBillStatus } from "@acme/validators";
 
 /**
  * Written into `Bill.sourceWebsite` for every state bill regardless of which
@@ -225,7 +226,9 @@ export function mapStatus(
   for (const [classification, label] of STATUS_BY_CLASSIFICATION) {
     if (classifications.has(classification)) return label;
   }
-  return action.description?.trim() || "Unknown";
+  const description = action.description?.trim();
+  if (!description) return "Unknown";
+  return sanitizeBillStatus(description) || "Unknown";
 }
 
 /** Actions in the shape `Bill.actions` stores, oldest first. */

--- a/packages/api/src/router/content.ts
+++ b/packages/api/src/router/content.ts
@@ -14,7 +14,7 @@ import {
   SavedArticle,
   Video,
 } from "@acme/db/schema";
-import { parseBillBriefRecord } from "@acme/validators";
+import { parseBillBriefRecord, sanitizeBillStatus } from "@acme/validators";
 
 import type { ContentJurisdiction } from "../lib/content-jurisdiction";
 import { toBillTimelineActions } from "../lib/bill-actions";
@@ -335,7 +335,9 @@ function toBillCard(bill: BillCardSource): ContentCard & { type: "bill" } {
     billNumber: bill.billNumber,
     jurisdiction,
     jurisdictionCode: jurisdictionCode(jurisdiction),
-    billStatus: bill.status ?? undefined,
+    billStatus: bill.status
+      ? sanitizeBillStatus(bill.status) || undefined
+      : undefined,
     activityAt:
       bill.lastActionAt ?? bill.introducedDate ?? bill.createdAt ?? undefined,
     chamber: bill.chamber ?? undefined,

--- a/packages/validators/src/bill-status.ts
+++ b/packages/validators/src/bill-status.ts
@@ -1,0 +1,10 @@
+/**
+ * Removes dotted leaders copied from print-form legislative action text.
+ *
+ * The action date is stored separately, so a status such as
+ * `Effective on . . . . .` should be displayed as `Effective on`. Requiring
+ * spaced dots preserves genuine trailing ellipses such as `Pending...`.
+ */
+export function sanitizeBillStatus(value: string): string {
+  return value.replace(/\s+(?:\.\s+){2,}\.\s*$/, "").trim();
+}

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -1,6 +1,7 @@
 import { z } from "zod/v4";
 
 export * from "./bill-brief";
+export * from "./bill-status";
 
 export const unused = z.string().describe(
   `This lib is currently not used as we use drizzle-zod for simple schemas


### PR DESCRIPTION
## Summary

- strip spaced print-form dot leaders from Open States fallback statuses during ingestion
- apply the same sanitizer at the API boundary so already-stored records render correctly immediately
- preserve genuine trailing ellipses

## Regression

The stored Texas SB 11 status is `Effective on . . . . . . . . . . . . . . .` while its action date is stored separately. Browse therefore rendered the source document’s dotted leader before `Sep 17`. After this change, the card renders `Effective on Sep 17`.

## Verification

- `pnpm --filter @acme/scraper test` (127 passing)
- `pnpm --filter @acme/api test` (19 passing)
- `pnpm --filter @acme/validators --filter @acme/api --filter @acme/scraper typecheck`
- `git diff --check`