### PR TITLE
Add weekly bill retention

### DIFF
--- a/apps/scraper/package.json
+++ b/apps/scraper/package.json
@@ -47,7 +47,8 @@
     "retroactive-briefs": "tsx src/retroactive-briefs-entry.ts",
     "reprocess-content": "tsx src/reprocess-content-entry.ts",
     "retroactive-videos": "tsx src/retroactive-videos-entry.ts",
-    "backfill-bill-descriptions": "tsx src/backfill-bill-descriptions-entry.ts"
+    "backfill-bill-descriptions": "tsx src/backfill-bill-descriptions-entry.ts",
+    "prune-bills": "tsx src/prune-bills-entry.ts"
   },
   "author": "It's not you it's me",
   "license": "ISC"

--- a/apps/scraper/src/prune-bills-entry.ts
+++ b/apps/scraper/src/prune-bills-entry.ts
@@ -1,0 +1,4 @@
+import { loadRepoEnv } from "@acme/env/load";
+
+loadRepoEnv();
+await import("./prune-bills.js");

--- a/apps/scraper/src/prune-bills.ts
+++ b/apps/scraper/src/prune-bills.ts
@@ -1,0 +1,273 @@
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { and, eq, inArray } from "@acme/db";
+import { db } from "@acme/db/client";
+import {
+  Bill,
+  BriefChangeImage,
+  ContentBrief,
+  ContentLens,
+  SavedArticle,
+  Video,
+} from "@acme/db/schema";
+
+import type { BillRetentionCandidate } from "./utils/bill-retention.js";
+import { databaseTarget, databaseTargetMessage } from "./env.js";
+import {
+  retentionJurisdiction,
+  selectBillsToEvict,
+} from "./utils/bill-retention.js";
+import {
+  createLogger,
+  printFooter,
+  printHeader,
+  printKeyValue,
+} from "./utils/log.js";
+
+const logger = createLogger("bill-retention");
+const DELETE_BATCH_SIZE = 500;
+
+interface DeleteCounts {
+  bills: number;
+  videos: number;
+  briefs: number;
+  lenses: number;
+  saves: number;
+  changeImages: number;
+}
+
+type RetentionExecutor = Pick<typeof db, "delete" | "select">;
+
+const argv = await yargs(hideBin(process.argv))
+  .option("keep-per-jurisdiction", {
+    type: "number",
+    default: 100,
+    description: "Newest bills to retain independently in each jurisdiction",
+  })
+  .option("apply", {
+    type: "boolean",
+    default: false,
+    description:
+      "Delete selected rows; without this flag the command is read-only",
+  })
+  .option("yes", {
+    type: "boolean",
+    default: false,
+    description: "Acknowledge production deletions",
+  })
+  .check((args) => {
+    const keepPerJurisdiction = args.keepPerJurisdiction;
+    if (
+      typeof keepPerJurisdiction !== "number" ||
+      !Number.isInteger(keepPerJurisdiction) ||
+      keepPerJurisdiction < 1
+    ) {
+      throw new Error("--keep-per-jurisdiction must be a positive integer");
+    }
+    return true;
+  })
+  .strict()
+  .help()
+  .parse();
+
+function batches<T>(items: readonly T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    result.push(items.slice(index, index + size));
+  }
+  return result;
+}
+
+async function loadCandidates(
+  executor: Pick<typeof db, "select">,
+): Promise<BillRetentionCandidate[]> {
+  return executor
+    .select({
+      id: Bill.id,
+      billNumber: Bill.billNumber,
+      sourceWebsite: Bill.sourceWebsite,
+      sourceUpdatedAt: Bill.sourceUpdatedAt,
+      lastActionAt: Bill.lastActionAt,
+      createdAt: Bill.createdAt,
+    })
+    .from(Bill);
+}
+
+function printSelection(
+  candidates: readonly BillRetentionCandidate[],
+  selected: ReturnType<typeof selectBillsToEvict>,
+) {
+  const jurisdictions = new Map<string, { total: number; evict: number }>();
+  for (const candidate of candidates) {
+    const jurisdiction = retentionJurisdiction(candidate);
+    const counts = jurisdictions.get(jurisdiction) ?? { total: 0, evict: 0 };
+    counts.total += 1;
+    jurisdictions.set(jurisdiction, counts);
+  }
+  for (const candidate of selected) {
+    jurisdictions.get(candidate.jurisdiction)!.evict += 1;
+  }
+
+  printHeader("Bill retention inventory");
+  for (const [jurisdiction, counts] of [...jurisdictions].sort()) {
+    printKeyValue(
+      jurisdiction,
+      `${counts.total} total; ${counts.evict} selected for eviction`,
+    );
+  }
+  printKeyValue("Selected bills", selected.length);
+  printKeyValue("Writes", argv.apply ? "enabled" : "disabled (dry run)");
+  printFooter();
+}
+
+async function deleteSelected(
+  executor: RetentionExecutor,
+  ids: string[],
+): Promise<DeleteCounts> {
+  const counts: DeleteCounts = {
+    bills: 0,
+    videos: 0,
+    briefs: 0,
+    lenses: 0,
+    saves: 0,
+    changeImages: 0,
+  };
+
+  for (const batch of batches(ids, DELETE_BATCH_SIZE)) {
+    const briefRows = await executor
+      .select({ id: ContentBrief.id })
+      .from(ContentBrief)
+      .where(
+        and(
+          eq(ContentBrief.contentType, "bill"),
+          inArray(ContentBrief.contentId, batch),
+        ),
+      );
+    const briefIds = briefRows.map((row) => row.id);
+    if (briefIds.length > 0) {
+      counts.changeImages += (
+        await executor
+          .select({ id: BriefChangeImage.id })
+          .from(BriefChangeImage)
+          .where(inArray(BriefChangeImage.contentBriefId, briefIds))
+      ).length;
+    }
+
+    counts.videos += (
+      await executor
+        .delete(Video)
+        .where(
+          and(eq(Video.contentType, "bill"), inArray(Video.contentId, batch)),
+        )
+        .returning({ id: Video.id })
+    ).length;
+    counts.lenses += (
+      await executor
+        .delete(ContentLens)
+        .where(
+          and(
+            eq(ContentLens.contentType, "bill"),
+            inArray(ContentLens.contentId, batch),
+          ),
+        )
+        .returning({ id: ContentLens.id })
+    ).length;
+    counts.saves += (
+      await executor
+        .delete(SavedArticle)
+        .where(
+          and(
+            eq(SavedArticle.contentType, "bill"),
+            inArray(SavedArticle.contentId, batch),
+          ),
+        )
+        .returning({ id: SavedArticle.id })
+    ).length;
+    counts.briefs += (
+      await executor
+        .delete(ContentBrief)
+        .where(
+          and(
+            eq(ContentBrief.contentType, "bill"),
+            inArray(ContentBrief.contentId, batch),
+          ),
+        )
+        .returning({ id: ContentBrief.id })
+    ).length;
+    counts.bills += (
+      await executor
+        .delete(Bill)
+        .where(inArray(Bill.id, batch))
+        .returning({ id: Bill.id })
+    ).length;
+  }
+
+  return counts;
+}
+
+function printResult(counts: DeleteCounts) {
+  printHeader("Eviction result");
+  printKeyValue("Bills", counts.bills);
+  printKeyValue("Feed images", counts.videos);
+  printKeyValue("Briefs", counts.briefs);
+  printKeyValue("Lenses", counts.lenses);
+  printKeyValue("Saved references", counts.saves);
+  printKeyValue("Brief change images", counts.changeImages);
+  printFooter();
+}
+
+async function main() {
+  const databaseUrl = process.env.POSTGRES_URL;
+  if (!databaseUrl) throw new Error("POSTGRES_URL is required");
+
+  const target = databaseTarget(databaseUrl);
+  if (argv.apply && target.target === "production" && !argv.yes) {
+    throw new Error("Production deletions require both --apply and --yes");
+  }
+  logger[target.target === "production" ? "warn" : "info"](
+    databaseTargetMessage(databaseUrl),
+  );
+
+  if (!argv.apply) {
+    const candidates = await loadCandidates(db);
+    const selected = selectBillsToEvict(candidates, argv.keepPerJurisdiction);
+    printSelection(candidates, selected);
+    return;
+  }
+
+  const counts = await db.transaction(async (tx) => {
+    // The supervisor runs one job at a time. Keeping selection and deletion in
+    // this transaction also makes a manual invocation atomic: either every
+    // polymorphic dependent and bill row is deleted, or none are.
+    const candidates = await loadCandidates(tx);
+    const selected = selectBillsToEvict(candidates, argv.keepPerJurisdiction);
+    printSelection(candidates, selected);
+    if (selected.length === 0) {
+      return {
+        bills: 0,
+        videos: 0,
+        briefs: 0,
+        lenses: 0,
+        saves: 0,
+        changeImages: 0,
+      } satisfies DeleteCounts;
+    }
+
+    const deleted = await deleteSelected(
+      tx,
+      selected.map((row) => row.id),
+    );
+    if (deleted.bills !== selected.length) {
+      throw new Error(
+        `Selected ${selected.length} bills but deleted ${deleted.bills}; rolling back`,
+      );
+    }
+    return deleted;
+  });
+
+  printResult(counts);
+  logger.success(`Evicted ${counts.bills} old bill(s)`);
+}
+
+await main();

--- a/apps/scraper/src/utils/bill-retention.test.ts
+++ b/apps/scraper/src/utils/bill-retention.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { BillRetentionCandidate } from "./bill-retention.js";
+import { retentionJurisdiction, selectBillsToEvict } from "./bill-retention.js";
+
+function candidate(
+  id: string,
+  jurisdiction: "US" | "CA",
+  sourceUpdatedAt: string | null,
+  lastActionAt = "2026-01-01T00:00:00Z",
+): BillRetentionCandidate {
+  return {
+    id,
+    billNumber:
+      jurisdiction === "US" ? `H.R. ${id}` : `CA AB ${id} (2025-2026)`,
+    sourceWebsite: jurisdiction === "US" ? "congress.gov" : "openstates.org",
+    sourceUpdatedAt: sourceUpdatedAt ? new Date(sourceUpdatedAt) : null,
+    lastActionAt: new Date(lastActionAt),
+    createdAt: new Date("2026-01-01T00:00:00Z"),
+  };
+}
+
+void test("retention is capped independently per jurisdiction", () => {
+  const rows = [
+    ...Array.from({ length: 101 }, (_, index) =>
+      candidate(
+        `us-${index}`,
+        "US",
+        `2026-01-${String((index % 28) + 1).padStart(2, "0")}T00:00:00Z`,
+      ),
+    ),
+    ...Array.from({ length: 101 }, (_, index) =>
+      candidate(
+        `ca-${index}`,
+        "CA",
+        `2026-02-${String((index % 28) + 1).padStart(2, "0")}T00:00:00Z`,
+      ),
+    ),
+  ];
+
+  const evicted = selectBillsToEvict(rows, 100);
+  assert.equal(evicted.length, 2);
+  assert.deepEqual(evicted.map((row) => row.jurisdiction).sort(), ["CA", "US"]);
+});
+
+void test("source update wins, with legislative action as its fallback", () => {
+  const evicted = selectBillsToEvict(
+    [
+      candidate("source-new", "US", "2026-08-10T00:00:00Z"),
+      candidate("action-new", "US", null, "2026-08-12T00:00:00Z"),
+      candidate("action-old", "US", null, "2026-08-11T00:00:00Z"),
+    ],
+    2,
+  );
+
+  assert.deepEqual(
+    evicted.map((row) => row.id),
+    ["action-old"],
+  );
+});
+
+void test("malformed state identities never enter the federal bucket", () => {
+  const malformed = {
+    ...candidate("broken", "CA", "2026-08-10T00:00:00Z"),
+    billNumber: "not a state identity",
+  };
+  assert.equal(retentionJurisdiction(malformed), "STATE");
+});
+
+void test("the retention limit must be positive", () => {
+  assert.throws(() => selectBillsToEvict([], 0), /positive integer/);
+});

--- a/apps/scraper/src/utils/bill-retention.ts
+++ b/apps/scraper/src/utils/bill-retention.ts
@@ -1,0 +1,63 @@
+export interface BillRetentionCandidate {
+  id: string;
+  billNumber: string;
+  sourceWebsite: string;
+  sourceUpdatedAt: Date | null;
+  lastActionAt: Date | null;
+  createdAt: Date;
+}
+
+export interface RankedBillRetentionCandidate extends BillRetentionCandidate {
+  jurisdiction: string;
+}
+
+/**
+ * State bill identity is embedded in the stable bill number as
+ * `CA AB 2047 (2025-2026)`. Federal sources share the US bucket; malformed
+ * Open States rows stay in their own bucket rather than crowding out Congress.
+ */
+export function retentionJurisdiction(candidate: BillRetentionCandidate) {
+  if (candidate.sourceWebsite !== "openstates.org") return "US";
+  return /^([A-Z]{2})\s/.exec(candidate.billNumber)?.[1] ?? "STATE";
+}
+
+function time(date: Date | null): number {
+  return date?.getTime() ?? Number.NEGATIVE_INFINITY;
+}
+
+function newestFirst(
+  left: BillRetentionCandidate,
+  right: BillRetentionCandidate,
+): number {
+  return (
+    time(right.sourceUpdatedAt) - time(left.sourceUpdatedAt) ||
+    time(right.lastActionAt) - time(left.lastActionAt) ||
+    right.createdAt.getTime() - left.createdAt.getTime() ||
+    right.id.localeCompare(left.id)
+  );
+}
+
+/** Select rows beyond the newest `keepPerJurisdiction` in each jurisdiction. */
+export function selectBillsToEvict(
+  candidates: readonly BillRetentionCandidate[],
+  keepPerJurisdiction: number,
+): RankedBillRetentionCandidate[] {
+  if (!Number.isInteger(keepPerJurisdiction) || keepPerJurisdiction < 1) {
+    throw new Error("keepPerJurisdiction must be a positive integer");
+  }
+
+  const groups = new Map<string, BillRetentionCandidate[]>();
+  for (const candidate of candidates) {
+    const jurisdiction = retentionJurisdiction(candidate);
+    const group = groups.get(jurisdiction) ?? [];
+    group.push(candidate);
+    groups.set(jurisdiction, group);
+  }
+
+  return [...groups.entries()].flatMap(([jurisdiction, group]) =>
+    group
+      .sort(newestFirst)
+      .slice(keepPerJurisdiction)
+      .map((candidate) => ({ ...candidate, jurisdiction })),
+  );
+}

--- a/apps/scraper/vite.config.ts
+++ b/apps/scraper/vite.config.ts
@@ -44,6 +44,9 @@ export default defineConfig({
         "change-images": fileURLToPath(
           new URL("./src/change-images.ts", import.meta.url),
         ),
+        "prune-bills": fileURLToPath(
+          new URL("./src/prune-bills.ts", import.meta.url),
+        ),
       },
       output: {
         chunkFileNames: "chunks/[name]-[hash].js",

--- a/apps/supervisor/README.md
+++ b/apps/supervisor/README.md
@@ -35,6 +35,7 @@ the arguments it takes; the supervisor supplies everything else.
 | `federalregister-weekly`          | Sundays 03:15     | Executive orders and presidential documents                                     |
 | `scc-cvig-weekly`                 | Sundays 03:15     | Santa Clara County voter guide                                                  |
 | `ca-sos-weekly`                   | Sundays 03:15     | California SoS candidate statements                                             |
+| `prune-bills-weekly`              | Sundays 23:30     | Keeps the 100 most recently updated bills in each jurisdiction                  |
 | `retro-briefs`                    | manual            | Fills in missing structured briefs                                              |
 | `retro-lenses`                    | manual            | Fills in missing dual-lens perspectives                                         |
 | `retro-videos`                    | manual            | Header art backfill                                                             |
@@ -59,6 +60,14 @@ something a scheduler starts at 3am.
 The three weekly scrapers are listed individually rather than as one `main.js
 all` run, so that dropping `all` (which would drag the cursor walk back in)
 cannot silently stop them.
+
+The Sunday-night retention job runs after ingestion and caps each jurisdiction
+independently, so the federal feed cannot displace California or another state.
+It deletes the evicted bills and their polymorphic feed images, briefs, lenses,
+saved references, and cascading brief-change images in one transaction. The
+underlying command is read-only unless passed `--apply`; production also
+requires `--yes`. PostgreSQL autovacuum makes the freed space reusable; the
+reported physical disk size may not fall immediately after deletion.
 
 A job that has never run fires immediately if it is interval-based, and waits
 for its next occurrence if it is on a calendar schedule — deploying at 4pm must

--- a/apps/supervisor/src/config.test.ts
+++ b/apps/supervisor/src/config.test.ts
@@ -32,6 +32,24 @@ void test("every supported state has an isolated daily refresh", () => {
   }
 });
 
+void test("weekly bill retention applies the per-jurisdiction cap", () => {
+  const job = findJob("prune-bills-weekly");
+  assert.ok(job, "weekly bill retention job is missing");
+  assert.equal(job.script, "prune-bills.js");
+  assert.deepEqual(job.args, [
+    "--keep-per-jurisdiction",
+    "100",
+    "--apply",
+    "--yes",
+  ]);
+  assert.deepEqual(job.schedule, {
+    kind: "weekly",
+    weekday: 0,
+    hour: 23,
+    minute: 30,
+  });
+});
+
 void test("limits are generous enough not to kill healthy work", () => {
   // The first version of this config used wall-clock timeouts picked by guess,
   // and one of them (12h for a 15.4h backfill) would have killed a healthy run

--- a/apps/supervisor/src/config.ts
+++ b/apps/supervisor/src/config.ts
@@ -77,6 +77,18 @@ export const jobs: readonly JobDefinition[] = [
     idleTimeoutMinutes: 60,
     maxRuntimeHours: 24,
   },
+  {
+    id: "prune-bills-weekly",
+    description: "Keep the 100 most recently updated bills per jurisdiction",
+    script: "prune-bills.js",
+    args: ["--keep-per-jurisdiction", "100", "--apply", "--yes"],
+    // Run after the Sunday ingestion jobs so the cap applies to the complete
+    // weekly picture. The supervisor serialises jobs if an earlier run is late.
+    schedule: { kind: "weekly", weekday: 0, hour: 23, minute: 30 },
+    priority: 18,
+    idleTimeoutMinutes: 60,
+    maxRuntimeHours: 12,
+  },
 
   // Everything below is manual: it runs only when someone drops a request file,
   // never on a schedule.

--- a/docs/scraper.md
+++ b/docs/scraper.md
@@ -390,6 +390,7 @@ content and are completed later by these standalone entry points. All are
 | `retroactive-lenses`         | `retroactive-lenses.ts`         | Missing/stale `content_lens` rows           | `--dry-run` to preview                                        |
 | `retroactive-videos`         | `retroactive-videos.ts`         | Missing `video` feed rows                   | —                                                             |
 | `backfill-bill-descriptions` | `backfill-bill-descriptions.ts` | Bills with no source/AI description         | `--apply` (+ `--yes` on prod)                                 |
+| `prune-bills`                | `prune-bills.ts`                | Bills beyond the newest N per jurisdiction  | **Read-only by default**; needs `--apply` (+ `--yes` on prod) |
 
 `reprocess-content` is the most general and the model the others follow:
 


### PR DESCRIPTION
## What changed

- add a `prune-bills` scraper command that keeps the 100 most recently source-updated bills independently in each jurisdiction
- delete evicted bills and their polymorphic feed images, briefs, lenses, saved references, and cascading brief-change images atomically
- schedule the production supervisor job for Sundays at 23:30 local time, after weekly ingestion
- keep the command read-only by default and require both `--apply` and `--yes` for production deletion

## Why

The daily scrapers now keep the head of each supported jurisdiction current, but the database retained every historical bill indefinitely. Federal bills therefore dominated storage and could eventually push the Supabase database over its storage allowance. Capping the entire table at 100 would let federal activity crowd out state measures, so retention is partitioned by jurisdiction instead.

## Impact and safety

The current production preview selects 1,039 bills: 2 California bills and 1,037 federal bills; Missouri, North Carolina, and Texas are already at or below the cap. No production rows were deleted while preparing this PR.

Deletion is batched and runs inside one transaction. The command also reports a dry-run inventory when invoked without `--apply`. PostgreSQL autovacuum will make deleted space reusable, although reported physical disk size may not fall immediately.

## Checks

- `pnpm --filter @acme/scraper test` (132 passed)
- `pnpm --filter @acme/scraper build`
- `pnpm --filter @acme/supervisor test` (37 passed)
- `pnpm --filter @acme/supervisor build`
- Prettier check on all changed files
- `git diff --check`
- local CLI dry run with writes disabled
- production inventory query (read-only)
